### PR TITLE
fix(api): add JWT session revocation and rate limit auth routes

### DIFF
--- a/apps/api/alembic/versions/0010_add_token_version.py
+++ b/apps/api/alembic/versions/0010_add_token_version.py
@@ -1,0 +1,31 @@
+"""add users.token_version for JWT revocation
+
+Sessions are stateless 30-day JWTs with no server-side revocation: demoting a workspace
+admin, or a user wanting to invalidate their existing sessions, previously had zero effect
+until natural token expiry. token_version is embedded in each issued JWT's claims and
+compared against the user's current value on every authenticated request; bumping it
+(via POST /auth/me/revoke-sessions) invalidates all previously issued tokens for that user.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -2,11 +2,15 @@
 JWT helpers and FastAPI auth dependencies.
 
 Two access levels:
-  - require_auth           — any authenticated user (valid JWT)
+  - require_auth           — any authenticated user (valid JWT, not revoked)
   - require_workspace_admin — authenticated user with is_workspace_admin=True (instance config only)
 
 Org-scoped access levels (member/admin per org) live in src/core/rbac.py, since they
 require a DB lookup rather than just the JWT claims.
+
+require_auth hits the DB on every request to compare the JWT's token_version claim
+against the user's current value, so that revoke-sessions (or any future forced logout)
+takes effect immediately instead of waiting out the 30-day token expiry.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -15,8 +19,10 @@ import jwt
 from fastapi import Cookie, Depends, HTTPException, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 from src.core.config import settings
+from src.core.db import User, get_db
 
 _ALGORITHM = "HS256"
 _TOKEN_EXPIRE_DAYS = 30
@@ -59,12 +65,15 @@ class UserOut(BaseModel):
     is_workspace_admin: bool
 
 
-def create_access_token(user_id: int, email: str, is_workspace_admin: bool, name: str | None = None) -> str:
+def create_access_token(
+    user_id: int, email: str, is_workspace_admin: bool, name: str | None = None, token_version: int = 0
+) -> str:
     payload = {
         "sub": str(user_id),
         "email": email,
         "is_workspace_admin": is_workspace_admin,
         "name": name,
+        "token_version": token_version,
         "exp": datetime.now(timezone.utc) + timedelta(days=_TOKEN_EXPIRE_DAYS),
     }
     return jwt.encode(payload, settings.auth_secret.get_secret_value(), algorithm=_ALGORITHM)
@@ -86,11 +95,14 @@ def decode_access_token(token: str) -> dict:
 def require_auth(
     credentials: HTTPAuthorizationCredentials | None = Depends(_http_bearer),
     session: str | None = Cookie(default=None, alias=SESSION_COOKIE_NAME),
+    db: Session = Depends(get_db),
 ) -> UserOut:
     """Dependency: validates the JWT (Authorization header or session cookie) and returns the user.
 
     Prefers the Bearer header (API clients) and falls back to the httpOnly session cookie
