### PR TITLE
fix(ui): retry and surface unconfirmed state on /auth/me failure (#163)

### DIFF
--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -11,7 +11,7 @@ const PUBLIC_ROUTES = ["/login", "/setup", "/register"]
 const PUBLIC_ROUTE_PREFIXES = ["/invite/"]
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { user, isLoading, logout } = useAuth()
+  const { user, isLoading, logout, authUnconfirmed } = useAuth()
   const router = useRouter()
   const pathname = usePathname()
 
@@ -67,5 +67,14 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     </div>
   )
 
-  return <>{children}</>
+  return (
+    <>
+      {authUnconfirmed && (
+        <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-1.5 text-center text-xs text-yellow-400">
+          Couldn&rsquo;t confirm your session with the server — your account info may be out of date until it&rsquo;s reachable again.
+        </div>
+      )}
+      {children}
+    </>
+  )
 }

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -167,18 +167,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!authUnconfirmed) return
     function handleOnline() {
+      const epochAtStart = sessionEpochRef.current
       const stored = localStorage.getItem(_TOKEN_KEY)
       fetch(`${BASE}/auth/me`, {
         headers: stored ? { Authorization: `Bearer ${stored}` } : {},
         credentials: "include",
       })
         .then(async (res) => {
+          if (sessionEpochRef.current !== epochAtStart) return
           if (res.status === 401) {
             if (stored) logout()
             return
           }
           if (!res.ok) return
           const data = (await res.json()) as AuthUser
+          // Re-check after the await — a concurrent login()/logout() could have
+          // bumped the epoch while the body was being parsed, in which case this
+          // response is stale and must not clobber the newer session.
+          if (sessionEpochRef.current !== epochAtStart) return
           if (stored) setToken(stored)
           setUser(data)
           setAuthUnconfirmed(false)

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -16,7 +16,9 @@ interface AuthContextValue {
   logoutWarning: string | null
   /** True once the optimistic JWT-derived user could not be confirmed against
    *  the server (network error, timeout, or non-401 failure) after a retry —
-   *  `user` may be stale (e.g. is_workspace_admin) until the next successful check. */
+   *  `user` may be stale (e.g. is_workspace_admin) until the next successful
+   *  check, which happens on login/setSession or once the browser is back
+   *  online. */
   authUnconfirmed: boolean
   login(email: string, password: string): Promise<void>
   logout(): void
@@ -84,6 +86,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const epochAtStart = sessionEpochRef.current
     const stored = localStorage.getItem(_TOKEN_KEY)
     let retryTimer: ReturnType<typeof setTimeout> | undefined
+    // Guards against a fetch that was already in flight when this effect's
+    // cleanup ran (e.g. unmount, or React StrictMode's mount/unmount/remount)
+    // from scheduling a retry or touching state after the fact — clearing
+    // retryTimer alone can't catch this, since it isn't assigned until the
+    // in-flight fetch's catch handler runs, which may be after cleanup.
+    let cancelled = false
 
     if (stored) {
       const optimistic = parseJwtPayload(stored)
@@ -92,6 +100,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUser(optimistic)
         setIsLoading(false)
       }
+    }
+
+    function stale() {
+      return cancelled || sessionEpochRef.current !== epochAtStart
     }
 
     function checkMe(attempt: number) {
@@ -105,19 +117,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         signal: controller.signal,
       })
         .then(async (res) => {
-          if (sessionEpochRef.current !== epochAtStart) return
+          if (stale()) return
           if (res.status === 401) {
             if (stored) logout()
             return
           }
           if (!res.ok) throw new Error(`auth/me responded ${res.status}`)
           const data = (await res.json()) as AuthUser
+          // Re-check after the await — a concurrent login()/logout() could have
+          // bumped the epoch while the body was being parsed, in which case this
+          // response is stale and must not clobber the newer session.
+          if (stale()) return
           if (stored) setToken(stored)
           setUser(data)
           setAuthUnconfirmed(false)
         })
         .catch(() => {
-          if (sessionEpochRef.current !== epochAtStart) return
+          if (stale()) return
           // One retry for a transient network hiccup/timeout before treating the
           // optimistic (or absent) user as unconfirmed instead of trusting it forever.
           if (attempt === 0) {
@@ -139,8 +155,39 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     checkMe(0)
 
-    return () => clearTimeout(retryTimer)
+    return () => {
+      cancelled = true
+      clearTimeout(retryTimer)
+    }
   }, [logout])
+
+  // Re-check once the browser regains connectivity, so a session left
+  // "unconfirmed" by a network blip doesn't sit that way forever — the mount
+  // effect above only runs once and has no periodic re-check of its own.
+  useEffect(() => {
+    if (!authUnconfirmed) return
+    function handleOnline() {
+      const stored = localStorage.getItem(_TOKEN_KEY)
+      fetch(`${BASE}/auth/me`, {
+        headers: stored ? { Authorization: `Bearer ${stored}` } : {},
+        credentials: "include",
+      })
+        .then(async (res) => {
+          if (res.status === 401) {
+            if (stored) logout()
+            return
+          }
+          if (!res.ok) return
+          const data = (await res.json()) as AuthUser
+          if (stored) setToken(stored)
+          setUser(data)
+          setAuthUnconfirmed(false)
+        })
+        .catch(() => {})
+    }
+    window.addEventListener("online", handleOnline)
+    return () => window.removeEventListener("online", handleOnline)
+  }, [authUnconfirmed, logout])
 
   const login = useCallback(async (email: string, password: string) => {
     const res = await fetch(`${BASE}/auth/login`, {
@@ -157,6 +204,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(access_token)
     setUser(u)
     setAuthUnconfirmed(false)
+    setIsLoading(false)
   }, [bumpSessionEpoch, clearLogoutWarning])
 
   const updateUser = useCallback((patch: Partial<AuthUser>) => {
@@ -170,6 +218,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(jwtToken)
     setUser(authUser)
     setAuthUnconfirmed(false)
+    setIsLoading(false)
   }, [bumpSessionEpoch, clearLogoutWarning])
 
   return (

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -14,6 +14,10 @@ interface AuthContextValue {
   token: string | null
   isLoading: boolean
   logoutWarning: string | null
+  /** True once the optimistic JWT-derived user could not be confirmed against
+   *  the server (network error, timeout, or non-401 failure) after a retry —
+   *  `user` may be stale (e.g. is_workspace_admin) until the next successful check. */
+  authUnconfirmed: boolean
   login(email: string, password: string): Promise<void>
   logout(): void
   clearLogoutWarning(): void
@@ -52,6 +56,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [logoutWarning, setLogoutWarning] = useState<string | null>(null)
+  const [authUnconfirmed, setAuthUnconfirmed] = useState(false)
   const sessionEpochRef = useRef(0)
 
   const bumpSessionEpoch = useCallback(() => {
@@ -72,11 +77,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.removeItem(_TOKEN_KEY)
     setToken(null)
     setUser(null)
+    setAuthUnconfirmed(false)
   }, [bumpSessionEpoch])
 
   useEffect(() => {
     const epochAtStart = sessionEpochRef.current
     const stored = localStorage.getItem(_TOKEN_KEY)
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
 
     if (stored) {
       const optimistic = parseJwtPayload(stored)
@@ -87,29 +94,52 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     }
 
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 15000)
-    fetch(`${BASE}/auth/me`, {
-      headers: stored ? { Authorization: `Bearer ${stored}` } : {},
-      credentials: "include",
-      signal: controller.signal,
-    })
-      .then(async (res) => {
-        if (sessionEpochRef.current !== epochAtStart) return
-        if (res.status === 401) {
-          if (stored) logout()
-          return
-        }
-        if (!res.ok) return
-        const data = (await res.json()) as AuthUser
-        if (stored) setToken(stored)
-        setUser(data)
+    function checkMe(attempt: number) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 15000)
+      let willRetry = false
+
+      fetch(`${BASE}/auth/me`, {
+        headers: stored ? { Authorization: `Bearer ${stored}` } : {},
+        credentials: "include",
+        signal: controller.signal,
       })
-      .catch(() => {})
-      .finally(() => {
-        clearTimeout(timer)
-        setIsLoading(false)
-      })
+        .then(async (res) => {
+          if (sessionEpochRef.current !== epochAtStart) return
+          if (res.status === 401) {
+            if (stored) logout()
+            return
+          }
+          if (!res.ok) throw new Error(`auth/me responded ${res.status}`)
+          const data = (await res.json()) as AuthUser
+          if (stored) setToken(stored)
+          setUser(data)
+          setAuthUnconfirmed(false)
+        })
+        .catch(() => {
+          if (sessionEpochRef.current !== epochAtStart) return
+          // One retry for a transient network hiccup/timeout before treating the
+          // optimistic (or absent) user as unconfirmed instead of trusting it forever.
+          if (attempt === 0) {
+            willRetry = true
+            retryTimer = setTimeout(() => checkMe(1), 2000)
+            return
+          }
+          if (stored) setAuthUnconfirmed(true)
+        })
+        .finally(() => {
+          clearTimeout(timer)
+          // Keep isLoading true while a retry is pending; otherwise this is the
+          // terminal outcome for this mount's check (success, 401, exhausted
+          // retries, or a stale epoch after a concurrent login/logout) and the
+          // initial loading phase is over regardless of which branch ran.
+          if (!willRetry) setIsLoading(false)
+        })
+    }
+
+    checkMe(0)
+
+    return () => clearTimeout(retryTimer)
   }, [logout])
 
   const login = useCallback(async (email: string, password: string) => {
@@ -126,6 +156,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem(_TOKEN_KEY, access_token)
     setToken(access_token)
     setUser(u)
+    setAuthUnconfirmed(false)
   }, [bumpSessionEpoch, clearLogoutWarning])
 
   const updateUser = useCallback((patch: Partial<AuthUser>) => {
@@ -138,6 +169,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem(_TOKEN_KEY, jwtToken)
     setToken(jwtToken)
     setUser(authUser)
+    setAuthUnconfirmed(false)
   }, [bumpSessionEpoch, clearLogoutWarning])
 
   return (
@@ -147,6 +179,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         token,
         isLoading,
         logoutWarning,
+        authUnconfirmed,
         login,
         logout,
         clearLogoutWarning,

--- a/apps/ui/tests/components/auth-guard.test.tsx
+++ b/apps/ui/tests/components/auth-guard.test.tsx
@@ -95,3 +95,50 @@ describe("AuthGuard clevis:unauthorized handling", () => {
     expect(replace).toHaveBeenCalledWith("/login");
   });
 });
+
+describe("AuthGuard authUnconfirmed banner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    replace.mockClear();
+    localStorage.setItem(TOKEN_KEY, makeJwt(1, "user@example.com"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("shows a banner once the session can't be confirmed with the server, without blocking the page", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) return Promise.reject(new Error("network down"));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    render(
+      <AuthProvider>
+        <AuthGuard>
+          <div>protected content</div>
+        </AuthGuard>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText("protected content")).toBeInTheDocument());
+    expect(screen.queryByText(/couldn.t confirm your session/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn.t confirm your session/i)).toBeInTheDocument(),
+    );
+    // Still renders the page — the stale optimistic state is surfaced, not hidden behind it.
+    expect(screen.getByText("protected content")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/lib/auth-context.test.tsx
+++ b/apps/ui/tests/lib/auth-context.test.tsx
@@ -129,6 +129,43 @@ describe("AuthProvider mount /auth/me race", () => {
     expect(result.current.user).toEqual(passwordUser);
   });
 
+  it("does not overwrite a concurrent login even if the stale response's body resolves after the login completes", async () => {
+    // Headers resolve before login() runs, but res.json() only resolves after —
+    // this exercises the epoch re-check *after* the `await res.json()` in the
+    // /auth/me handler, distinct from the epoch check at the top of the handler.
+    let resolveJson!: () => void;
+    const jsonPromise = new Promise<unknown>((resolve) => {
+      resolveJson = () => resolve(cookieUser);
+    });
+    const staleResponse = {
+      ok: true,
+      status: 200,
+      json: () => jsonPromise,
+    } as Response;
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      meDeferred.resolve(staleResponse);
+    });
+
+    await act(async () => {
+      await result.current.login("password@example.com", "supersecret1234");
+    });
+
+    expect(result.current.user).toEqual(passwordUser);
+
+    await act(async () => {
+      resolveJson();
+    });
+
+    // The stale /auth/me body must not clobber the concurrently-logged-in user.
+    expect(result.current.user).toEqual(passwordUser);
+  });
+
   it("ignores a stale /auth/me response after logout", async () => {
     localStorage.setItem(TOKEN_KEY, makeJwt(cookieUser.id, cookieUser.email));
 
@@ -375,6 +412,41 @@ describe("AuthProvider authUnconfirmed", () => {
     // The optimistic user is kept (not wiped) — the caller decides what to do with the flag.
     expect(result.current.user).toEqual(cookieUser);
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("clears authUnconfirmed on the next 'online' event once connectivity returns", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem(TOKEN_KEY, makeJwtForUser(cookieUser));
+
+    let online = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          return online ? Promise.resolve(jsonResponse(cookieUser)) : Promise.reject(new Error("offline"));
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await waitFor(() => expect(result.current.authUnconfirmed).toBe(true));
+
+    online = true;
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => expect(result.current.authUnconfirmed).toBe(false));
+    expect(result.current.user).toEqual(cookieUser);
   });
 
   it("does not set authUnconfirmed when there was no stored token to begin with", async () => {

--- a/apps/ui/tests/lib/auth-context.test.tsx
+++ b/apps/ui/tests/lib/auth-context.test.tsx
@@ -24,6 +24,18 @@ function makeJwt(sub: number, email: string): string {
   return `${header}.${payload}.sig`;
 }
 
+function makeJwtForUser(user: AuthUser): string {
+  const header = b64url({ alg: "none", typ: "JWT" });
+  const payload = b64url({
+    sub: String(user.id),
+    email: user.email,
+    name: user.name,
+    is_workspace_admin: user.is_workspace_admin,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  return `${header}.${payload}.sig`;
+}
+
 const passwordUser: AuthUser = {
   id: 2,
   email: "password@example.com",
@@ -285,5 +297,109 @@ describe("AuthProvider logoutWarning", () => {
     });
 
     expect(result.current.logoutWarning).toBeNull();
+  });
+});
+
+describe("AuthProvider authUnconfirmed", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries once after a transient /auth/me failure and clears authUnconfirmed on success", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem(TOKEN_KEY, makeJwtForUser(cookieUser));
+
+    let meCallCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          meCallCount += 1;
+          if (meCallCount === 1) return Promise.reject(new Error("network blip"));
+          return Promise.resolve(jsonResponse(cookieUser));
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    // Optimistic decode from the stored JWT applies immediately.
+    expect(result.current.user).toEqual(cookieUser);
+    expect(result.current.authUnconfirmed).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() => expect(meCallCount).toBe(2));
+    expect(result.current.authUnconfirmed).toBe(false);
+    expect(result.current.user).toEqual(cookieUser);
+  });
+
+  it("marks authUnconfirmed after the retry also fails, without clearing the optimistic user", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem(TOKEN_KEY, makeJwtForUser(cookieUser));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) return Promise.reject(new Error("network down"));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.user).toEqual(cookieUser);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() => expect(result.current.authUnconfirmed).toBe(true));
+    // The optimistic user is kept (not wiped) — the caller decides what to do with the flag.
+    expect(result.current.user).toEqual(cookieUser);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not set authUnconfirmed when there was no stored token to begin with", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) return Promise.reject(new Error("network down"));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.authUnconfirmed).toBe(false);
+    expect(result.current.user).toBeNull();
   });
 });

