### PR TITLE
feat(api): Repositories Dashboard backend endpoints (1/3)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -18,6 +18,7 @@ from src.routers import (
     invitations,
     jobs,
     orgs,
+    repos,
     tokens,
     webhooks,
 )
@@ -62,6 +63,7 @@ app.include_router(orgs.router, tags=["orgs"])
 app.include_router(invitations.router, tags=["invitations"])
 app.include_router(analytics.router, tags=["analytics"])
 app.include_router(actions_cache.router, tags=["actions-cache"])
+app.include_router(repos.router, tags=["repos"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -1,0 +1,140 @@
+import time
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from src.core.db import get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.schemas.repos import (
+    RepoListInput,
+    RepoListResponse,
+    RepoPullsInput,
+    RepoPullsResponse,
+    RepoStatsInput,
+    RepoStatsResponse,
+)
+from src.services.github_client import GitHubClient
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token
+
+router = APIRouter()
+
+_STATS_CACHE_TTL_SECONDS = 600
+_stats_cache: dict[tuple[str, str], tuple[float, RepoStatsResponse]] = {}
+
+
+def _github_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    if isinstance(exc, httpx.RequestError):
+        return HTTPException(status_code=503, detail="GitHub API unreachable")
+    raise exc
+
+
+def _client_token(payload: RepoListInput | RepoStatsInput | RepoPullsInput) -> str | None:
+    return payload.token.get_secret_value() if payload.token else None
+
+
+def _list_repos(owner: str, token: str) -> RepoListResponse:
+    try:
+        client = GitHubClient(token)
+        repos = client.request_paginated(f"/orgs/{owner}/repos", params={"type": "all", "sort": "pushed"})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    return {"org": owner, "total": len(repos), "repos": repos}
+
+
+def _fetch_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+    client = GitHubClient(token)
+    commit_activity = client.request("GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+    participation = client.request("GET", f"/repos/{owner}/{repo}/stats/participation")
+    contributors = client.request("GET", f"/repos/{owner}/{repo}/stats/contributors")
+    return {
+        "repository": f"{owner}/{repo}",
+        # GitHub computes these stats asynchronously and returns 202 with an empty body
+        # on a cache miss — treat "not a list/dict yet" as "not ready", not an error.
+        "commit_activity": commit_activity if isinstance(commit_activity, list) else [],
+        "participation": participation if isinstance(participation, dict) else {},
+        "contributors": contributors if isinstance(contributors, list) else [],
+    }
+
+
+def _cached_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+    key = (owner, repo)
+    now = time.monotonic()
+    cached = _stats_cache.get(key)
+    if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:
+        return cached[1]
+    stats = _fetch_stats(owner, repo, token)
+    _stats_cache[key] = (now, stats)
+    return stats
+
+
+def _list_pulls(owner: str, repo: str, token: str, state: str) -> RepoPullsResponse:
+    try:
+        client = GitHubClient(token)
+        pulls = client.request_paginated(f"/repos/{owner}/{repo}/pulls", params={"state": state})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    summaries = [
+        {
+            "number": p["number"],
+            "title": p["title"],
+            "user": (p.get("user") or {}).get("login"),
+            "created_at": p["created_at"],
+            "html_url": p["html_url"],
+        }
+        for p in pulls
+    ]
+    return {"repository": f"{owner}/{repo}", "total": len(summaries), "pulls": summaries}
+
+
+@router.post("/orgs/{org_login}/repos", response_model=RepoListResponse)
+def org_list_repos(
+    org_login: str,
+    payload: RepoListInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=org_login, client_token=_client_token(payload))
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_repos(org_login, token)
+
+
+@router.post("/orgs/{org_login}/repos/{owner}/{repo}/stats", response_model=RepoStatsResponse)
+def org_repo_stats(
+    org_login: str,
+    owner: str,
+    repo: str,
+    payload: RepoStatsInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    assert_owner_matches_org(owner, ctx)
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    try:
+        return _cached_stats(owner, repo, token)
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+
+@router.post("/orgs/{org_login}/repos/{owner}/{repo}/pulls", response_model=RepoPullsResponse)
+def org_repo_pulls(
+    org_login: str,
+    owner: str,
+    repo: str,
+    payload: RepoPullsInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    assert_owner_matches_org(owner, ctx)
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_pulls(owner, repo, token, payload.state)

--- a/apps/api/src/schemas/repos.py
+++ b/apps/api/src/schemas/repos.py
@@ -1,0 +1,55 @@
+from pydantic import BaseModel, SecretStr
+
+
+class RepoListInput(BaseModel):
+    # Optional: falls back to a GitHub App installation token when one is connected
+    # for this owner (see src.services.token_resolution).
+    token: SecretStr | None = None
+
+
+class RepoSummary(BaseModel):
+    name: str
+    full_name: str
+    private: bool
+    language: str | None = None
+    stargazers_count: int
+    open_issues_count: int
+    pushed_at: str | None = None
+    default_branch: str
+    html_url: str
+
+
+class RepoListResponse(BaseModel):
+    org: str
+    total: int
+    repos: list[RepoSummary]
+
+
+class RepoStatsInput(BaseModel):
+    token: SecretStr | None = None
+
+
+class RepoStatsResponse(BaseModel):
+    repository: str
+    commit_activity: list[dict]
+    participation: dict
+    contributors: list[dict]
+
+
+class RepoPullsInput(BaseModel):
+    token: SecretStr | None = None
+    state: str = "open"
+
+
+class PullSummary(BaseModel):
+    number: int
+    title: str
+    user: str | None = None
+    created_at: str
+    html_url: str
+
+
+class RepoPullsResponse(BaseModel):
+    repository: str
+    total: int
+    pulls: list[PullSummary]

--- a/apps/api/src/services/github_client.py
+++ b/apps/api/src/services/github_client.py
@@ -30,3 +30,34 @@ class GitHubClient:
                 resp.raise_for_status()
                 return resp.json() if resp.text else {}
         raise RuntimeError("request loop exhausted without returning")
+
+    def request_paginated(self, path: str, params: dict | None = None) -> list:
+        """GET every page of a list endpoint, following the `Link: rel="next"` header."""
+        results: list = []
+        url: str | None = f"{self.base}{path}"
+        next_params = dict(params or {})
+        next_params.setdefault("per_page", 100)
+        with httpx.Client(timeout=20) as client:
+            while url:
+                resp = None
+                for attempt in range(3):
+                    try:
+                        resp = client.get(url, headers=self.headers, params=next_params)
+                    except httpx.RequestError:
+                        if attempt < 2:
+                            time.sleep(2 ** attempt)
+                            continue
+                        raise
+                    if resp.status_code == 429 and attempt < 2:
+                        time.sleep(2 ** attempt)
+                        continue
+                    resp.raise_for_status()
+                    break
+                results.extend(resp.json())
+                next_params = {}
+                url = None
+                for part in resp.headers.get("Link", "").split(","):
+                    part = part.strip()
+                    if 'rel="next"' in part:
+                        url = part.split(";")[0].strip().strip("<>")
+        return results

--- a/apps/api/tests/test_github_client.py
+++ b/apps/api/tests/test_github_client.py
@@ -13,11 +13,12 @@ def client():
     yield GitHubClient(token="ghp_test", base_url="https://api.github.com")
 
 
-def _make_response(status_code: int, json_body: dict | list | None = None, text: str = "{}"):
+def _make_response(status_code: int, json_body: dict | list | None = None, text: str = "{}", link: str = ""):
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
     resp.text = text if json_body is None else str(json_body)
     resp.json.return_value = json_body if json_body is not None else {}
+    resp.headers = {"Link": link} if link else {}
     resp.raise_for_status = MagicMock()
     if status_code >= 400:
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -101,3 +102,67 @@ class TestExhaustedRetries:
             result = client.request("GET", "/test")
 
         assert result == {"data": "hello"}
+
+
+class TestRequestPaginated:
+    def test_follows_link_header_across_pages(self, client):
+        page1 = _make_response(
+            200, [{"id": 1}], link='<https://api.github.com/repos/acme/x?page=2>; rel="next"'
+        )
+        page2 = _make_response(200, [{"id": 2}])
+
+        with patch("src.services.github_client.httpx.Client") as mock_client_cls:
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_ctx.get.side_effect = [page1, page2]
+            mock_client_cls.return_value = mock_ctx
+
+            result = client.request_paginated("/repos/acme/x")
+
+        assert result == [{"id": 1}, {"id": 2}]
+        assert mock_ctx.get.call_count == 2
+
+    def test_retries_on_429_then_succeeds(self, client):
+        resp_429 = _make_response(429)
+        resp_429.raise_for_status = MagicMock()
+        ok_resp = _make_response(200, [{"id": 1}])
+
+        with (
+            patch("src.services.github_client.httpx.Client") as mock_client_cls,
+            patch("src.services.github_client.time.sleep"),
+        ):
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_ctx.get.side_effect = [resp_429, ok_resp]
+            mock_client_cls.return_value = mock_ctx
+
+            result = client.request_paginated("/repos/acme/x")
+
+        assert result == [{"id": 1}]
+
+    def test_raises_after_exhausted_retries_on_request_error(self, client):
+        with (
+            patch("src.services.github_client.httpx.Client") as mock_client_cls,
+            patch("src.services.github_client.time.sleep"),
+        ):
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_ctx.get.side_effect = httpx.RequestError("connection failed")
+            mock_client_cls.return_value = mock_ctx
+
+            with pytest.raises(httpx.RequestError):
+                client.request_paginated("/repos/acme/x")
+
+    def test_raises_on_http_status_error(self, client):
+        with patch("src.services.github_client.httpx.Client") as mock_client_cls:
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx.__exit__ = MagicMock(return_value=False)
+            mock_ctx.get.return_value = _make_response(404)
+            mock_client_cls.return_value = mock_ctx
+
+            with pytest.raises(httpx.HTTPStatusError):
+                client.request_paginated("/repos/acme/x")

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -1,0 +1,157 @@
+"""Tests for the repos router (Phase 8 groundwork)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
+from src.routers.repos import router as repos_router
+from src.routers.repos import _stats_cache
+
+_ADMIN = UserOut(id=1, email="admin@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_stats_cache():
+    _stats_cache.clear()
+    yield
+    _stats_cache.clear()
+
+
+@pytest.fixture()
+def acme_org(db):
+    user = User(id=_ADMIN.id, email=_ADMIN.email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    return org
+
+
+@pytest.fixture()
+def repos_client(db, acme_org):
+    app = FastAPI()
+    app.include_router(repos_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_list_repos_returns_paginated_results(repos_client):
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {
+                "name": "demo",
+                "full_name": "acme/demo",
+                "private": False,
+                "language": "Python",
+                "stargazers_count": 3,
+                "open_issues_count": 1,
+                "pushed_at": "2026-07-01T00:00:00Z",
+                "default_branch": "main",
+                "html_url": "https://github.com/acme/demo",
+            }
+        ]
+        resp = repos_client.post("/orgs/acme/repos", json={"token": "ghp_testtoken123456789012345678901234"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "demo"
+    mock_client.return_value.request_paginated.assert_called_once_with(
+        "/orgs/acme/repos", params={"type": "all", "sort": "pushed"}
+    )
+
+
+def test_list_repos_no_installation_and_no_token_returns_400(repos_client):
+    resp = repos_client.post("/orgs/acme/repos", json={})
+    assert resp.status_code == 400
+
+
+def test_list_repos_maps_github_status_error_to_400(repos_client):
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x"))
+    error = httpx.HTTPStatusError("missing", request=response.request, response=response)
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = error
+        resp = repos_client.post("/orgs/acme/repos", json={"token": "ghp_testtoken123456789012345678901234"})
+    assert resp.status_code == 400
+    assert "404" in resp.json()["detail"]
+
+
+def test_repo_stats_treats_202_empty_body_as_not_ready(repos_client):
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [{}, {}, {}]
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity"] == []
+    assert body["participation"] == {}
+    assert body["contributors"] == []
+
+
+def test_repo_stats_second_call_is_served_from_cache(repos_client):
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [
+            [{"week": 1, "total": 5}],
+            {"all": [1], "owner": [1]},
+            [{"login": "octocat", "total": 5}],
+        ]
+        first = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+        second = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert mock_client.return_value.request.call_count == 3
+
+
+def test_repo_stats_owner_mismatch_returns_403(repos_client):
+    resp = repos_client.post(
+        "/orgs/acme/repos/someone-else/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+    )
+    assert resp.status_code == 403
+
+
+def test_list_pulls_returns_summaries(repos_client):
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {
+                "number": 7,
+                "title": "Add feature",
+                "user": {"login": "octocat"},
+                "created_at": "2026-07-01T00:00:00Z",
+                "html_url": "https://github.com/acme/demo/pull/7",
+            }
+        ]
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/pulls", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["pulls"][0]["user"] == "octocat"
+    mock_client.return_value.request_paginated.assert_called_once_with(
+        "/repos/acme/demo/pulls", params={"state": "open"}
+    )
+
+
+def test_non_member_forbidden(db):
+    org_repo.get_or_create(db, github_login="acme")
+    app = FastAPI()
+    app.include_router(repos_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=99, email="outsider@example.com", name=None, is_workspace_admin=False
+    )
+    app.dependency_overrides[get_db] = lambda: db
+    client = TestClient(app)
+    resp = client.post("/orgs/acme/repos", json={})
+    assert resp.status_code == 403

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -114,6 +114,45 @@ def test_repo_stats_second_call_is_served_from_cache(repos_client):
     assert mock_client.return_value.request.call_count == 3
 
 
+def test_list_repos_maps_github_request_error_to_503(repos_client):
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = httpx.RequestError("boom")
+        resp = repos_client.post("/orgs/acme/repos", json={"token": "ghp_testtoken123456789012345678901234"})
+    assert resp.status_code == 503
+
+
+def test_repo_stats_no_installation_and_no_token_returns_400(repos_client):
+    resp = repos_client.post("/orgs/acme/repos/acme/demo/stats", json={})
+    assert resp.status_code == 400
+
+
+def test_repo_stats_maps_github_status_error_to_400(repos_client):
+    response = httpx.Response(500, request=httpx.Request("GET", "https://api.github.com/x"))
+    error = httpx.HTTPStatusError("boom", request=response.request, response=response)
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 400
+
+
+def test_list_pulls_maps_github_status_error_to_400(repos_client):
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x"))
+    error = httpx.HTTPStatusError("missing", request=response.request, response=response)
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = error
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/pulls", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 400
+
+
+def test_list_pulls_no_installation_and_no_token_returns_400(repos_client):
+    resp = repos_client.post("/orgs/acme/repos/acme/demo/pulls", json={})
+    assert resp.status_code == 400
+
+
 def test_repo_stats_owner_mismatch_returns_403(repos_client):
     resp = repos_client.post(
         "/orgs/acme/repos/someone-else/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}


### PR DESCRIPTION
## Summary
Part 1 of 3 for issue #175 (Repositories Dashboard / Phase 8), stacked into the `feat/issue-175-repos-dashboard` tracking branch. This PR is backend-only: no schema/migration changes, no RBAC bypass.

- New `apps/api/src/routers/repos.py`: org-scoped endpoints for repo listing, per-repo stats (commit activity + participation + contributors), and open-PR listing — following the existing `actions_cache.py`/`analytics.py` pattern (POST + JSON body so an optional client-supplied token never rides in a URL, `resolve_org_token` for GitHub App installation tokens, `require_org_role(min_role="member")`).
- `GitHubClient.request_paginated()` added to `apps/api/src/services/github_client.py` — follows every `Link: rel="next"` page, mirroring the pagination already implemented as a free function in `packages/checks/src/checks/github_checks.py`.
- Per-repo stats responses are cached in-process for 10 minutes (GitHub computes these stats asynchronously server-side and can return 202 with an empty body on a cache miss — treated as "not ready yet", not an error).

## Why scoped down from the issue's literal endpoint list
The repo-list endpoint intentionally omits per-repo "latest release" and "open PR count" fields that the issue's UI mock implies, because populating them would require one extra GitHub API call *per repo* in the list response (N+1 fan-out) — a real rate-limit risk for orgs with many repos. The dedicated `/stats` and `/pulls` endpoints in this PR exist precisely so the frontend list dashboard (PR 2/3) can fetch those lazily per visible row instead.

## Why POST instead of the issue's literal `GET`
Every existing GitHub-proxy read endpoint in this codebase (`analytics.py`'s overview, `actions_cache.py`'s cache list) uses POST with a JSON body for reads that accept an optional client-supplied token, specifically so the token never appears in a URL/query string or server access log. Matched that convention here rather than introducing a new pattern.

## Test plan
- [x] `pytest -q apps/api/tests/test_repos.py` — 8 new tests (pagination, 400/403/mismatch error mapping, 202-empty-body handling, cache hit behavior)
- [x] `pytest -q` from repo root — 257 passed, no regressions