### PR TITLE
ci: detect SQLAlchemy model / Alembic migration drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
         working-directory: apps/api
         run: python -m alembic upgrade head
 
+      - name: Check for model / migration drift
+        working-directory: apps/api
+        run: python -m alembic check
+
       - name: Run Python tests
         run: python -m pytest -q
 

--- a/apps/api/alembic/versions/0011_fix_model_migration_drift.py
+++ b/apps/api/alembic/versions/0011_fix_model_migration_drift.py
@@ -1,0 +1,43 @@
+"""fix model/migration drift: NOT NULL timestamps, drop redundant saved_tokens index
+
+`alembic check` (added to CI in this same change) flagged pre-existing drift between the
+SQLAlchemy models and the schema actually produced by earlier migrations:
+
+- audit_logs.created_at, github_installations.created_at, jobs.created_at, and
+  jobs.updated_at are declared as non-nullable (`Mapped[datetime]`) in db.py, but
+  0001_initial_schema.py created them without NOT NULL. All existing rows have a value
+  (the columns have always had server_default=now() and nothing sets them to NULL), so
+  this is a safe, non-destructive tightening.
+- saved_tokens.org already has a UNIQUE constraint (0003_add_saved_tokens.py), which
+  Postgres backs with its own implicit unique index; the separate explicit
+  ix_saved_tokens_org index created in that same migration is redundant and has no
+  corresponding `index=True` in the model, so alembic wants it gone.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("audit_logs", "created_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+    op.alter_column("github_installations", "created_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+    op.alter_column("jobs", "created_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+    op.alter_column("jobs", "updated_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+    op.drop_index("ix_saved_tokens_org", table_name="saved_tokens")
+
+
+def downgrade() -> None:
+    op.create_index("ix_saved_tokens_org", "saved_tokens", ["org"])
+    op.alter_column("jobs", "updated_at", existing_type=sa.DateTime(timezone=True), nullable=True)
+    op.alter_column("jobs", "created_at", existing_type=sa.DateTime(timezone=True), nullable=True)
+    op.alter_column("github_installations", "created_at", existing_type=sa.DateTime(timezone=True), nullable=True)
+    op.alter_column("audit_logs", "created_at", existing_type=sa.DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary
- `alembic upgrade head` in CI only proves the migration chain applies cleanly against an empty database — it doesn't prove the resulting schema matches what the SQLAlchemy models in `apps/api/src/core/db.py` currently declare. A model-only change (add/modify a column without writing the matching migration) previously stayed CI-green and only surfaced at deploy time as a runtime `sqlalchemy.exc.ProgrammingError`. Adds an `alembic check` step right after migrations run in `.github/workflows/ci.yml`, which fails the build if autogenerate would produce a non-empty diff.
- Running `alembic check` against a genuinely clean database (not my polluted local dev DB) surfaced real pre-existing drift on `main`, unrelated to this change: `audit_logs.created_at`, `github_installations.created_at`, and `jobs.created_at`/`updated_at` were nullable in the actual schema despite being declared non-nullable on the models (the original `0001_initial_schema.py` never set `NOT NULL`), and `saved_tokens` carried a redundant explicit index (`ix_saved_tokens_org`) alongside the unique constraint that already indexes that column. New migration `0011` fixes both — both changes are additive/non-destructive (tightening a NOT NULL on a column that's always had a `server_default`; dropping a redundant index) — so the new check starts green instead of failing on day one.

## Test plan
- [x] Verified against a fresh, throwaway Postgres container (not reused dev state): `alembic upgrade head` then `alembic check` failed with the drift described above, confirming it was real
- [x] After adding migration `0011`, re-ran the same clean-container check: `No new upgrade operations detected.`
- [x] `pytest -q` (full API suite) — 132 passed

Fixes #23