### PR TITLE
fix(worker): reclaim stuck jobs, validate payloads, retry transient errors (#22, #130)

### DIFF
--- a/apps/api/alembic/versions/0014_add_jobs_retry_count.py
+++ b/apps/api/alembic/versions/0014_add_jobs_retry_count.py
@@ -1,0 +1,35 @@
+"""add jobs.retry_count
+
+The worker previously had no way to detect or bound a job that gets stuck in
+'processing' forever after its worker crashes, and no bounded retry for jobs
+that fail due to a transient error (network blip, GitHub 5xx). Both cases now
+share this single counter: the worker's reclaim sweep increments it when
+resetting a stale 'processing' job back to 'queued', and process_job
+increments it when requeueing after a transient failure — either path marks
+the job 'failed' once the shared cap is exceeded, so a job that repeatedly
+fails (whichever reason) can't retry indefinitely.
+
+Uses a DDL default so existing rows are backfilled to 0 in the same
+add_column statement — jobs is a low-volume queue table, so a two-step
+add-then-backfill isn't needed here.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-07-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "retry_count")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -79,6 +79,10 @@ class Job(Base):
     payload: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
     result: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Counts attempts caused by either the worker reclaiming a job stuck in
+    # 'processing' (its worker likely crashed) or a transient failure being requeued —
+    # a single shared cap on both prevents a job from retrying forever either way.
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -1,4 +1,5 @@
 httpx==0.28.1
+pydantic==2.11.9
 pydantic-settings==2.14.1
 psycopg[binary]==3.2.9
 cryptography==44.0.2

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -4,6 +4,7 @@ import time
 
 import httpx
 import psycopg
+from pydantic import BaseModel, Field, ValidationError
 
 from _crypto import decrypt_job_token
 from _sanitize import sanitize_error
@@ -17,6 +18,14 @@ log = logging.getLogger(__name__)
 
 # psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+
+# Shared cap on jobs.retry_count, incremented by both the reclaim sweep (a worker
+# crashed mid-job) and a transient-failure requeue in process_job — either path marks
+# the job 'failed' once exceeded, so a job can't retry forever regardless of cause.
+MAX_RETRIES = 5
+# A job left in 'processing' longer than this almost certainly had its worker crash or
+# get killed mid-job (see _reclaim_stale_jobs) rather than still being genuinely in flight.
+RECLAIM_TIMEOUT_MINUTES = 30
 
 
 def _read_app_config(key: str, default: str) -> str:
@@ -43,41 +52,136 @@ def _read_poll_seconds() -> int:
         return 5
 
 
-def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None:
-    base = settings.github_api_base
-    try:
-        payload = json.loads(payload_raw)
-        owner, repo = payload["owner"], payload["repo"]
-        token = decrypt_job_token(payload["token"], settings.job_secret_key.get_secret_value())
-        params = {k: payload[k] for k in ("key", "ref") if payload.get(k)}
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-        with httpx.Client(timeout=20) as client:
-            resp = client.delete(
-                f"{base}/repos/{owner}/{repo}/actions/caches",
-                headers=headers,
-                params=params,
-            )
-        if resp.status_code >= 300:
-            raise RuntimeError(f"GitHub API error: {resp.status_code}")
-        result = json.dumps({"ok": True, "status": resp.status_code})
+class ClearActionsCachePayload(BaseModel):
+    owner: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+    token: str = Field(min_length=1)
+    key: str | None = None
+    ref: str | None = None
+
+
+def _mark_done(conn: psycopg.Connection, job_id: int, result: dict) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s",
+            (json.dumps(result), job_id),
+        )
+    conn.commit()
+
+
+def _mark_failed(conn: psycopg.Connection, job_id: int, error_text: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s",
+            (error_text, job_id),
+        )
+    conn.commit()
+
+
+def _requeue_for_retry(conn: psycopg.Connection, job_id: int, retry_count: int, error_text: str) -> None:
+    new_count = retry_count + 1
+    if new_count > MAX_RETRIES:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s",
-                (result, job_id),
+                "UPDATE jobs SET status='failed', retry_count=%s, result=%s, updated_at=NOW() WHERE id=%s",
+                (new_count, f"exceeded max retry attempts ({MAX_RETRIES}): {error_text}", job_id),
             )
-        log.info("job %d done", job_id)
-    except Exception as error:
-        log.error("job %d failed: %s", job_id, error)
+    else:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s",
-                (sanitize_error(error), job_id),
+                "UPDATE jobs SET status='queued', retry_count=%s, result=%s, updated_at=NOW() WHERE id=%s",
+                (new_count, error_text, job_id),
             )
     conn.commit()
+
+
+def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str, retry_count: int = 0) -> None:
+    try:
+        payload = ClearActionsCachePayload.model_validate_json(payload_raw)
+    except ValidationError as error:
+        log.error("job %d has an invalid payload: %s", job_id, error)
+        _mark_failed(conn, job_id, sanitize_error(error))
+        return
+
+    try:
+        token = decrypt_job_token(payload.token, settings.job_secret_key.get_secret_value())
+    except Exception as error:
+        log.error("job %d failed to decrypt its token: %s", job_id, error)
+        _mark_failed(conn, job_id, sanitize_error(error))
+        return
+
+    base = settings.github_api_base
+    params = {k: v for k, v in (("key", payload.key), ("ref", payload.ref)) if v}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        try:
+            with httpx.Client(timeout=20) as client:
+                resp = client.delete(
+                    f"{base}/repos/{payload.owner}/{payload.repo}/actions/caches",
+                    headers=headers,
+                    params=params,
+                )
+        except httpx.RequestError as error:
+            log.warning("job %d hit a network error (attempt %d): %s", job_id, retry_count + 1, error)
+            _requeue_for_retry(conn, job_id, retry_count, sanitize_error(error))
+            return
+
+        if resp.status_code >= 500:
+            # 5xx is presumed transient (GitHub-side issue) — worth retrying, unlike 4xx.
+            log.warning("job %d got a %d from GitHub (attempt %d)", job_id, resp.status_code, retry_count + 1)
+            _requeue_for_retry(conn, job_id, retry_count, f"GitHub API error: {resp.status_code}")
+            return
+
+        if resp.status_code >= 300:
+            log.error("job %d failed: GitHub API error %d", job_id, resp.status_code)
+            _mark_failed(conn, job_id, f"GitHub API error: {resp.status_code}")
+            return
+
+        _mark_done(conn, job_id, {"ok": True, "status": resp.status_code})
+        log.info("job %d done", job_id)
+    except Exception as error:
+        # Safety net for anything not handled above (e.g. a bug in this function, or an
+        # unanticipated exception type) — without this, the job would stay 'processing'
+        # until the reclaim sweep picks it up, up to RECLAIM_TIMEOUT_MINUTES later,
+        # instead of failing/retrying immediately.
+        log.error("job %d hit an unexpected error: %s", job_id, error)
+        _mark_failed(conn, job_id, sanitize_error(error))
+
+
+def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
+    """Reset jobs stuck in 'processing' past RECLAIM_TIMEOUT_MINUTES back to 'queued' —
+    the worker that claimed them almost certainly crashed or was killed mid-job, and the
+    poll query only ever selects 'queued' rows, so without this such a job is stuck
+    forever. Shares retry_count/MAX_RETRIES with process_job's transient-failure retry so
+    a job that repeatedly crashes its worker eventually gets marked 'failed' instead of
+    looping indefinitely."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE jobs
+            SET status = CASE WHEN retry_count + 1 > %(max_retries)s THEN 'failed' ELSE 'queued' END,
+                retry_count = retry_count + 1,
+                result = CASE WHEN retry_count + 1 > %(max_retries)s THEN %(exceeded_message)s ELSE result END,
+                updated_at = NOW()
+            WHERE status = 'processing'
+              AND updated_at < NOW() - make_interval(mins => %(timeout_minutes)s)
+            RETURNING id, status
+            """,
+            {
+                "max_retries": MAX_RETRIES,
+                "exceeded_message": f"exceeded max reclaim attempts ({MAX_RETRIES})",
+                "timeout_minutes": RECLAIM_TIMEOUT_MINUTES,
+            },
+        )
+        reclaimed = cur.fetchall()
+    conn.commit()
+    for job_id, status in reclaimed:
+        log.warning("reclaimed stale job %d -> %s", job_id, status)
 
 
 def run() -> None:
@@ -88,6 +192,8 @@ def run() -> None:
         poll_seconds = _read_poll_seconds()
         try:
             with psycopg.connect(_DB_URL) as conn:
+                _reclaim_stale_jobs(conn)
+
                 with conn.cursor() as cur:
                     cur.execute("""
                         UPDATE jobs SET status = 'processing', updated_at = NOW()
@@ -99,7 +205,7 @@ def run() -> None:
                             LIMIT 1
                             FOR UPDATE SKIP LOCKED
                         )