--- a/apps/ui/tests/lib/auth-context.test.tsx
+++ b/apps/ui/tests/lib/auth-context.test.tsx
@@ -474,4 +474,76 @@ describe("AuthProvider authUnconfirmed", () => {
     expect(result.current.authUnconfirmed).toBe(false);
     expect(result.current.user).toBeNull();
   });
+
+  it("does not overwrite a concurrent login with a stale online-reconnect /auth/me response", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    localStorage.setItem(TOKEN_KEY, makeJwtForUser(cookieUser));
+
+    const passwordToken = makeJwt(passwordUser.id, passwordUser.email);
+
+    let meCallCount = 0;
+    const onlineDeferred = (() => {
+      let resolve!: (response: Response) => void;
+      const promise = new Promise<Response>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    })();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          meCallCount += 1;
+          // Mount attempt (1) and its retry (2) both fail, so authUnconfirmed
+          // becomes true; the online-triggered call (3) is held open so a
+          // concurrent login can race it.
+          if (meCallCount <= 2) return Promise.reject(new Error("network down"));
+          return onlineDeferred.promise;
+        }
+        if (url.endsWith("/auth/login")) {
+          return Promise.resolve(
+            jsonResponse({ access_token: passwordToken, user: passwordUser }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await waitFor(() => expect(result.current.authUnconfirmed).toBe(true));
+
+    // Connectivity returns, firing the online handler's /auth/me check —
+    // its response is held open via onlineDeferred.
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+    });
+    await waitFor(() => expect(meCallCount).toBe(3));
+
+    // A password login happens while that online-triggered fetch is still
+    // in flight.
+    await act(async () => {
+      await result.current.login("password@example.com", "supersecret1234");
+    });
+
+    expect(result.current.user).toEqual(passwordUser);
+    expect(result.current.token).toEqual(passwordToken);
+
+    // The stale online-triggered /auth/me response resolves after the login.
+    await act(async () => {
+      onlineDeferred.resolve(jsonResponse(cookieUser));
+    });
+
+    // It must not clobber the newer, concurrently-logged-in session.
+    expect(result.current.user).toEqual(passwordUser);
+    expect(result.current.token).toEqual(passwordToken);
+  });
 });


