### PR TITLE
fix(worker): dispatch queued jobs by job_type instead of one hardcoded value (#143)

### DIFF
--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -43,31 +43,45 @@ def _read_poll_seconds() -> int:
         return 5
 
 
-def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None:
+def _clear_actions_cache(payload: dict) -> dict:
     base = settings.github_api_base
+    owner, repo = payload["owner"], payload["repo"]
+    token = decrypt_job_token(payload["token"], settings.job_secret_key.get_secret_value())
+    params = {k: payload[k] for k in ("key", "ref") if payload.get(k)}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.delete(
+            f"{base}/repos/{owner}/{repo}/actions/caches",
+            headers=headers,
+            params=params,
+        )
+    if resp.status_code >= 300:
+        raise RuntimeError(f"GitHub API error: {resp.status_code}")
+    return {"ok": True, "status": resp.status_code}
+
+
+# job_type -> handler. Each handler takes the decoded payload dict and returns
+# a JSON-serializable result on success, or raises on failure.
+JOB_HANDLERS = {
+    "github.clear_actions_cache": _clear_actions_cache,
+}
+
+
+def process_job(conn: psycopg.Connection, job_id: int, job_type: str, payload_raw: str) -> None:
     try:
+        handler = JOB_HANDLERS.get(job_type)
+        if handler is None:
+            raise ValueError(f"no handler registered for job_type {job_type!r}")
         payload = json.loads(payload_raw)
-        owner, repo = payload["owner"], payload["repo"]
-        token = decrypt_job_token(payload["token"], settings.job_secret_key.get_secret_value())
-        params = {k: payload[k] for k in ("key", "ref") if payload.get(k)}
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-        with httpx.Client(timeout=20) as client:
-            resp = client.delete(
-                f"{base}/repos/{owner}/{repo}/actions/caches",
-                headers=headers,
-                params=params,
-            )
-        if resp.status_code >= 300:
-            raise RuntimeError(f"GitHub API error: {resp.status_code}")
-        result = json.dumps({"ok": True, "status": resp.status_code})
+        result = handler(payload)
         with conn.cursor() as cur:
             cur.execute(
                 "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s",
-                (result, job_id),
+                (json.dumps(result), job_id),
             )
         log.info("job %d done", job_id)
     except Exception as error:
@@ -94,12 +108,11 @@ def run() -> None:
                         WHERE id = (
                             SELECT id FROM jobs
                             WHERE status = 'queued'
-                              AND job_type = 'github.clear_actions_cache'
                             ORDER BY id
                             LIMIT 1
                             FOR UPDATE SKIP LOCKED
                         )
-                        RETURNING id, payload
+                        RETURNING id, job_type, payload
                     """)
                     row = cur.fetchone()
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -53,7 +53,7 @@ def test_process_job_marks_done_on_success():
         mock_client.delete = MagicMock(return_value=mock_response)
         mock_client_cls.return_value = mock_client
 
-        process_job(conn, 1, _payload())
+        process_job(conn, 1, "github.clear_actions_cache", _payload())
 
     sql, params = conn._cursor.calls[0]
     assert "status='done'" in sql
@@ -78,7 +78,7 @@ def test_process_job_marks_failed_on_http_error():
         mock_client.delete = MagicMock(return_value=mock_response)
         mock_client_cls.return_value = mock_client
 
-        process_job(conn, 2, _payload())
+        process_job(conn, 2, "github.clear_actions_cache", _payload())
 
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
@@ -97,7 +97,7 @@ def test_process_job_marks_failed_on_network_error():
         mock_client.delete = MagicMock(side_effect=ConnectionError("timeout"))
         mock_client_cls.return_value = mock_client
 
-        process_job(conn, 3, _payload())
+        process_job(conn, 3, "github.clear_actions_cache", _payload())
 
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
@@ -115,7 +115,7 @@ def test_process_job_truncates_long_error():
         mock_client.delete = MagicMock(side_effect=ConnectionError("x" * 1000))
         mock_client_cls.return_value = mock_client
 
-        process_job(conn, 4, _payload())
+        process_job(conn, 4, "github.clear_actions_cache", _payload())
 
     sql, params = conn._cursor.calls[0]
     assert len(params[0]) <= 500
@@ -134,8 +134,43 @@ def test_process_job_redacts_token_shaped_text_in_error():
         )
         mock_client_cls.return_value = mock_client
 
-        process_job(conn, 5, _payload())
+        process_job(conn, 5, "github.clear_actions_cache", _payload())
 
     sql, params = conn._cursor.calls[0]
     assert "ghp_" not in params[0]
     assert "[redacted]" in params[0]
+
+
+def test_process_job_marks_unknown_job_type_failed_without_calling_github():
+    conn = _FakeConn()
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        process_job(conn, 6, "some.future.job_type", _payload())
+        mock_client_cls.assert_not_called()
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert params[1] == 6
+    assert "some.future.job_type" in params[0]
+    assert conn.committed is True
+
+
+def test_process_job_dispatches_known_job_type_to_its_handler():
+    conn = _FakeConn()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.text = ""
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 7, "github.clear_actions_cache", _payload())
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='done'" in sql
+    assert params[1] == 7


### PR DESCRIPTION
## Summary

`apps/worker/src/worker.py`'s poll query hardcoded the job type it looks for:

```sql
WHERE status = 'queued' AND job_type = 'github.clear_actions_cache'
```

But `job_repo.enqueue(db, job_type, payload)` takes an arbitrary `job_type` string, and the `jobs` table schema is fully generic. Only `github.clear_actions_cache` is enqueued today, but any future feature that calls `job_repo.enqueue()` with a different `job_type` would insert a row the worker's poll query could never match — it would sit queued forever with no error, no timeout, no visibility that anything is wrong.

Changes to `apps/worker/src/worker.py`:
- Extracted the existing cache-clear logic into `_clear_actions_cache(payload) -> dict`, registered in a `JOB_HANDLERS = {"github.clear_actions_cache": _clear_actions_cache}` dispatch table.
- The poll query's `RETURNING` clause now also selects `job_type`, and no longer filters on it — it claims any queued job regardless of type.
- `process_job(conn, job_id, job_type, payload_raw)` (now takes `job_type` as an explicit parameter) looks up a handler by `job_type`; if none is registered, it raises immediately and the existing failure path marks the job `failed` with a clear `"no handler registered for job_type '...'"` reason — instead of the job silently never being picked up.

This is a worker-only fix — no API schema, RBAC, or migration changes (the `jobs` table already had a generic `job_type` column; this only changes how the worker reads it).

Closes #143

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed) — not applicable, no UI changes
- [x] `python -m compileall apps/api/src apps/worker/src`
- [x] Relevant `pytest` tests pass
- [ ] Docker images still build, if `Dockerfile`/deps changed — not applicable, no deps changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Updated the 5 existing `apps/worker/tests/test_process_job.py` call sites for the new `job_type` parameter, and added two tests: an unknown `job_type` marks the job `failed` without ever calling GitHub, and a known `job_type` still dispatches to `_clear_actions_cache` and marks `done`. Full `pytest -q` suite (198 tests) passes against a real Postgres instance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7RDvvVu5mqC4pybwNqq7A)_