-                        RETURNING id, payload
+                        RETURNING id, payload, retry_count
                     """)
                     row = cur.fetchone()
 

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -61,9 +61,13 @@ class ClearActionsCachePayload(BaseModel):
 
 
 def _mark_done(conn: psycopg.Connection, job_id: int, result: dict) -> None:
+    # WHERE status='processing' guards against a lost update if the reclaim sweep
+    # already reset this job (e.g. this worker stalled past RECLAIM_TIMEOUT_MINUTES)
+    # out from under us — the write becomes a safe no-op instead of clobbering
+    # whatever state/retry_count the reclaim (or another worker) since wrote.
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s",
+            "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s AND status='processing'",
             (json.dumps(result), job_id),
         )
     conn.commit()
@@ -72,7 +76,7 @@ def _mark_done(conn: psycopg.Connection, job_id: int, result: dict) -> None:
 def _mark_failed(conn: psycopg.Connection, job_id: int, error_text: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s",
+            "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s AND status='processing'",
             (error_text, job_id),
         )
     conn.commit()
@@ -83,13 +87,15 @@ def _requeue_for_retry(conn: psycopg.Connection, job_id: int, retry_count: int, 
     if new_count > MAX_RETRIES:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE jobs SET status='failed', retry_count=%s, result=%s, updated_at=NOW() WHERE id=%s",
+                "UPDATE jobs SET status='failed', retry_count=%s, result=%s, updated_at=NOW() "
+                "WHERE id=%s AND status='processing'",
                 (new_count, f"exceeded max retry attempts ({MAX_RETRIES}): {error_text}", job_id),
             )
     else:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE jobs SET status='queued', retry_count=%s, result=%s, updated_at=NOW() WHERE id=%s",
+                "UPDATE jobs SET status='queued', retry_count=%s, result=%s, updated_at=NOW() "
+                "WHERE id=%s AND status='processing'",
                 (new_count, error_text, job_id),
             )
     conn.commit()

--- a/apps/worker/tests/conftest.py
+++ b/apps/worker/tests/conftest.py
@@ -1,0 +1,31 @@
+"""DB fixture for worker tests that need a real Postgres connection (the reclaim sweep
+is raw SQL worth verifying end-to-end, not just mocked). The worker uses psycopg3
+directly (not SQLAlchemy), so this mirrors apps/api/tests/conftest.py's real-DB
+approach but with psycopg's own connection API.
+
+Unlike apps/api's db fixture, the functions under test (worker._reclaim_stale_jobs,
+worker.process_job) call conn.commit() themselves, so a single wrapping transaction
+can't be rolled back for isolation. Instead each test creates its own rows and the
+fixture deletes anything left over by id.
+"""
+
+import psycopg
+import pytest
+
+from config import settings
+
+_DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+
+
+@pytest.fixture()
+def worker_db():
+    conn = psycopg.connect(_DB_URL, autocommit=False)
+    created_ids: list[int] = []
+    try:
+        yield conn, created_ids
+    finally:
+        if created_ids:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM jobs WHERE id = ANY(%s)", (created_ids,))
+            conn.commit()
+        conn.close()

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -3,9 +3,11 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from _crypto import encrypt_job_token
 from config import settings
-from worker import process_job
+from worker import MAX_RETRIES, process_job
 
 
 class _FakeCursor:
@@ -64,12 +66,13 @@ def test_process_job_marks_done_on_success():
     assert conn.committed is True
 
 
-def test_process_job_marks_failed_on_http_error():
+def test_process_job_marks_failed_on_4xx_http_error():
+    """4xx is a permanent failure (bad token, missing repo, etc.) — never worth retrying."""
     conn = _FakeConn()
 
     mock_response = MagicMock()
-    mock_response.status_code = 500
-    mock_response.text = "upstream error"
+    mock_response.status_code = 404
+    mock_response.text = "not found"
 
     with patch("worker.httpx.Client") as mock_client_cls:
         mock_client = MagicMock()
@@ -87,7 +90,83 @@ def test_process_job_marks_failed_on_http_error():
     assert conn.committed is True
 
 
-def test_process_job_marks_failed_on_network_error():
+def test_process_job_requeues_on_5xx_http_error():
+    """5xx is presumed transient (GitHub-side issue) — worth a bounded retry, unlike 4xx."""
+    conn = _FakeConn()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+    mock_response.text = "upstream error"
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 6, _payload(), retry_count=0)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='queued'" in sql
+    new_retry_count, result_text, job_id = params
+    assert new_retry_count == 1
+    assert job_id == 6
+    assert "GitHub API error" in result_text
+    assert conn.committed is True
+
+
+def test_process_job_requeues_on_httpx_request_error():
+    """A genuine httpx.RequestError (what httpx actually raises for network failures) is
+    treated as transient and requeued, distinct from an unrecognized exception type."""
+    conn = _FakeConn()
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(side_effect=httpx.ConnectError("connection refused"))
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 7, _payload(), retry_count=2)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='queued'" in sql
+    new_retry_count, result_text, job_id = params
+    assert new_retry_count == 3  # incremented from the passed-in retry_count=2
+    assert job_id == 7
+    assert "connection refused" in result_text
+    assert conn.committed is True
+
+
+def test_process_job_fails_once_retry_cap_exceeded():
+    conn = _FakeConn()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 8, _payload(), retry_count=MAX_RETRIES)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    new_retry_count, result_text, job_id = params
+    assert new_retry_count == MAX_RETRIES + 1
+    assert job_id == 8
+    assert "exceeded max retry attempts" in result_text
+    assert conn.committed is True
+
+
+def test_process_job_marks_failed_on_unrecognized_exception_safety_net():
+    """Something other than httpx.RequestError (a bug, an unanticipated exception type)
+    must still fail the job immediately rather than leaving it stuck in 'processing'
+    until the reclaim sweep eventually picks it up."""
     conn = _FakeConn()
 
     with patch("worker.httpx.Client") as mock_client_cls:
@@ -139,3 +218,30 @@ def test_process_job_redacts_token_shaped_text_in_error():
     sql, params = conn._cursor.calls[0]
     assert "ghp_" not in params[0]
     assert "[redacted]" in params[0]
+
+
+def test_process_job_rejects_invalid_payload_without_calling_github():
+    conn = _FakeConn()
+    bad_payload = json.dumps({"owner": "acme"})  # missing repo/token
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        process_job(conn, 9, bad_payload)
+        mock_client_cls.assert_not_called()
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert params[1] == 9
+    assert conn.committed is True
+
+
+def test_process_job_rejects_empty_string_fields():
+    conn = _FakeConn()
+    bad_payload = json.dumps({"owner": "", "repo": "demo", "token": "x"})
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        process_job(conn, 10, bad_payload)
+        mock_client_cls.assert_not_called()
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert conn.committed is True

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -1,13 +1,14 @@
 """Worker job processing: unit-style tests with mocked GitHub HTTP and psycopg connection."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import httpx
 
 from _crypto import encrypt_job_token
 from config import settings