-    (browser sessions established via GitHub OAuth). Raises 401 if neither is present/valid.
+    (browser sessions established via GitHub OAuth). Raises 401 if neither is present/valid,
+    or if the token's token_version claim no longer matches the user's current value (i.e.
+    the session was revoked via POST /auth/me/revoke-sessions).
     """
     token = credentials.credentials if credentials else session
     if not token:
@@ -104,6 +116,9 @@ def require_auth(
         user_id = int(sub)
     except (ValueError, TypeError):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token claims")
+    db_user = db.query(User).filter(User.id == user_id).first()
+    if db_user is None or db_user.token_version != payload.get("token_version", 0):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
     return UserOut(
         id=user_id,
         email=email,

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -91,6 +91,8 @@ class User(Base):
     # Null for users who only sign in with GitHub (no email/password credential).
     password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_workspace_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Bumped by POST /auth/me/revoke-sessions to invalidate all previously issued JWTs.
+    token_version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     # GitHub identity (set when the user links / signs in via GitHub OAuth).
     github_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
     github_login: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/apps/api/src/core/rate_limit.py
+++ b/apps/api/src/core/rate_limit.py
@@ -1,0 +1,43 @@
+"""In-memory fixed-window rate limiter for auth endpoints.
+
+Per-process only: state lives in a module-level dict, so a multi-replica deployment
+would need a shared store (e.g. Redis) for this to be effective across instances. Fine
+for the current single-API-instance deployment; revisit if we ever scale out /auth.
+"""
+
+import time
+from threading import Lock
+
+from fastapi import HTTPException, Request, status
+
+_DEFAULT_MAX_REQUESTS = 10
+_DEFAULT_WINDOW_SECONDS = 60
+
+_lock = Lock()
+_buckets: dict[str, tuple[int, float]] = {}
+
+
+def _client_key(request: Request) -> str:
+    ip = request.client.host if request.client else "unknown"
+    return f"{request.url.path}:{ip}"
+
+
+def rate_limit(max_requests: int = _DEFAULT_MAX_REQUESTS, window_seconds: int = _DEFAULT_WINDOW_SECONDS):
+    """FastAPI dependency factory: 429s once a client IP exceeds max_requests within window_seconds."""
+
+    def _dependency(request: Request) -> None:
+        key = _client_key(request)
+        now = time.monotonic()
+        with _lock:
+            count, window_start = _buckets.get(key, (0, now))
+            if now - window_start >= window_seconds:
+                count, window_start = 0, now
+            count += 1
+            _buckets[key] = (count, window_start)
+        if count > max_requests:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many requests, please try again later",
+            )
+
+    return _dependency

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -7,7 +7,11 @@ Endpoints:
   POST /auth/login          Returns a JWT on valid credentials
   GET  /auth/me             Returns the current authenticated user
   PATCH /auth/me            Updates the current user's display name
+  POST /auth/me/revoke-sessions Invalidates all previously issued JWTs for the caller
   GET  /auth/setup-required Returns { setup_required: bool } for the UI routing decision
+
+/auth/login and /auth/register are rate-limited per client IP (see src.core.rate_limit)
+to blunt credential-stuffing / registration-spam attempts.
 """
 
 from datetime import datetime
@@ -21,6 +25,7 @@ from sqlalchemy.orm import Session
 from src.core.app_config import get_config
 from src.core.auth import UserOut, clear_session_cookie, create_access_token, require_auth
 from src.core.db import User, get_db
+from src.core.rate_limit import rate_limit
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -107,11 +112,11 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
-@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(rate_limit())])
 def register(body: RegisterRequest, db: Session = Depends(get_db)):
     """Creates a non-admin account. 409 if setup hasn't run yet; 403 if registration is disabled."""
     if db.query(User).count() == 0:
