### PR TITLE
fix(api): spoofable installation identity and audit actor

### DIFF
--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -36,10 +36,11 @@ def org_clear_caches(
     repo: str,
     payload: CacheClearInput,
     ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(owner, ctx)
-    return clear(db, owner, repo, payload)
+    return clear(db, owner, repo, payload, actor=user.email)
 
 
 @router.post("/me/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
@@ -58,6 +59,6 @@ def personal_clear_caches(
     repo: str,
     payload: CacheClearInput,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_auth),
+    user: UserOut = Depends(require_auth),
 ):
-    return clear(db, owner, repo, payload)
+    return clear(db, owner, repo, payload, actor=user.email)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -70,7 +70,12 @@ def sync_personal_installation(
 ):
     if payload.account_type == "User":
         db_user = db.query(User).filter(User.id == user.id).first()
-        if db_user and db_user.github_login and payload.account_login != db_user.github_login:
+        if not db_user or not db_user.github_login:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Link your GitHub account before syncing a personal installation",
+            )
+        if payload.account_login != db_user.github_login:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="account_login must match your own GitHub account",

--- a/apps/api/src/schemas/cache.py
+++ b/apps/api/src/schemas/cache.py
@@ -7,7 +7,6 @@ class CacheListInput(BaseModel):
 
 class CacheClearInput(BaseModel):
     token: SecretStr
-    actor: str
     key: str | None = None
     ref: str | None = None
     dry_run: bool = True

--- a/apps/api/src/services/cache_service.py
+++ b/apps/api/src/services/cache_service.py
@@ -6,10 +6,10 @@ from src.repositories import audit_repo, job_repo
 from src.schemas.cache import CacheClearInput
 
 
-def clear(db: Session, owner: str, repo: str, payload: CacheClearInput) -> dict:
+def clear(db: Session, owner: str, repo: str, payload: CacheClearInput, actor: str) -> dict:
     target = f"{owner}/{repo}"
     if payload.dry_run:
-        audit_repo.write(db, payload.actor, "cache.clear.dry_run", target, payload.model_dump(exclude={"token"}))
+        audit_repo.write(db, actor, "cache.clear.dry_run", target, payload.model_dump(exclude={"token"}))
         return {"queued": False, "dry_run": True, "message": "Dry run completed."}
 
     encrypted_token = encrypt_job_token(
@@ -22,7 +22,7 @@ def clear(db: Session, owner: str, repo: str, payload: CacheClearInput) -> dict:
         "token": encrypted_token,
         "key": payload.key,
         "ref": payload.ref,
-        "actor": payload.actor,
+        "actor": actor,
     })
-    audit_repo.write(db, payload.actor, "cache.clear.queued", target, {"job_id": job_id, **payload.model_dump(exclude={"token"})})
+    audit_repo.write(db, actor, "cache.clear.queued", target, {"job_id": job_id, **payload.model_dump(exclude={"token"})})
     return {"queued": True, "job_id": job_id}

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -12,8 +12,8 @@ from src.routers.installations import router as inst_router
 _OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
 
 
-def _make_user(db, email: str) -> UserOut:
-    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+def _make_user(db, email: str, github_login: str | None = None) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False, github_login=github_login)
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -112,10 +112,28 @@ def test_personal_installations_scoped_to_self(db):
 
 
 def test_sync_personal_installation(db):
-    me = _make_user(db, "shabnam@e.com")
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
     resp = _client(db, me).post(
         "/me/installations/sync",
         json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
     )
     assert resp.status_code == 200
     assert resp.json()["synced"] is True
+
+
+def test_sync_personal_installation_requires_linked_github_account(db):
+    me = _make_user(db, "unlinked@e.com")
+    resp = _client(db, me).post(
+        "/me/installations/sync",
+        json={"account_login": "someone-else", "account_type": "User", "installation_id": 3},
+    )
+    assert resp.status_code == 403
+
+
+def test_sync_personal_installation_login_mismatch_forbidden(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    resp = _client(db, me).post(
+        "/me/installations/sync",
+        json={"account_login": "someone-else", "account_type": "User", "installation_id": 3},
+    )
+    assert resp.status_code == 403

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -116,7 +116,7 @@ def test_org_actions_cache_clear_member_forbidden(cache_app, acme_membership):
     cache_app.dependency_overrides[require_auth] = lambda: acme_membership["member"]
     resp = TestClient(cache_app).post(
         "/orgs/acme/repos/acme/widget/actions-caches/clear",
-        json={"token": "ghp_test", "actor": "member@example.com"},
+        json={"token": "ghp_test"},
     )
     assert resp.status_code == 403
 


### PR DESCRIPTION
## Summary
- `sync_personal_installation` skipped the ownership check entirely for users with no linked GitHub account (`github_login is None`), letting anyone sync a personal installation under an arbitrary `account_login`. Now 403s with a clear message unless the caller has a linked GitHub account matching the target login.
- `CacheClearInput.actor` was a free-text field set by the caller and written verbatim into `audit_logs.actor` for both dry-run and queued cache-clear actions. Removed it from the schema; `actor` is now derived server-side from the authenticated user's email on every call path (org + personal clear endpoints).

## Test plan
- [x] `pytest -q apps/api/tests/test_installations.py apps/api/tests/test_owner_only_routes.py` — added regression tests for the unlinked-account bypass and the login-mismatch case
- [x] `pytest -q` (full API suite) — 121 passed

Fixes #66