-from worker import MAX_RETRIES, process_job
+from worker import MAX_RETRIES, RECLAIM_TIMEOUT_MINUTES, _reclaim_stale_jobs, process_job
 
 
 class _FakeCursor:
@@ -245,3 +246,52 @@ def test_process_job_rejects_empty_string_fields():
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
     assert conn.committed is True
+
+
+def test_process_job_terminal_write_is_a_noop_if_reclaimed_out_from_under_it(worker_db):
+    """If the reclaim sweep resets this job back to 'queued' (or another worker later
+    claims it) while this call is still in flight, process_job's own terminal write
+    must not clobber that newer state — the WHERE status='processing' guard should
+    make it a no-op instead of a lost update."""
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO jobs (job_type, payload, status, retry_count, updated_at)
+            VALUES ('github.clear_actions_cache', '{}', 'processing', 0, %s)
+            RETURNING id
+            """,
+            (stale,),
+        )
+        job_id = cur.fetchone()[0]
+    conn.commit()
+    created_ids.append(job_id)
+
+    # Simulate the reclaim sweep firing while this worker is still mid-process_job for
+    # the same job (e.g. this worker stalled past the reclaim timeout).
+    _reclaim_stale_jobs(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, retry_count FROM jobs WHERE id = %s", (job_id,))
+        reclaimed_status, reclaimed_retry_count = cur.fetchone()
+    assert reclaimed_status == "queued"
+    assert reclaimed_retry_count == 1
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.text = ""
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        # This worker's in-memory retry_count is stale (captured before the reclaim).
+        process_job(conn, job_id, _payload(), retry_count=0)
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, retry_count FROM jobs WHERE id = %s", (job_id,))
+        final_status, final_retry_count = cur.fetchone()
+    assert final_status == "queued"
+    assert final_retry_count == 1

--- a/apps/worker/tests/test_reclaim.py
+++ b/apps/worker/tests/test_reclaim.py
@@ -1,0 +1,104 @@
+"""Integration tests for the reclaim sweep against a real Postgres instance — this is
+raw SQL with CASE expressions worth verifying end-to-end rather than only mocking."""
+
+from datetime import datetime, timedelta, timezone
+
+from worker import MAX_RETRIES, RECLAIM_TIMEOUT_MINUTES, _reclaim_stale_jobs
+
+
+def _insert_job(conn, created_ids, *, status: str, updated_at, retry_count: int = 0) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO jobs (job_type, payload, status, retry_count, updated_at)
+            VALUES ('github.clear_actions_cache', '{}', %s, %s, %s)
+            RETURNING id
+            """,
+            (status, retry_count, updated_at),
+        )
+        job_id = cur.fetchone()[0]
+    conn.commit()
+    created_ids.append(job_id)
+    return job_id
+
+
+def _fetch(conn, job_id):
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, retry_count, result FROM jobs WHERE id = %s", (job_id,))
+        return cur.fetchone()
+
+
+def test_reclaims_stale_processing_job_back_to_queued(worker_db):
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    job_id = _insert_job(conn, created_ids, status="processing", updated_at=stale, retry_count=0)
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, _result = _fetch(conn, job_id)
+    assert status == "queued"
+    assert retry_count == 1
+
+
+def test_leaves_recently_updated_processing_job_alone(worker_db):
+    conn, created_ids = worker_db
+    recent = datetime.now(timezone.utc) - timedelta(minutes=1)
+    job_id = _insert_job(conn, created_ids, status="processing", updated_at=recent, retry_count=0)
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, _result = _fetch(conn, job_id)
+    assert status == "processing"
+    assert retry_count == 0
+
+
+def test_leaves_queued_and_done_jobs_alone(worker_db):
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    queued_id = _insert_job(conn, created_ids, status="queued", updated_at=stale)
+    done_id = _insert_job(conn, created_ids, status="done", updated_at=stale)
+
+    _reclaim_stale_jobs(conn)
+
+    assert _fetch(conn, queued_id)[0] == "queued"
+    assert _fetch(conn, done_id)[0] == "done"
+
+
+def test_marks_failed_once_reclaim_cap_exceeded(worker_db):
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    job_id = _insert_job(conn, created_ids, status="processing", updated_at=stale, retry_count=MAX_RETRIES)
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, result = _fetch(conn, job_id)
+    assert status == "failed"
+    assert retry_count == MAX_RETRIES + 1
+    assert "exceeded max reclaim attempts" in result
+
+
+def test_repeated_reclaims_eventually_fail_a_job_that_keeps_getting_stuck(worker_db):
+    """Simulates a job whose worker crashes every time: reclaimed repeatedly, each time
+    still ending up stuck in 'processing' (simulated here by re-staling updated_at),
+    until retry_count exceeds MAX_RETRIES and it's marked 'failed' instead of looping."""
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    job_id = _insert_job(conn, created_ids, status="processing", updated_at=stale, retry_count=0)
+
+    for _ in range(MAX_RETRIES):
+        _reclaim_stale_jobs(conn)
+        status, _retry_count, _result = _fetch(conn, job_id)
+        assert status == "queued"
+        # Simulate the worker picking it back up (processing) and crashing again.
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE jobs SET status = 'processing', updated_at = %s WHERE id = %s",
+                (stale, job_id),
+            )
+        conn.commit()
+
+    _reclaim_stale_jobs(conn)
+    status, retry_count, result = _fetch(conn, job_id)
+    assert status == "failed"
+    assert retry_count == MAX_RETRIES + 1
+    assert "exceeded max reclaim attempts" in result