@@ -134,7 +139,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
@@ -145,13 +150,13 @@ def logout(response: Response):
     return {"ok": True}
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login", response_model=TokenResponse, dependencies=[Depends(rate_limit())])
 def login(body: LoginRequest, db: Session = Depends(get_db)):
     """Returns a JWT on valid credentials. Always returns 401 on failure (no field leaking)."""
     user = db.query(User).filter(User.email == body.email).first()
     if not user or not _verify_password(body.password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
@@ -179,3 +184,17 @@ def patch_me(
     db.commit()
     db.refresh(user)
     return user
+
+
+@router.post("/me/revoke-sessions")
+def revoke_sessions(
+    current_user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    """Invalidate every previously issued JWT for the caller (log out everywhere)."""
+    user = db.query(User).filter(User.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.token_version += 1
+    db.commit()
+    return {"ok": True}

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import create_access_token, set_session_cookie
 from src.core.config import settings
 from src.core.db import User, get_db
+from src.core.rate_limit import rate_limit
 from src.services import github_oauth, org_provisioning
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ def github_login(request: Request):
     return RedirectResponse(url, status_code=307)
 
 
-@router.get("/callback", name="github_callback")
+@router.get("/callback", name="github_callback", dependencies=[Depends(rate_limit())])
 def github_callback(
     request: Request,
     code: str | None = None,
@@ -93,7 +94,7 @@ def github_callback(
         raise HTTPException(status_code=400, detail=str(exc))
     user = find_or_create_user(db, identity)
     org_provisioning.sync_org_admin_memberships(db, user, user_token)
-    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     response = RedirectResponse(_ui_redirect_target(), status_code=303)
     set_session_cookie(response, token)
     return response

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -174,6 +174,42 @@ def test_patch_me_updates_name(auth_client):
     assert resp.json()["name"] == "Alice"
 
 
+# revoke-sessions
+
+def test_revoke_sessions_unauthenticated(auth_client):
+    resp = auth_client.post("/auth/me/revoke-sessions")
+    assert resp.status_code == 401
+
+
+def test_revoke_sessions_invalidates_existing_token(auth_client):
+    token = _setup_owner(auth_client)["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = auth_client.post("/auth/me/revoke-sessions", headers=headers)
+    assert resp.status_code == 200
+
+    resp = auth_client.get("/auth/me", headers=headers)
+    assert resp.status_code == 401
+
+
+def test_revoke_sessions_new_login_still_works(auth_client):
+    _setup_owner(auth_client)
+    auth_client.post(
+        "/auth/login", json={"email": "owner@example.com", "password": "supersecret1234"}
+    )
+    first_token = auth_client.post(
+        "/auth/login", json={"email": "owner@example.com", "password": "supersecret1234"}
+    ).json()["access_token"]
+    auth_client.post(
+        "/auth/me/revoke-sessions", headers={"Authorization": f"Bearer {first_token}"}
+    )
+    new_token = auth_client.post(
+        "/auth/login", json={"email": "owner@example.com", "password": "supersecret1234"}
+    ).json()["access_token"]
+    resp = auth_client.get("/auth/me", headers={"Authorization": f"Bearer {new_token}"})
+    assert resp.status_code == 200
+
+
 # ── Config router ─────────────────────────────────────────────────────────────
 
 _OWNER = UserOut(id=1, email="owner@example.com", name=None, is_workspace_admin=True)

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,0 +1,50 @@
+"""Tests for the in-memory fixed-window rate limiter."""
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.rate_limit import rate_limit
+
+
+def _app(path: str, max_requests: int, window_seconds: int = 60) -> FastAPI:
+    # Bucket keys are (path, client IP), so each test uses its own path to avoid
+    # sharing rate-limit state with other tests via the module-level bucket dict.
+    app = FastAPI()
+
+    @app.get(path, dependencies=[Depends(rate_limit(max_requests=max_requests, window_seconds=window_seconds))])
+    def limited():
+        return {"ok": True}
+
+    return app
+
+
+def test_rate_limit_allows_up_to_max_requests():
+    client = TestClient(_app("/limited-allow", max_requests=2))
+    assert client.get("/limited-allow").status_code == 200
+    assert client.get("/limited-allow").status_code == 200
+
+
+def test_rate_limit_blocks_after_max_requests():
+    client = TestClient(_app("/limited-block", max_requests=2))
+    assert client.get("/limited-block").status_code == 200
+    assert client.get("/limited-block").status_code == 200
+    resp = client.get("/limited-block")
+    assert resp.status_code == 429
+
+
+def test_rate_limit_scoped_per_path():
+    """Two independently-limited routes don't share a bucket."""
+    app = FastAPI()
+
+    @app.get("/a", dependencies=[Depends(rate_limit(max_requests=1))])
+    def a():
+        return {"ok": True}
+
+    @app.get("/b", dependencies=[Depends(rate_limit(max_requests=1))])
+    def b():
+        return {"ok": True}
+
+    client = TestClient(app)
+    assert client.get("/a").status_code == 200
+    assert client.get("/b").status_code == 200
+    assert client.get("/a").status_code == 429

--- a/apps/api/tests/test_session_cookie.py
+++ b/apps/api/tests/test_session_cookie.py
@@ -10,30 +10,56 @@ from src.core.auth import (
     require_auth,
     set_session_cookie,
 )
+from src.core.db import User
 
 
-def test_require_auth_accepts_session_cookie():
-    token = create_access_token(1, "a@b.com", is_workspace_admin=False, name="A")
-    user = require_auth(credentials=None, session=token)
-    assert user.id == 1
-    assert user.email == "a@b.com"
-    assert user.is_workspace_admin is False
+def _make_user(db, email: str, is_workspace_admin: bool = False, name: str | None = None) -> User:
+    user = User(email=email, name=name, password_hash=None, is_workspace_admin=is_workspace_admin)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
 
 
-def test_require_auth_header_takes_precedence_over_cookie():
+def test_require_auth_accepts_session_cookie(db):
+    user = _make_user(db, "a@b.com", name="A")
+    token = create_access_token(user.id, user.email, is_workspace_admin=False, name="A", token_version=user.token_version)
+    result = require_auth(credentials=None, session=token, db=db)
+    assert result.id == user.id
+    assert result.email == "a@b.com"
+    assert result.is_workspace_admin is False
+
+
+def test_require_auth_header_takes_precedence_over_cookie(db):
     from fastapi.security import HTTPAuthorizationCredentials
 
-    header_token = create_access_token(2, "header@b.com", is_workspace_admin=True, name=None)
-    cookie_token = create_access_token(9, "cookie@b.com", is_workspace_admin=False, name=None)
+    header_user = _make_user(db, "header@b.com", is_workspace_admin=True)
+    cookie_user = _make_user(db, "cookie@b.com")
+    header_token = create_access_token(
+        header_user.id, header_user.email, is_workspace_admin=True, name=None, token_version=header_user.token_version
+    )
+    cookie_token = create_access_token(
+        cookie_user.id, cookie_user.email, is_workspace_admin=False, name=None, token_version=cookie_user.token_version
+    )
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=header_token)
-    user = require_auth(credentials=creds, session=cookie_token)
-    assert user.id == 2
-    assert user.is_workspace_admin is True
+    result = require_auth(credentials=creds, session=cookie_token, db=db)
+    assert result.id == header_user.id
+    assert result.is_workspace_admin is True
 
 
-def test_require_auth_rejects_when_missing():
+def test_require_auth_rejects_when_missing(db):
     with pytest.raises(HTTPException) as exc:
-        require_auth(credentials=None, session=None)
+        require_auth(credentials=None, session=None, db=db)
+    assert exc.value.status_code == 401
+
+
+def test_require_auth_rejects_revoked_session(db):
+    user = _make_user(db, "revoked@b.com")
+    token = create_access_token(user.id, user.email, is_workspace_admin=False, name=None, token_version=user.token_version)
+    user.token_version += 1
+    db.commit()
+    with pytest.raises(HTTPException) as exc:
+        require_auth(credentials=None, session=token, db=db)
     assert exc.value.status_code == 401
 
 


### PR DESCRIPTION
## Summary
- Sessions were stateless 30-day JWTs with no server-side revocation: demoting a workspace admin, or a user wanting to log out everywhere, had zero effect until natural token expiry (up to 30 days). Adds `users.token_version` (migration `0010`), embedded in every issued JWT. `require_auth` now hits the DB on each request and compares the claim against the user's current value, 401ing on mismatch. New `POST /auth/me/revoke-sessions` bumps the counter, invalidating all previously issued tokens for that user immediately.
- No rate limiting existed on any auth route, and no Redis is available in this stack, so this adds a small in-memory fixed-window limiter (`src/core/rate_limit.py`, per-process, documented as such) applied to `POST /auth/login`, `POST /auth/register`, and `GET /auth/github/callback` — 10 requests/60s per client IP, 429 past that.
- Note: this changes `require_auth` from a JWT-only check to one that hits the DB on every request (previously documented as JWT-only in the module docstring, now updated).

## Test plan
- [x] `pytest -q` (full API suite) — 128 passed, including new coverage for revoke-sessions (old token 401s, new login still works) and the rate limiter (allows up to the limit, blocks past it, buckets scoped per path)
- [x] `alembic upgrade head` applies migration `0010` cleanly

Fixes #67