### PR TITLE
docs: fix stale RBAC/token-persistence claims across architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,24 +13,33 @@ Clevis is a GitHub analytics dashboard with three independently deployable servi
 
 ### Database models (`apps/api/src/core/db.py`)
 
-Three tables managed by Alembic — no runtime DDL:
-- **`github_installations`** — account login, installation ID, auth mode, and `token_ref` (a symbolic reference like `tok_acme`, not the actual token).
+Managed by Alembic — no runtime DDL. Core tables:
+- **`users`** — email/password (bcrypt) or GitHub-OAuth-linked accounts. `is_workspace_admin` marks the instance-level admin (the first user ever created); everyone else is a regular user whose access is scoped per-org via `org_memberships`.
+- **`orgs`** / **`org_memberships`** — the multi-tenant model (added in migration `0009_add_org_rbac.py`). `org_memberships.role` is `member` or `admin`, scoped per org.
+- **`invitations`** — pending/accepted/revoked org invites; a shareable link (`/invite/{token}`) that grants membership to whoever accepts it with a matching email. Currently has no expiry — see open issues.
+- **`github_installations`** — account login, installation ID, auth mode, and `token_ref` (a symbolic reference like `tok_acme`, not the actual token); scoped to exactly one of `org_id` or `owner_user_id` (enforced by a DB check constraint).
+- **`saved_tokens`** — Fernet-encrypted GitHub PATs saved per org for reuse, so a workspace admin doesn't have to paste a token on every request. See "Token encryption" below.
 - **`audit_logs`** — immutable audit trail; every significant action (cache clear, dry-run, etc.) writes here with actor, action, target, and payload JSON.
 - **`jobs`** — job queue; composite index on `(status, job_type)` for efficient worker polling. Status lifecycle: `queued → processing → done/failed`. The `result` column stores JSON on success or a raw exception string on failure.
 
 ### Job queue flow
 
-**Enqueueing (API):** `POST /repos/{owner}/{repo}/actions-caches/clear` — if `dry_run=true`, only an audit log is written; if `dry_run=false`, the token is Fernet-encrypted and a `jobs` row with `status='queued'` is inserted.
+**Enqueueing (API):** `POST /orgs/{org_login}/repos/{owner}/{repo}/actions-caches/clear` (org-scoped) or `POST /me/repos/{owner}/{repo}/actions-caches/clear` (personal-scope, caller supplies their own token) — if `dry_run=true`, only an audit log is written; if `dry_run=false`, the token is Fernet-encrypted and a `jobs` row with `status='queued'` is inserted.
 
 **Processing (worker):** atomic `SELECT FOR UPDATE SKIP LOCKED` claims one job, updates status to `processing`, decrypts the token, calls the GitHub API, then updates to `done` or `failed`. Multiple worker replicas can poll safely.
 
-### RBAC
+### Auth & RBAC
 