### PR DESCRIPTION
## ⚠️ Includes a schema change (migration 0014)

Adds `jobs.retry_count` (`Integer`, `NOT NULL`, `server_default '0'`). This is a genuinely necessary change, not a reflexive one — per AGENTS.md guardrail #1, the reasoning: neither the reclaim cap nor the transient-retry cap described below has anywhere to persist state across attempts and worker restarts without it. `alembic revision --autogenerate` picked up exactly this one column (verified — no unrelated drift), and I used a DDL `server_default` rather than a two-step add/backfill/alter-not-null, since `jobs` is a low-volume queue table where that's unnecessary caution. Applied and verified against a real Postgres instance; downgrade (`drop_column`) reviewed but not executed.

## Summary

This combines two related issues into one PR, since implementing one properly subsumes the other (see the two questions I resolved with you before starting):

- **#22** (original): jobs claimed by a worker that then crashes are stuck forever — `status='processing'` permanently, since the poll query only ever selects `'queued'`. No schema validation on job payloads before use (a malformed row surfaces only as an opaque `KeyError`/`TypeError`). No retry/backoff for transient failures (rate limit, network blip, momentary 5xx) — everything failed permanently.
- **#130**: a narrower follow-up assuming a reclaim loop already existed (from a different PR) and asking only for a retry cap on it. That reclaim loop was never actually merged to `main`, so implementing #22's reclaim mechanism properly — with the cap designed in from the start rather than bolted on later — satisfies both.