### PR DESCRIPTION
## Summary

`AuthProvider` (`apps/ui/lib/auth-context.tsx`) decodes the JWT from `localStorage` client-side and immediately sets `user`/`is_workspace_admin` "optimistically", before the authoritative `GET /auth/me` call resolves. If that fetch fails — a network hiccup, a CORS issue, or the 15s `AbortController` timeout — the failure was swallowed silently by `.catch(() => {})`, with no retry and no fallback. The optimistic claim from the locally-decoded JWT stood for the rest of the session, with no way for the user (or admin-gated UI like `InstanceConfigSection` on Settings) to know the authoritative check never actually completed.

Changes:
- The `/auth/me` check now retries once after a 2s delay on any failure (network error, timeout, or a non-401 non-ok response) before giving up — this alone fixes ordinary transient blips without ever bothering the user.
- If the retry also fails, a new `authUnconfirmed` boolean is set on the auth context instead of silently trusting the stale optimistic value forever. It's cleared on the next successful check, `login`, `setSession`, or `logout`.
- `AuthGuard` renders a small non-blocking banner when `authUnconfirmed` is true, so a user (or an admin whose access may have since been revoked) has visible indication their session state might be stale — matching the issue's "surface a banner" suggested fix, reusing `AuthGuard` since it already wraps every protected page.

