### PR TITLE
fix(api): add GitHub App webhook endpoint to keep installations in sync (#142)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -19,6 +19,7 @@ from src.routers import (
     jobs,
     orgs,
     tokens,
+    webhooks,
 )
 
 # CORS allowed origins are a deploy-time security boundary, set via the CORS_ORIGINS env var.
@@ -65,3 +66,4 @@ app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])
 app.include_router(config.router, prefix="/config", tags=["config"])
+app.include_router(webhooks.router, tags=["webhooks"])

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -102,3 +102,11 @@ def list_for_user(db: Session, owner_user_id: int) -> list[GitHubInstallation]:
         .order_by(GitHubInstallation.created_at.desc())
         .all()
     )
+
+
+def delete_by_installation_id(db: Session, installation_id: int) -> int:
+    """Remove every row referencing a GitHub installation_id (e.g. on uninstall).
+    Returns the number of rows deleted."""
+    count = db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).delete()
+    db.commit()
+    return count

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -14,11 +14,29 @@ from sqlalchemy.orm import Session
 
 from src.core.config import settings
 from src.core.db import get_db
+from src.core.rate_limit import rate_limit
 from src.repositories import audit_repo, installation_repo
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# GitHub caps webhook deliveries around 25MB; refuse anything larger long before that
+# so a body this endpoint (unauthenticated until the signature check passes) can't be
+# used to exhaust memory. Enforced by counting streamed bytes, not by trusting a
+# client-supplied Content-Length header.
+_MAX_BODY_BYTES = 5 * 1024 * 1024
+
+
+async def _read_bounded_body(request: Request) -> bytes:
+    chunks = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > _MAX_BODY_BYTES:
+            raise HTTPException(status_code=413, detail="Webhook payload too large")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _verify_signature(raw_body: bytes, signature_header: str | None, secret: str) -> bool:
@@ -26,16 +44,23 @@ def _verify_signature(raw_body: bytes, signature_header: str | None, secret: str
         return False
     expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
     provided = signature_header.removeprefix("sha256=")
-    return hmac.compare_digest(expected, provided)
+    # Compare as bytes, not str — hmac.compare_digest raises TypeError on a str
+    # containing non-ASCII characters, which an attacker fully controls via this
+    # header; encoding first keeps a malformed signature a clean 401, not a 500.
+    return hmac.compare_digest(expected.encode(), provided.encode("utf-8", errors="replace"))
 
 
-@router.post("/webhooks/github")
+# Generous relative to the auth-endpoint default (10/60s): GitHub's webhook deliveries
+# for many customers' installations can share the same egress IP, so a strict per-IP
+# limit risks throttling legitimate traffic. Still bounds worst-case abuse from any
+# single source.
+@router.post("/webhooks/github", dependencies=[Depends(rate_limit(max_requests=120, window_seconds=60))])
 async def github_webhook(request: Request, db: Session = Depends(get_db)):
     secret = settings.github_app_webhook_secret
     if not secret:
         raise HTTPException(status_code=503, detail="GitHub webhook secret not configured")
 
-    raw_body = await request.body()
+    raw_body = await _read_bounded_body(request)
     if not _verify_signature(raw_body, request.headers.get("X-Hub-Signature-256"), secret.get_secret_value()):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
@@ -58,8 +83,8 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
 
 def _handle_installation_deleted(db: Session, payload: dict) -> None:
     installation_id = (payload.get("installation") or {}).get("id")
-    if installation_id is None:
-        logger.warning("installation.deleted webhook missing installation.id")
+    if not isinstance(installation_id, int) or isinstance(installation_id, bool):
+        logger.warning("installation.deleted webhook has a missing/non-integer installation.id: %r", installation_id)
         return
     removed = installation_repo.delete_by_installation_id(db, installation_id)
     if removed:

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -73,6 +73,16 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
 
     if event == "installation" and payload.get("action") == "deleted":
         _handle_installation_deleted(db, payload)
+    # installation.created is deliberately a no-op: rows are only ever written to
+    # github_installations by the authenticated /orgs/{org}/installations/sync and
+    # /me/installations/sync endpoints, which independently verify (via
+    # _verify_installation, see #141) that the installation_id genuinely belongs to
+    # the claimed account before persisting. Auto-creating a row straight from this
+    # webhook would mean trusting GitHub's payload to decide which clevis org/user it
+    # belongs to with no equivalent ownership check — that's a bigger trust-boundary
+    # decision than "keep an existing verified row in sync," so it's left to the
+    # explicit sync flow rather than done implicitly here.
+    #
     # installation_repositories (repo access added/removed within an existing
     # installation) has nothing to sync yet — github_installations tracks the
     # installation itself, not per-repo access, so there's no row-level change

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,0 +1,72 @@
+"""GitHub App webhook receiver.
+
+  POST /webhooks/github   verifies X-Hub-Signature-256, then handles installation
+                           lifecycle events to keep github_installations in sync.
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import get_db
+from src.repositories import audit_repo, installation_repo
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None, secret: str) -> bool:
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    provided = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, provided)
+
+
+@router.post("/webhooks/github")
+async def github_webhook(request: Request, db: Session = Depends(get_db)):
+    secret = settings.github_app_webhook_secret
+    if not secret:
+        raise HTTPException(status_code=503, detail="GitHub webhook secret not configured")
+
+    raw_body = await request.body()
+    if not _verify_signature(raw_body, request.headers.get("X-Hub-Signature-256"), secret.get_secret_value()):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Malformed webhook payload")
+
+    event = request.headers.get("X-GitHub-Event", "")
+
+    if event == "installation" and payload.get("action") == "deleted":
+        _handle_installation_deleted(db, payload)
+    # installation_repositories (repo access added/removed within an existing
+    # installation) has nothing to sync yet — github_installations tracks the
+    # installation itself, not per-repo access, so there's no row-level change
+    # to make here today. Accepted (200) so GitHub doesn't retry.
+
+    return {"ok": True}
+
+
+def _handle_installation_deleted(db: Session, payload: dict) -> None:
+    installation_id = (payload.get("installation") or {}).get("id")
+    if installation_id is None:
+        logger.warning("installation.deleted webhook missing installation.id")
+        return
+    removed = installation_repo.delete_by_installation_id(db, installation_id)
+    if removed:
+        audit_repo.write(
+            db,
+            actor="github-webhook",
+            action="installation.deleted",
+            target=str(installation_id),
+            payload={"installation_id": installation_id, "rows_removed": removed},
+        )

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -1,0 +1,132 @@
+"""Tests for the GitHub App webhook receiver."""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from src.core.config import settings
+from src.core.db import AuditLog, get_db
+from src.repositories import installation_repo, org_repo
+from src.routers.webhooks import router as webhooks_router
+
+_SECRET = "test-webhook-secret"
+
+
+@pytest.fixture()
+def webhook_client(db, monkeypatch):
+    monkeypatch.setattr(settings, "github_app_webhook_secret", SecretStr(_SECRET))
+    app = FastAPI()
+    app.include_router(webhooks_router)
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _sign(body: bytes, secret: str = _SECRET) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _post(client, event: str, payload: dict, *, secret: str = _SECRET, signature: str | None = None):
+    body = json.dumps(payload).encode()
+    sig = signature if signature is not None else _sign(body, secret)
+    return client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-GitHub-Event": event,
+            "X-Hub-Signature-256": sig,
+        },
+    )
+
+
+def test_rejects_missing_signature(webhook_client):
+    resp = webhook_client.post(
+        "/webhooks/github",
+        content=b'{"action": "deleted"}',
+        headers={"X-GitHub-Event": "installation"},
+    )
+    assert resp.status_code == 401
+
+
+def test_rejects_invalid_signature(webhook_client):
+    resp = _post(webhook_client, "installation", {"action": "deleted"}, signature="sha256=deadbeef")
+    assert resp.status_code == 401
+
+
+def test_rejects_signature_signed_with_wrong_secret(webhook_client):
+    resp = _post(webhook_client, "installation", {"action": "deleted"}, secret="wrong-secret")
+    assert resp.status_code == 401
+
+
+def test_returns_503_when_webhook_secret_not_configured(db, monkeypatch):
+    monkeypatch.setattr(settings, "github_app_webhook_secret", None)
+    app = FastAPI()
+    app.include_router(webhooks_router)
+    app.dependency_overrides[get_db] = lambda: db
+    client = TestClient(app)
+    resp = _post(client, "installation", {"action": "deleted"})
+    assert resp.status_code == 503
+
+
+def test_installation_deleted_removes_matching_rows_and_writes_audit_log(db, webhook_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(webhook_client, "installation", {"action": "deleted", "installation": {"id": 42}})
+
+    assert resp.status_code == 200
+    assert installation_repo.list_for_org(db, org_id=org.id) == []
+    logs = db.query(AuditLog).filter(AuditLog.action == "installation.deleted").all()
+    assert len(logs) == 1
+    assert logs[0].actor == "github-webhook"
+    assert logs[0].target == "42"
+
+
+def test_installation_deleted_only_removes_matching_installation_id(db, webhook_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(webhook_client, "installation", {"action": "deleted", "installation": {"id": 999}})
+
+    assert resp.status_code == 200
+    assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1
+
+
+def test_installation_created_action_is_a_no_op(db, webhook_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(webhook_client, "installation", {"action": "created", "installation": {"id": 42}})
+
+    assert resp.status_code == 200
+    assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1
+
+
+def test_unrecognized_event_type_returns_200_without_side_effects(webhook_client):
+    resp = _post(webhook_client, "ping", {"zen": "hello"})
+    assert resp.status_code == 200
+
+
+def test_malformed_json_body_returns_400(webhook_client):
+    body = b"not json"
+    resp = webhook_client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "installation",
+            "X-Hub-Signature-256": _sign(body),
+        },
+    )
+    assert resp.status_code == 400

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -179,3 +179,23 @@ def test_installation_deleted_ignores_non_integer_installation_id(db, webhook_cl
     # Nothing should be deleted, and no exception should propagate from a type mismatch
     # hitting the database — an installation_id of the wrong type must be a safe no-op.
     assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1
+
+
+def test_route_is_registered_on_the_real_app(db, monkeypatch):
+    # Every other test in this file mounts `webhooks_router` on an isolated FastAPI()
+    # instance, so they would all still pass even if `src.main` never actually included
+    # the router — a dropped `app.include_router(webhooks.router, ...)` in main.py would
+    # only surface as a 404 in production. Import the real app the way
+    # `uvicorn src.main:app` does and hit the route through it, so a missing/broken
+    # registration fails here instead.
+    from src.main import app as real_app
+
+    monkeypatch.setattr(settings, "github_app_webhook_secret", SecretStr(_SECRET))
+    real_app.dependency_overrides[get_db] = lambda: db
+    try:
+        resp = _post(TestClient(real_app), "ping", {"zen": "hello"})
+    finally:
+        real_app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -130,3 +130,52 @@ def test_malformed_json_body_returns_400(webhook_client):
         },
     )
     assert resp.status_code == 400
+
+
+def test_non_ascii_signature_header_is_a_clean_401_not_a_crash(webhook_client):
+    # hmac.compare_digest raises TypeError on a `str` with non-ASCII characters.
+    # HTTP header values are latin-1, so a raw byte like \xe9 is a valid header on
+    # the wire but decodes to a non-ASCII Python str — pass raw bytes (not a str,
+    # which httpx would refuse to even encode as a header) to actually exercise
+    # that path. Must fail closed with 401, not bubble up as an unhandled 500.
+    body = json.dumps({"action": "deleted"}).encode()
+    resp = webhook_client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "installation",
+            "X-Hub-Signature-256": b"sha256=\xe9\xe9\xe9\xe9",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_oversized_body_rejected_with_413(webhook_client):
+    from src.routers.webhooks import _MAX_BODY_BYTES
+
+    oversized = b"a" * (_MAX_BODY_BYTES + 1)
+    resp = webhook_client.post(
+        "/webhooks/github",
+        content=oversized,
+        headers={
+            "Content-Type": "application/octet-stream",
+            "X-GitHub-Event": "installation",
+            "X-Hub-Signature-256": _sign(oversized),
+        },
+    )
+    assert resp.status_code == 413
+
+
+def test_installation_deleted_ignores_non_integer_installation_id(db, webhook_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(webhook_client, "installation", {"action": "deleted", "installation": {"id": "not-an-int"}})
+
+    assert resp.status_code == 200
+    # Nothing should be deleted, and no exception should propagate from a type mismatch
+    # hitting the database — an installation_id of the wrong type must be a safe no-op.
+    assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -21,7 +21,7 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
 3. Register a GitHub App on github.com (**Settings → Developer settings → GitHub Apps → New GitHub App**) so users can connect their orgs after the instance is running:
    - **Homepage URL** — your deployed UI URL.
    - **Callback URL** — `<NEXT_PUBLIC_API_BASE>/auth/github/callback` (this exact path is required for "Sign in with GitHub" to work).
-   - **Webhook** — can be left disabled/unconfigured; Clevis doesn't currently consume GitHub webhooks, so there's nothing to point it at yet.
+   - **Webhook** — optional, but recommended: point it at `<NEXT_PUBLIC_API_BASE>/webhooks/github`, generate a webhook secret, and set `GITHUB_APP_WEBHOOK_SECRET` in `.env` to the same value. Without it, `github_installations` rows are never cleaned up when a user uninstalls the App — they just go stale.
    - Grant read access to the repository/organization data the security checks need (contents, metadata, administration, members) — generate a private key once the App is created.
    - Copy the resulting values into `.env`: `GITHUB_APP_ID`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY` (the full `.pem` contents). Also set `NEXT_PUBLIC_GITHUB_APP_SLUG` to the App's slug (from its public page URL) — this powers the "Install GitHub App" button in the UI.
 


### PR DESCRIPTION
## ⚠️ Touches auth/trust-boundary code

This PR adds a new unauthenticated (signature-verified, not session-authenticated) endpoint that writes to `github_installations`. Flagging per AGENTS.md guardrail #2/#3. No RBAC changes, no token-encryption logic touched, no migration — the endpoint is protected entirely by HMAC signature verification against `GITHUB_APP_WEBHOOK_SECRET`, and fails closed (503) if that secret isn't configured rather than accepting unverified calls.

## Summary

`apps/api/src/core/config.py` defines `github_app_webhook_secret: SecretStr | None`, implying GitHub App webhook events are meant to be received and verified — but no webhook-receiving router existed anywhere in `apps/api/src/main.py`'s router list, and `docs/self-hosting.md` explicitly told self-hosters the webhook could be left unconfigured "since Clevis doesn't currently consume GitHub webhooks." Without it, `github_installations` rows could never be kept in sync with reality: if a user uninstalled the GitHub App, revoked access, or anything else changed on GitHub's side, clevis had no way to find out and would keep treating a stale/invalid installation row as valid indefinitely.

Changes:
- New `apps/api/src/routers/webhooks.py`: `POST /webhooks/github` verifies `X-Hub-Signature-256` (HMAC-SHA256 over the *raw* request body — computed before any JSON parsing, using `hmac.compare_digest` for constant-time comparison) against `GITHUB_APP_WEBHOOK_SECRET`. Missing/invalid signature → 401. Secret not configured → 503 (fail closed; accepting unverified calls in that case would defeat the entire point of the fix).
- Handles the `installation` event's `deleted` action: looks up `installation.id` from the payload and removes matching `github_installations` rows via a new `installation_repo.delete_by_installation_id()`, writing an `audit_repo` entry (`actor="github-webhook"`) for the removal — matching the existing audit-trail pattern used by `cache_service.py`/`tokens.py`.
- `installation_repositories` events are accepted (200, so GitHub doesn't retry) but are currently a no-op — the schema tracks the installation row itself, not per-repo access, so there's genuinely nothing to sync at that granularity without a schema change, which is out of scope here. Left as an explicit comment rather than silently doing nothing unexplained.
- Registered the new router in `main.py`, and corrected the now-stale line in `docs/self-hosting.md` that told self-hosters the webhook wasn't needed.

### Follow-up while re-reviewing against #142's exact wording

#142 asked for the webhook to handle "installation (created/deleted) ... events" — the original version of this PR only acted on `deleted`, and `installation.created` silently fell through to the 200 response with no comment, unlike the documented `installation_repositories` no-op right below it. Added the same kind of explicit comment for `created`: rows are only ever written to `github_installations` by the authenticated `/orgs/{org}/installations/sync` and `/me/installations/sync` endpoints, which independently verify (`_verify_installation`, #141) that the `installation_id` genuinely belongs to the claimed account before persisting. Auto-creating a row straight from this webhook would mean trusting GitHub's payload alone to decide which clevis org/user it belongs to, with no equivalent ownership check — a materially bigger trust-boundary decision than "keep an existing verified row in sync," so it stays deliberately out of scope for this webhook and is left to the explicit, verified sync flow instead.

Closes #142

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed) — not applicable, no UI changes
- [x] `python -m compileall apps/api/src apps/worker/src`
- [x] Relevant `pytest` tests pass
- [ ] Docker images still build, if `Dockerfile`/deps changed — not applicable, no deps changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Added `apps/api/tests/test_webhooks.py`: missing/invalid/wrong-secret signature all rejected with 401, secret-not-configured returns 503, `installation.deleted` removes only matching-`installation_id` rows and writes the audit log entry, `installation.created` and unrecognized event types are accepted as no-ops, malformed JSON body returns 400. Also verified the full FastAPI app actually registers the `/webhooks/github` route (not just the isolated router in tests). Full `pytest -q` suite (208 tests) passes against a real Postgres instance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7RDvvVu5mqC4pybwNqq7A)_