Changes to `apps/worker/src/worker.py`:
- **Reclaim**: `_reclaim_stale_jobs()` resets jobs stuck in `'processing'` for more than 30 minutes back to `'queued'`, run once per poll cycle before claiming a new job.
- **Shared retry cap**: both the reclaim sweep and a new transient-failure retry path in `process_job` increment the same `jobs.retry_count`, capped at `MAX_RETRIES = 5`. A job that either repeatedly crashes its worker *or* repeatedly hits a transient error eventually gets marked `'failed'` with a clear reason ("exceeded max reclaim/retry attempts"), regardless of which failure mode caused it — matching the issue's explicit ask to reuse one column for both.
- **Payload validation**: `process_job` now validates the payload against a Pydantic model (`ClearActionsCachePayload`) before any decryption or network I/O, failing fast with a clear message on malformed data.
- **Retry/backoff distinguishing transient vs. permanent**: `httpx.RequestError` and 5xx GitHub responses are treated as transient and requeued (bounded by the shared cap, naturally paced by the existing poll interval); 4xx responses, decryption failures, and payload-validation failures fail immediately, since retrying those can never succeed.

### Caught during self-review before pushing

My first draft removed the original blanket `except Exception` around the whole function in favor of narrower, more specific except clauses (`ValidationError`, `httpx.RequestError`, status-code branches). That's an improvement for the cases I anticipated, but it left a real gap: any exception type I *didn't* anticipate (a bug in my own code, an unexpected error from httpx internals) would propagate uncaught out of `process_job` — caught by `run()`'s outer try/except, which only logs it, so the job would sit silently `'processing'` for up to 30 minutes until the reclaim sweep eventually caught it, instead of failing/retrying immediately. Added back a safety-net `except Exception` wrapping the network/response-handling section specifically (the validation and decryption steps already had their own narrower catches), so an unanticipated error still fails the job right away.