While rewriting the retry logic I introduced and then caught a regression in my own change: the original `.finally()` always cleared `isLoading` unconditionally, which matters for the case where a concurrent `login()` call bumps the session epoch while the mount-time `/auth/me` check is still in flight — my first draft only cleared `isLoading` inside the epoch-gated branches, so a stale response would leave `isLoading` stuck `true` forever. Fixed by tracking a `willRetry` flag and only skipping the `isLoading` clear when an actual retry is about to fire; the existing test `does not overwrite a concurrent password login with a stale /auth/me response` catches this.

This is a UI-only fix — no API, auth *backend*, or schema changes (client-side JWT decode/display logic only; no change to how tokens are verified server-side).

Closes #163

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [x] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed) — not applicable, no API/worker changes
- [ ] Relevant `pytest` tests pass (if API/worker changed) — not applicable
- [ ] Docker images still build, if `Dockerfile`/deps changed — not applicable, no deps changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Added tests in `apps/ui/tests/lib/auth-context.test.tsx` (retry-then-success, retry-then-still-failing marks `authUnconfirmed`, no-stored-token case doesn't falsely set it) and `apps/ui/tests/components/auth-guard.test.tsx` (banner appears without blocking the page). Full `bun run test` suite (71 tests) passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7RDvvVu5mqC4pybwNqq7A)_