-Role passed via `X-Role` HTTP header (`viewer` / `analyst` / `admin`). Defaults to `settings.default_rbac_role`. Enforced via `require_role()` FastAPI dependency (`src/services/rbac.py`). Only the cache-clear endpoint requires `admin`; all other routes are unrestricted. There is no session or JWT — the header is trusted to come from an auth proxy.
+Sessions are JWTs (`AUTH_SECRET`, HS256, 30-day expiry), issued on email/password login (`POST /auth/login`) or GitHub OAuth (`GET /auth/github/callback`), and carried either as a `Bearer` header (API clients) or an httpOnly `clevis_session` cookie (browser). There are two independent access layers, defined in `apps/api/src/core`:
+
+- **`core/auth.py`** — `require_auth` (any valid JWT) and `require_workspace_admin` (JWT claims only, no DB hit — `is_workspace_admin` is baked into the token at issuance, so revoking/demoting a user does not take effect until their token expires).
+- **`core/rbac.py`** — `require_org_role(min_role)` (`member` / `admin`), which resolves the caller's `OrgMembership` fresh from the DB on every request, since org access can change while a JWT is still valid. `assert_owner_matches_org` additionally guards that a repo-level `owner` path/body value matches the org context the caller was authorized for.
+
+Most routes are org-scoped (`/orgs/{org_login}/...`, `require_org_role`) or personal-scope (`/me/...`, `require_auth` only — the caller brings their own GitHub token, so there's no installation to authorize against). Workspace-admin-only routes (`/tokens`, `/jobs`, `/audit`, `/config`) manage instance-wide state, not per-org data.
 
 ### Token encryption
 
-Tokens are never stored persistently. When a job is enqueued the API encrypts the token with Fernet (key derived via SHA-256 of `JOB_SECRET_KEY`, base64-encoded). The worker decrypts it at processing time. Both sides duplicate the same `_crypto.py` logic.
+GitHub PATs are Fernet-encrypted at rest in two places: transiently in `jobs.payload` while a cache-clear job is queued, and persistently in `saved_tokens.encrypted_token` when a workspace admin saves an org's token for reuse (`POST /tokens/{org}`). The Fernet key is derived from `JOB_SECRET_KEY` via SHA-256 (base64-encoded) — both `apps/api` and `apps/worker` duplicate the same `_crypto.py` logic. `GET /tokens` never returns raw tokens; `POST /tokens/resolve` does (workspace-admin only), for cases where the raw PAT needs to be reused client-side.
 
 ### Database URL dialect
 
@@ -46,7 +55,7 @@ The API uses `postgresql+psycopg://` (SQLAlchemy dialect). The worker strips the
 
 ### UI routing
 
-Owner and repo are joined with `~` in URL dynamic segments (e.g., `/repos/octocat~hello-world/cache`). The API client lives in `apps/ui/lib/api/client.ts`; it centralises JSON serialisation, error parsing, and `X-Role` header injection.
+Owner and repo are joined with `~` in URL dynamic segments (e.g., `/repos/octocat~hello-world/cache`). The API client lives in `apps/ui/lib/api/client.ts`; it centralises JSON serialisation, error parsing, and attaches the session (via the httpOnly cookie sent automatically on same-site credentialed requests, or a `Bearer` header where applicable).
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clevis is three independently deployable services around one shared check librar
 | **`apps/ui`** | Next.js 15 · React 19 · TanStack Query | The dashboard — dense, dark, keyboard-friendly. |
 | **`packages/checks`** | `clevis-checks` (Python) | The security-check engine (MFA, branch protection, secret scanning) with built-in GitHub pagination. |
 
-**Security model:** RBAC is enforced per route (`viewer` / `analyst` / `admin`). GitHub tokens are **never stored persistently** — they are Fernet-encrypted when a job is enqueued and decrypted only at processing time. Every request carries a propagated `X-Request-ID` for traceability.
+**Security model:** Sessions are JWT-based (email/password or GitHub OAuth login). Access is org-scoped RBAC (`member` / `admin` per org, resolved fresh from the DB on every request) plus a small set of workspace-admin-only routes for instance-wide config. GitHub tokens are Fernet-encrypted whenever they're persisted — transiently in the job queue, or durably if a workspace admin chooses to save one for reuse — and only ever decrypted at the point of use. Every request carries a propagated `X-Request-ID` for traceability.
 
 ---
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -13,7 +13,9 @@
 ## Security notes
 - Use GitHub App auth in production, not PAT.
 - Restrict API ingress behind your reverse proxy and SSO.
-- Set `X-Role: admin` only for trusted automation/users.
+- Set `CORS_ORIGINS` to your real UI origin(s) before going live — it's a security boundary (credentialed CORS + the session cookie), read once at API startup, so changing it requires a restart.
+- The first account created via `/auth/setup` becomes the workspace admin. Access beyond that is granted per-org (invite links from an org admin), or instance-wide for workspace-admin-only routes (`/tokens`, `/jobs`, `/audit`, `/config`).
+- Generate `AUTH_SECRET` and `JOB_SECRET_KEY` with `openssl rand -hex 32` each — don't reuse one for the other, and don't commit real values.
 
 ## Observability
 - API has request-id logs and health endpoint at `/healthz`.


### PR DESCRIPTION
## Summary

The architecture docs (`CLAUDE.md`, `README.md`, `docs/self-hosting.md`) still described the
security model from before `feat/org-rbac` landed:

- **Stale RBAC claim**: docs said access is controlled by a trusted `X-Role` HTTP header
  (`viewer`/`analyst`/`admin`, no session, no JWT). That model no longer exists in code —
  `grep -r "X-Role"` across `.py`/`.ts`/`.tsx` only matched the docs themselves. Current auth is
  JWT + httpOnly cookie sessions (`AUTH_SECRET`), with a DB-backed org/membership RBAC layer
  added in migration `0009_add_org_rbac.py` (`apps/api/src/core/rbac.py`).
- **Stale token-persistence claim**: docs said "GitHub tokens are never stored persistently."
  False since migration `0003_add_saved_tokens.py` — the `saved_tokens` table exists
  specifically so a workspace admin can save an org's token for reuse
  (`apps/api/src/routers/tokens.py`).

Both were flagged independently by two codebase-survey passes while auditing the branch for
security issues (see linked issues in this repo for the actual code-level findings — this PR is
docs-only and isn't linked to an issue since it's just correcting wrong text, not tracking
collaborator work).

## Changes

- `CLAUDE.md` — rewrote the "RBAC" section into "Auth & RBAC" (JWT + org-scoped `require_org_role`
  vs. JWT-claims-only `require_workspace_admin`), expanded "Database models" to list the
  `users`/`orgs`/`org_memberships`/`invitations`/`saved_tokens` tables added since the doc was
  last updated, fixed the job-enqueue endpoint path, corrected "Token encryption" to reflect that
  tokens *are* persisted (in `saved_tokens`), and fixed the UI-routing note about `X-Role`
  injection.
- `README.md` — corrected the one-line "Security model" summary in the Architecture section.
- `docs/self-hosting.md` — replaced the `X-Role: admin` security note (dead) with accurate
  guidance on `CORS_ORIGINS`, workspace-admin bootstrapping, and secret generation.

`CONTRIBUTING.md` and `DESIGN.md` were checked and don't reference the old model — no changes
needed there. The gitignored `docs/plan.md` (a phased implementation-planning doc) intentionally
narrates the *old* `X-Role` model as historical context for a migration phase already marked
done — that's accurate as written, so it was left untouched.

## Test plan

- [x] `grep -rn "X-Role\|never stored persistently" CLAUDE.md README.md docs/self-hosting.md` → no matches
- [x] Read each changed doc end-to-end against the current `apps/api/src/core/{auth,rbac}.py` and migration `0009_add_org_rbac.py` for accuracy