### Follow-up fix: lost-update race between reclaim and a stalled worker's terminal write

While re-reviewing this PR for completeness against #22/#130, I found a real gap in the first version: `_mark_done`, `_mark_failed`, and `_requeue_for_retry` updated a job row by `id` alone, with no check that the row was still `'processing'`. Concretely: if `_reclaim_stale_jobs` resets a job back to `'queued'` (because the worker holding it stalled past `RECLAIM_TIMEOUT_MINUTES`) while that same worker is still mid-`process_job` for it, the original worker's eventual terminal write would silently clobber the reclaim's newer `status`/`retry_count` — letting a job dodge the shared `MAX_RETRIES` cap this PR is supposed to enforce. Fixed by adding `AND status='processing'` to all three UPDATE statements, so a write against an already-reclaimed row becomes a safe no-op instead of a lost update. Covered by a new real-DB test (`test_process_job_terminal_write_is_a_noop_if_reclaimed_out_from_under_it`) that reproduces the race: reclaim fires first, then the stale `process_job` call's terminal write must not clobber the reclaimed `'queued'`/`retry_count` state.

Closes #22, closes #130

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed) — not applicable, no UI changes
- [x] `python -m compileall apps/api/src apps/worker/src`
- [x] Relevant `pytest` tests pass
- [ ] Docker images still build, if `Dockerfile`/deps changed — `pydantic` was already a transitive dependency (via `pydantic-settings`) but I'm now importing it directly in `worker.py`, so I pinned it explicitly in `apps/worker/requirements.txt` (matching the version already pinned in `apps/api/requirements.txt`) rather than relying on it implicitly.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`apps/worker/tests/test_process_job.py`: updated the existing HTTP-error test to use a 4xx code (permanent failure) since 5xx now requeues instead; added tests for 5xx requeue, a genuine `httpx.RequestError` requeue (distinct from the safety-net path), failing once the retry cap is exceeded, the safety-net catching an unrecognized exception type, payload validation rejecting a malformed/incomplete payload without ever calling GitHub, and the reclaim-vs-terminal-write lost-update guard described above.

`apps/worker/tests/test_reclaim.py` (new, with a new `apps/worker/tests/conftest.py` providing a real Postgres connection — the worker uses raw psycopg3, not SQLAlchemy, so this mirrors `apps/api/tests/conftest.py`'s real-DB approach with psycopg's own API): verifies the reclaim SQL end-to-end — a stale `'processing'` job gets reclaimed to `'queued'`, a recently-updated one is left alone, `'queued'`/`'done'` jobs are never touched, the cap is enforced, and a job that keeps getting stuck across repeated reclaim cycles eventually reaches `'failed'`.

Full `pytest -q` suite (207 tests) passes against a real Postgres instance with migration 0014 applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7RDvvVu5mqC4pybwNqq7A)_