### PR TITLE
fix(api): audit token resolves and harden Fernet key derivation

### DIFF
--- a/apps/api/src/core/_crypto.py
+++ b/apps/api/src/core/_crypto.py
@@ -2,16 +2,36 @@ import base64
 import hashlib
 
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
+# job is to make the derived key resistant to precomputed-hash attacks, not to add
+# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
+_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
+_PBKDF2_ITERATIONS = 480_000
+_V2_PREFIX = "v2:"
 
 
-def _fernet(raw_key: str) -> Fernet:
+def _legacy_fernet(raw_key: str) -> Fernet:
+    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
+    to decrypt ciphertext persisted before this change; never used for new encryption."""
     derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
     return Fernet(derived)
 
 
+def _fernet_v2(raw_key: str) -> Fernet:
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
+    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
+    return Fernet(derived)
+
+
 def encrypt_job_token(token: str, key: str) -> str:
-    return _fernet(key).encrypt(token.encode()).decode()
+    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
 
 
 def decrypt_job_token(encrypted: str, key: str) -> str:
-    return _fernet(key).decrypt(encrypted.encode()).decode()
+    if encrypted.startswith(_V2_PREFIX):
+        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
+    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
+    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -16,6 +16,7 @@ from src.core._crypto import decrypt_job_token, encrypt_job_token
 from src.core.auth import UserOut, require_workspace_admin
 from src.core.config import settings
 from src.core.db import SavedToken, get_db
+from src.repositories import audit_repo
 
 router = APIRouter()
 
@@ -83,7 +84,7 @@ def upsert_token(
 def resolve_token(
     body: VerifyTokenRequest,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_workspace_admin),
+    user: UserOut = Depends(require_workspace_admin),
 ) -> VerifyTokenResponse:
     """Decrypt and return the saved token for an org. Returns raw secret — workspace admin only."""
     row = db.query(SavedToken).filter_by(org=body.org).first()
@@ -93,6 +94,7 @@ def resolve_token(
         row.encrypted_token,
         settings.job_secret_key.get_secret_value(),
     )
+    audit_repo.write(db, user.email, "token.resolve", body.org, {})
     return VerifyTokenResponse(token=raw)
 
 

--- a/apps/api/tests/test_crypto.py
+++ b/apps/api/tests/test_crypto.py
@@ -1,0 +1,37 @@
+"""Round-trip and backward-compatibility tests for token encryption (src.core._crypto)."""
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+
+from src.core._crypto import decrypt_job_token, encrypt_job_token
+
+_KEY = "test-job-secret-key"
+
+
+def _legacy_encrypt(token: str, key: str) -> str:
+    """Mirrors the pre-fix unsalted single-round SHA-256 derivation, to prove
+    already-encrypted (pre-migration) ciphertext still decrypts correctly."""
+    derived = base64.urlsafe_b64encode(hashlib.sha256(key.encode()).digest())
+    return Fernet(derived).encrypt(token.encode()).decode()
+
+
+def test_round_trip_new_format():
+    encrypted = encrypt_job_token("ghp_supersecret", _KEY)
+    assert encrypted.startswith("v2:")
+    assert decrypt_job_token(encrypted, _KEY) == "ghp_supersecret"
+
+
+def test_decrypts_legacy_unprefixed_ciphertext():
+    legacy_ciphertext = _legacy_encrypt("ghp_oldtoken", _KEY)
+    assert decrypt_job_token(legacy_ciphertext, _KEY) == "ghp_oldtoken"
+
+
+def test_wrong_key_fails_new_format():
+    encrypted = encrypt_job_token("ghp_supersecret", _KEY)
+    try:
+        decrypt_job_token(encrypted, "wrong-key")
+        assert False, "expected decryption to fail with the wrong key"
+    except Exception:
+        pass

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -80,6 +80,22 @@ def test_tokens_resolve_non_owner_forbidden(db):
     assert resp.status_code == 403
 
 
+def test_tokens_resolve_writes_audit_log(db):
+    from src.core.db import AuditLog
+
+    client = _client(tokens_router, db, _OWNER, prefix="/tokens")
+    client.put("/tokens/acme", json={"token": "ghp_test", "label": "acme"})
+
+    resp = client.post("/tokens/resolve", json={"org": "acme"})
+    assert resp.status_code == 200
+    assert resp.json()["token"] == "ghp_test"
+
+    logs = db.query(AuditLog).filter(AuditLog.action == "token.resolve").all()
+    assert len(logs) == 1
+    assert logs[0].actor == _OWNER.email
+    assert logs[0].target == "acme"
+
+
 # ── actions cache ─────────────────────────────────────────────────────────────
 # Org-role dependencies are resolved before the handler body runs, so a non-member/
 # non-admin never reaches the real GitHub API call — no need to mock GitHubClient here.

--- a/apps/worker/src/_crypto.py
+++ b/apps/worker/src/_crypto.py
@@ -2,16 +2,36 @@ import base64
 import hashlib
 
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
+# job is to make the derived key resistant to precomputed-hash attacks, not to add
+# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
+_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
+_PBKDF2_ITERATIONS = 480_000
+_V2_PREFIX = "v2:"
 
 
-def _fernet(raw_key: str) -> Fernet:
+def _legacy_fernet(raw_key: str) -> Fernet:
+    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
+    to decrypt ciphertext persisted before this change; never used for new encryption."""
     derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
     return Fernet(derived)
 
 
+def _fernet_v2(raw_key: str) -> Fernet:
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
+    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
+    return Fernet(derived)
+
+
 def encrypt_job_token(token: str, key: str) -> str:
-    return _fernet(key).encrypt(token.encode()).decode()
+    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
 
 
 def decrypt_job_token(encrypted: str, key: str) -> str:
-    return _fernet(key).decrypt(encrypted.encode()).decode()
+    if encrypted.startswith(_V2_PREFIX):
+        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
+    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
+    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()


### PR DESCRIPTION
## Summary
- `POST /tokens/resolve` decrypts and returns a raw GitHub PAT — the only endpoint in the app that returns a raw secret, and the only sensitive token action that didn't write an audit log entry. Now calls `audit_repo.write` with the actor, `token.resolve` action, and target org.
- `_fernet()` in both `apps/api/src/core/_crypto.py` and `apps/worker/src/_crypto.py` (identical, duplicated) derived the Fernet key via a single unsalted SHA-256 round. Replaced with PBKDF2-HMAC-SHA256 (480,000 iterations, fixed application salt, in line with current OWASP guidance). New ciphertext is versioned with a `"v2:"` prefix; `decrypt_job_token` still falls back to the legacy unsalted-SHA256 derivation for un-prefixed ciphertext, so already-encrypted `saved_tokens` rows keep decrypting correctly without a backfill. Both copies of `_crypto.py` were changed identically to stay in sync (their duplication itself is a separate, lower-priority issue).

## Test plan
- [x] `pytest -q` (full API suite) — 125 passed, including new coverage: `test_crypto.py` (new-format round-trip, legacy-ciphertext decrypt, wrong-key failure) and a `resolve_token` audit-log assertion in `test_owner_only_routes.py`
- [x] `pytest -q apps/worker/tests` — 3 passed (worker's `_crypto` copy still round-trips correctly)

Fixes #68