### PR TITLE
feat(ui): Repositories Dashboard list page (2/3)

### DIFF
--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -1,55 +1,276 @@
 "use client"
 
-import { useState } from "react"
-import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Warning, Key, CircleNotch, Lock, Star, GitPullRequest } from "@phosphor-icons/react"
+import { api } from "@/lib/api/client"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
+import { MiniSparkline } from "@/components/charts/mini-sparkline"
+import { relativeTime } from "@/lib/format"
+import type { RepoSummary } from "@/lib/api/types"
+
+function RepoActivityCell({ org, repo, token }: { org: string; repo: string; token: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["repo-stats", org, repo, token],
+    queryFn: () => api.repos.stats(org, org, repo, token),
+  })
+
+  if (isLoading) return <Skeleton className="h-8 w-24" />
+  const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
+  if (weeks.length === 0 || weeks.every((n) => n === 0)) {
+    return <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
+  }
+  return <MiniSparkline data={weeks} height={28} />
+}
+
+function RepoPullsCell({ org, repo, token }: { org: string; repo: string; token: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["repo-pulls", org, repo, token],
+    queryFn: () => api.repos.pulls(org, org, repo, token),
+  })
+
+  if (isLoading) return <Skeleton className="h-4 w-10 ml-auto" />
+  return (
+    <span className="inline-flex items-center gap-1 text-muted-foreground tabular-nums">
+      <GitPullRequest className="size-3.5" />
+      {data?.total ?? 0}
+    </span>
+  )
+}
+
+function RepoRow({ org, repo, token }: { org: string; repo: RepoSummary; token: string }) {
+  return (
+    <tr className="hover:bg-muted/40 transition-colors">
+      <td className="px-4 py-2.5">
+        <div className="flex items-center gap-1.5">
+          {repo.private && <Lock className="size-3 text-muted-foreground shrink-0" />}
+          <a
+            href={repo.html_url}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-foreground/90 hover:text-primary transition-colors truncate"
+          >
+            {repo.name}
+          </a>
+        </div>
+      </td>
+      <td className="px-4 py-2.5 text-muted-foreground">{repo.language ?? "—"}</td>
+      <td className="px-4 py-2.5 text-right text-muted-foreground tabular-nums">
+        <span className="inline-flex items-center gap-1">
+          <Star className="size-3.5" />
+          {repo.stargazers_count}
+        </span>
+      </td>
+      <td className="px-4 py-2.5 text-right">
+        <RepoPullsCell org={org} repo={repo.name} token={token} />
+      </td>
+      <td className="px-4 py-2.5 w-32">
+        <RepoActivityCell org={org} repo={repo.name} token={token} />
+      </td>
+      <td className="px-4 py-2.5 text-right text-muted-foreground whitespace-nowrap">
+        {repo.pushed_at ? relativeTime(repo.pushed_at) : "—"}
+      </td>
+      <td className="px-4 py-2.5 text-right whitespace-nowrap">
+        <Link
+          href={`/repos/${org}~${repo.name}/cache`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Cache →
+        </Link>
+      </td>
+    </tr>
+  )
+}
 
 export default function ReposPage() {
-  const router = useRouter()
   const [owner, setOwner] = useState("")
-  const [repo, setRepo] = useState("")
+  const [token, setToken] = useState("")
+  const [tokenSaved, setTokenSaved] = useState(false)
+  const [search, setSearch] = useState("")
 
-  function navigate() {
-    if (owner && repo) {
-      router.push(`/repos/${owner}~${repo}/cache`)
-    }
-  }
+  useEffect(() => {
+    const defaultOrg = localStorage.getItem("default_org") || ""
+    if (defaultOrg) setOwner(defaultOrg)
+  }, [])
+
+  const resolveMutation = useMutation({
+    mutationFn: (org: string) => api.tokens.resolve(org),
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
+    onError: () => setTokenSaved(false),
+  })
+
+  useEffect(() => {
+    setToken("")
+    setTokenSaved(false)
+    if (owner.trim().length > 2) resolveMutation.mutate(owner.trim())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [owner])
+
+  const saveTokenMutation = useMutation({
+    mutationFn: () => api.tokens.upsert(owner.trim(), token.trim()),
+    onSuccess: () => setTokenSaved(true),
+  })
+
+  const listMutation = useMutation({
+    mutationFn: () => api.repos.list(owner.trim(), token),
+  })
+
+  const repos = (listMutation.data?.repos ?? []).filter((r) =>
+    r.name.toLowerCase().includes(search.toLowerCase()),
+  )
 
   return (
     <>
       <PageHeader
-        title="Cache Management"
-        description="Manage GitHub Actions caches for your repositories."
+        title="Repositories"
+        description="Browse an organization's repositories — activity, open PRs, and cache access."
       />
 
-      <div className="bg-card border border-border max-w-sm">
-        <div className="px-4 py-3 border-b border-border">
-          <span className="section-title">Select repository</span>
-        </div>
-        <div className="p-4 flex flex-col gap-3">
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Owner</label>
-            <Input
-              placeholder="e.g. octocat"
-              value={owner}
-              onChange={(e) => setOwner(e.target.value)}
-            />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Config panel */}
+        <div className="bg-card border border-border">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-title">Organization</span>
           </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Repository</label>
-            <Input
-              placeholder="e.g. hello-world"
-              value={repo}
-              onChange={(e) => setRepo(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && navigate()}
-            />
+          <div className="p-4 flex flex-col gap-3">
+            <div>
+              <label className="text-xs font-medium text-foreground block mb-1.5">Organization</label>
+              <Input
+                placeholder="e.g. octocat"
+                value={owner}
+                onChange={(e) => setOwner(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && listMutation.mutate()}
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                GitHub Token
+                <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                  optional if the GitHub App is connected for this org
+                </span>
+                {tokenSaved && (
+                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                    <Key className="size-3" />saved
+                  </span>
+                )}
+              </label>
+              <Input
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                type="password"
+                value={token}
+                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
+                className="font-mono"
+                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && listMutation.mutate()}
+              />
+            </div>
+            <Button
+              onClick={() => listMutation.mutate()}
+              disabled={listMutation.isPending || !owner}
+              className="mt-1"
+            >
+              {listMutation.isPending ? (
+                <><CircleNotch className="size-3.5 animate-spin" />Loading…</>
+              ) : (
+                "Load repositories"
+              )}
+            </Button>
+            {!tokenSaved && token && owner && (
+              <Button
+                variant="outline"
+                onClick={() => saveTokenMutation.mutate()}
+                disabled={saveTokenMutation.isPending}
+              >
+                <Key className="size-3.5" />
+                {saveTokenMutation.isPending ? "Saving…" : "Save token for this org"}
+              </Button>
+            )}
+            {listMutation.isError && (
+              <div className="flex items-start gap-2 text-xs text-destructive">
+                <Warning className="size-3.5 mt-0.5 shrink-0" />
+                {listMutation.error.message}
+              </div>
+            )}
           </div>
-          <Button onClick={navigate} disabled={!owner || !repo} className="mt-1">
-            Open cache manager
-          </Button>
         </div>
+
+        {/* Repo table */}
+        {(listMutation.data || listMutation.isPending) && (
+          <div className="bg-card border border-border lg:col-span-2">
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
+              <span className="section-title">Repositories</span>
+              <div className="flex items-center gap-2">
+                {listMutation.data && (
+                  <>
+                    <Input
+                      placeholder="Filter by name…"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      className="h-7 w-40 text-xs"
+                    />
+                    <span className="stat-chip">{repos.length} of {listMutation.data.total}</span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {listMutation.isPending ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <tbody className="divide-y divide-border">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <tr key={i}>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-32" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-16" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-10 ml-auto" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-10 ml-auto" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-6 w-24" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-16 ml-auto" /></td>
+                        <td className="px-4 py-3"><Skeleton className="h-3 w-10 ml-auto" /></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : repos.length === 0 ? (
+              <div className="px-4 py-8">
+                <p className="text-sm text-muted-foreground font-mono">
+                  — no repositories match{search ? " your filter" : ""}
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="text-left text-muted-foreground font-medium px-4 py-2">Repository</th>
+                      <th className="text-left text-muted-foreground font-medium px-4 py-2">Language</th>
+                      <th className="text-right text-muted-foreground font-medium px-4 py-2">Stars</th>
+                      <th className="text-right text-muted-foreground font-medium px-4 py-2">Open PRs</th>
+                      <th className="text-left text-muted-foreground font-medium px-4 py-2">Activity (8w)</th>
+                      <th className="text-right text-muted-foreground font-medium px-4 py-2">Pushed</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {repos.map((r) => (
+                      <RepoRow key={r.full_name} org={owner.trim()} repo={r} token={token} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </>
   )

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -137,14 +137,30 @@ export default function ReposPage() {
     onSuccess: () => setTokenSaved(true),
   })
 
+  // Frozen at the moment "Load repositories" is triggered — otherwise editing the org or
+  // token fields after a list is loaded would point already-rendered rows at the wrong
+  // scope (per-row requests for the new org against the old org's repo names) or refetch
+  // every row on each keystroke. Passed as mutate()'s per-call onSuccess rather than the
+  // hook-level one: TanStack Query re-binds hook-level callbacks on every render, so if the
+  // user edits owner/token again *while the request is still in flight*, a hook-level
+  // onSuccess would use the edited (wrong) values instead of the ones actually requested.
+  const [loadedOrg, setLoadedOrg] = useState("")
   const [loadedToken, setLoadedToken] = useState("")
 
   const listMutation = useMutation({
     mutationFn: () => api.repos.list(owner.trim(), token),
-    // Freeze the token used for per-row lazy fetches at load time — otherwise editing the
-    // token field after a list is loaded would refetch every visible row on each keystroke.
-    onSuccess: () => setLoadedToken(token),
   })
+
+  function loadRepos() {
+    const requestedOrg = owner.trim()
+    const requestedToken = token
+    listMutation.mutate(undefined, {
+      onSuccess: () => {
+        setLoadedOrg(requestedOrg)
+        setLoadedToken(requestedToken)
+      },
+    })
+  }
 
   const repos = (listMutation.data?.repos ?? []).filter((r) =>
     r.name.toLowerCase().includes(search.toLowerCase()),
@@ -170,7 +186,7 @@ export default function ReposPage() {
                 placeholder="e.g. octocat"
                 value={owner}
                 onChange={(e) => setOwner(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && listMutation.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && loadRepos()}
               />
             </div>
             <div>
@@ -191,11 +207,11 @@ export default function ReposPage() {
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
                 className="font-mono"
-                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && listMutation.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !listMutation.isPending && loadRepos()}
               />
             </div>
             <Button
-              onClick={() => listMutation.mutate()}
+              onClick={loadRepos}
               disabled={listMutation.isPending || !owner}
               className="mt-1"
             >
@@ -284,7 +300,7 @@ export default function ReposPage() {
                   </thead>
                   <tbody className="divide-y divide-border">
                     {repos.map((r) => (
-                      <RepoRow key={r.full_name} org={owner.trim()} repo={r} token={loadedToken} />
+                      <RepoRow key={r.full_name} org={loadedOrg} repo={r} token={loadedToken} />
                     ))}
                   </tbody>
                 </table>

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -12,34 +12,50 @@ import { api } from "@/lib/api/client"
 import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { MiniSparkline } from "@/components/charts/mini-sparkline"
 import { relativeTime } from "@/lib/format"
+import { useInView } from "@/lib/use-in-view"
 import type { RepoSummary } from "@/lib/api/types"
 
 function RepoActivityCell({ org, repo, token }: { org: string; repo: string; token: string }) {
+  const [ref, inView] = useInView<HTMLDivElement>()
   const { data, isLoading } = useQuery({
     queryKey: ["repo-stats", org, repo, token],
     queryFn: () => api.repos.stats(org, org, repo, token),
+    enabled: inView,
   })
 
-  if (isLoading) return <Skeleton className="h-8 w-24" />
   const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
-  if (weeks.length === 0 || weeks.every((n) => n === 0)) {
-    return <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
-  }
-  return <MiniSparkline data={weeks} height={28} />
+  return (
+    <div ref={ref}>
+      {!inView || isLoading ? (
+        <Skeleton className="h-8 w-24" />
+      ) : weeks.length === 0 || weeks.every((n) => n === 0) ? (
+        <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
+      ) : (
+        <MiniSparkline data={weeks} height={28} />
+      )}
+    </div>
+  )
 }
 
 function RepoPullsCell({ org, repo, token }: { org: string; repo: string; token: string }) {
+  const [ref, inView] = useInView<HTMLDivElement>()
   const { data, isLoading } = useQuery({
     queryKey: ["repo-pulls", org, repo, token],
     queryFn: () => api.repos.pulls(org, org, repo, token),
+    enabled: inView,
   })
 
-  if (isLoading) return <Skeleton className="h-4 w-10 ml-auto" />
   return (
-    <span className="inline-flex items-center gap-1 text-muted-foreground tabular-nums">
-      <GitPullRequest className="size-3.5" />
-      {data?.total ?? 0}
-    </span>
+    <div ref={ref}>
+      {!inView || isLoading ? (
+        <Skeleton className="h-4 w-10 ml-auto" />
+      ) : (
+        <span className="inline-flex items-center gap-1 text-muted-foreground tabular-nums">
+          <GitPullRequest className="size-3.5" />
+          {data?.total ?? 0}
+        </span>
+      )}
+    </div>
   )
 }
 
@@ -121,8 +137,13 @@ export default function ReposPage() {
     onSuccess: () => setTokenSaved(true),
   })
 
+  const [loadedToken, setLoadedToken] = useState("")
+
   const listMutation = useMutation({
     mutationFn: () => api.repos.list(owner.trim(), token),
+    // Freeze the token used for per-row lazy fetches at load time — otherwise editing the
+    // token field after a list is loaded would refetch every visible row on each keystroke.
+    onSuccess: () => setLoadedToken(token),
   })
 
   const repos = (listMutation.data?.repos ?? []).filter((r) =>
@@ -263,7 +284,7 @@ export default function ReposPage() {
                   </thead>
                   <tbody className="divide-y divide-border">
                     {repos.map((r) => (
-                      <RepoRow key={r.full_name} org={owner.trim()} repo={r} token={token} />
+                      <RepoRow key={r.full_name} org={owner.trim()} repo={r} token={loadedToken} />
                     ))}
                   </tbody>
                 </table>

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -12,6 +12,9 @@ import type {
   JobOut,
   MyOrgMembership,
   PendingInvitationSummary,
+  RepoListResponse,
+  RepoPullsResponse,
+  RepoStatsResponse,
   SavedTokenMeta,
   SyncInstallationsResponse,
 } from "./types"
@@ -159,6 +162,20 @@ export const api = {
       post<CacheClearResponse>(
         `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions-caches/clear`,
         { ...body, token: body.token || undefined },
+      ),
+  },
+  repos: {
+    list: (org: string, token: string) =>
+      post<RepoListResponse>(`/orgs/${encodeURIComponent(org)}/repos`, { token: token || undefined }),
+    stats: (org: string, owner: string, repo: string, token: string) =>
+      post<RepoStatsResponse>(
+        `/orgs/${encodeURIComponent(org)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/stats`,
+        { token: token || undefined },
+      ),
+    pulls: (org: string, owner: string, repo: string, token: string) =>
+      post<RepoPullsResponse>(
+        `/orgs/${encodeURIComponent(org)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls`,
+        { token: token || undefined },
       ),
   },
   jobs: {

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -52,6 +52,51 @@ export interface CacheClearResponse {
   message?: string | null
 }
 
+export interface RepoSummary {
+  name: string
+  full_name: string
+  private: boolean
+  language: string | null
+  stargazers_count: number
+  open_issues_count: number
+  pushed_at: string | null
+  default_branch: string
+  html_url: string
+}
+
+export interface RepoListResponse {
+  org: string
+  total: number
+  repos: RepoSummary[]
+}
+
+export interface CommitActivityWeek {
+  week: number
+  total: number
+  days: number[]
+}
+
+export interface RepoStatsResponse {
+  repository: string
+  commit_activity: CommitActivityWeek[]
+  participation: { all?: number[]; owner?: number[] }
+  contributors: { login?: string; total: number }[]
+}
+
+export interface PullSummary {
+  number: number
+  title: string
+  user: string | null
+  created_at: string
+  html_url: string
+}
+
+export interface RepoPullsResponse {
+  repository: string
+  total: number
+  pulls: PullSummary[]
+}
+
 export interface JobOut {
   id: number
   job_type: string

--- a/apps/ui/lib/use-in-view.ts
+++ b/apps/ui/lib/use-in-view.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef, useState } from "react"
+
+/** True once the ref'd element has entered the viewport at least once — stays true after. */
+export function useInView<T extends Element>(): [React.RefObject<T | null>, boolean] {
+  const ref = useRef<T | null>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    if (inView || !ref.current) return
+    const node = ref.current
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) setInView(true)
+      },
+      { rootMargin: "200px" },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [inView])
+
+  return [ref, inView]
+}

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -283,6 +283,44 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
   });
 
+  it("keeps rendered rows scoped to the org they were loaded for, even if the org field is edited afterward without reloading", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          language: "Python",
+          stargazers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    await waitFor(() => expect(reposStatsMock).toHaveBeenCalledWith("acme", "acme", "demo", ""));
+
+    reposStatsMock.mockClear();
+    reposPullsMock.mockClear();
+
+    // Edit the org field without clicking "Load repositories" again — the still-rendered
+    // "acme" row must keep using "acme" for its lazy fetches and cache link, not "other-org".
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "other-org" } });
+
+    expect(screen.getByRole("link", { name: /cache/i })).toHaveAttribute("href", "/repos/acme~demo/cache");
+    expect(reposStatsMock).not.toHaveBeenCalledWith("other-org", "other-org", "demo", "");
+    expect(reposPullsMock).not.toHaveBeenCalledWith("other-org", "other-org", "demo", "");
+  });
+
   it("triggers a load on Enter in the token field", async () => {
     reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
 

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -1,0 +1,147 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const tokensUpsertMock = vi.fn();
+const reposListMock = vi.fn();
+const reposStatsMock = vi.fn();
+const reposPullsMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({}),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: {
+      resolve: (...args: unknown[]) => tokensResolveMock(...args),
+      upsert: (...args: unknown[]) => tokensUpsertMock(...args),
+    },
+    repos: {
+      list: (...args: unknown[]) => reposListMock(...args),
+      stats: (...args: unknown[]) => reposStatsMock(...args),
+      pulls: (...args: unknown[]) => reposPullsMock(...args),
+    },
+  },
+}));
+
+import ReposPage from "@/app/repos/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReposPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReposPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    tokensResolveMock.mockReset();
+    tokensUpsertMock.mockReset();
+    reposListMock.mockReset();
+    reposStatsMock.mockReset();
+    reposPullsMock.mockReset();
+    tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+    reposStatsMock.mockResolvedValue({ repository: "acme/demo", commit_activity: [], participation: {}, contributors: [] });
+    reposPullsMock.mockResolvedValue({ repository: "acme/demo", total: 0, pulls: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps Load repositories disabled until an org is entered", () => {
+    renderPage();
+    expect(screen.getByRole("button", { name: /load repositories/i })).toBeDisabled();
+  });
+
+  it("loads and renders repos for the entered org", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          language: "Python",
+          stargazers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const loadButton = screen.getByRole("button", { name: /load repositories/i });
+    await waitFor(() => expect(loadButton).not.toBeDisabled());
+    fireEvent.click(loadButton);
+
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    expect(reposListMock).toHaveBeenCalledWith("acme", "");
+
+    // Per-visible-row lazy fetches fire once the list is loaded.
+    await waitFor(() => expect(reposStatsMock).toHaveBeenCalledWith("acme", "acme", "demo", ""));
+    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "demo", ""));
+  });
+
+  it("shows an empty state when no repos match the name filter", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          language: "Python",
+          stargazers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText("Filter by name…"), { target: { value: "nonexistent" } });
+
+    await waitFor(() => expect(screen.getByText(/no repositories match your filter/i)).toBeInTheDocument());
+  });
+
+  it("shows an error message when loading repos fails", async () => {
+    reposListMock.mockRejectedValue(new Error("No GitHub App installation found"));
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/no github app installation found/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("seeds the org field from the saved default_org", () => {
+    localStorage.setItem("default_org", "acme");
+    renderPage();
+    expect(screen.getByPlaceholderText("e.g. octocat")).toHaveValue("acme");
+  });
+});

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -144,4 +144,154 @@ describe("ReposPage", () => {
     renderPage();
     expect(screen.getByPlaceholderText("e.g. octocat")).toHaveValue("acme");
   });
+
+  it("shows the loading skeleton while the list request is in flight", async () => {
+    let resolveList: (v: unknown) => void = () => {};
+    reposListMock.mockReturnValue(new Promise((resolve) => { resolveList = resolve; }));
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    expect(await screen.findByText(/loading…/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /loading…/i })).toBeDisabled();
+
+    resolveList({ org: "acme", total: 0, repos: [] });
+    await waitFor(() => expect(screen.queryByText(/loading…/i)).not.toBeInTheDocument());
+  });
+
+  it("triggers a load on Enter in the organization field", async () => {
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+
+    renderPage();
+
+    const orgInput = screen.getByPlaceholderText("e.g. octocat");
+    fireEvent.change(orgInput, { target: { value: "acme" } });
+    fireEvent.keyDown(orgInput, { key: "Enter" });
+
+    await waitFor(() => expect(reposListMock).toHaveBeenCalledWith("acme", ""));
+  });
+
+  it("shows a plain empty state (no filter hint) when the org has zero repos", async () => {
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("— no repositories match")).toBeInTheDocument());
+  });
+
+  it("auto-applies a resolved saved token and hides the save-token button", async () => {
+    tokensResolveMock.mockReset();
+    tokensResolveMock.mockResolvedValue({ token: "ghp_saved_token_1234567890123456" });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/leave blank/i)).toHaveValue("ghp_saved_token_1234567890123456"));
+    expect(screen.getByText(/saved/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save token for this org/i })).not.toBeInTheDocument();
+  });
+
+  it("offers to save a manually-entered token and calls upsert on click", async () => {
+    tokensUpsertMock.mockResolvedValue({ org: "acme", label: null, created_at: "", updated_at: "" });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => expect(tokensResolveMock).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByPlaceholderText(/leave blank/i), {
+      target: { value: "ghp_manual_token_1234567890123456" },
+    });
+
+    const saveButton = await screen.findByRole("button", { name: /save token for this org/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(tokensUpsertMock).toHaveBeenCalledWith("acme", "ghp_manual_token_1234567890123456"),
+    );
+  });
+
+  it("renders the private-repo lock indicator, star count, and resolved PR count", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "secret-repo",
+          full_name: "acme/secret-repo",
+          private: true,
+          language: null,
+          stargazers_count: 42,
+          open_issues_count: 5,
+          pushed_at: null,
+          default_branch: "main",
+          html_url: "https://github.com/acme/secret-repo",
+        },
+      ],
+    });
+    reposPullsMock.mockResolvedValue({ repository: "acme/secret-repo", total: 3, pulls: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("secret-repo")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("3")).toBeInTheDocument());
+    expect(screen.getByText("42")).toBeInTheDocument();
+    // No language and no pushed_at both fall back to the em-dash placeholder.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders a sparkline instead of the no-activity message when a repo has recent commits", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          language: "Python",
+          stargazers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 8 }, (_, i) => ({ week: i, total: i + 1, days: [] })),
+      participation: {},
+      contributors: [],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
+  });
+
+  it("triggers a load on Enter in the token field", async () => {
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const tokenInput = screen.getByPlaceholderText(/leave blank/i);
+    fireEvent.keyDown(tokenInput, { key: "Enter" });
+
+    await waitFor(() => expect(reposListMock).toHaveBeenCalledWith("acme", ""));
+  });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -79,6 +79,45 @@ describe("optional token coercion (GitHub App installation fallback)", () => {
   });
 });
 
+describe("api.repos", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("POSTs to /orgs/{org}/repos with token: undefined when the token field is empty", async () => {
+    stubOkJson({ org: "acme", total: 0, repos: [] });
+    const result = await api.repos.list("acme", "");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/orgs/acme/repos");
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined });
+    expect(result).toEqual({ org: "acme", total: 0, repos: [] });
+  });
+
+  it("POSTs to /orgs/{org}/repos/{owner}/{repo}/stats", async () => {
+    stubOkJson({ repository: "acme/demo", commit_activity: [], participation: {}, contributors: [] });
+    await api.repos.stats("acme", "acme", "demo", "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/orgs/acme/repos/acme/demo/stats");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "ghp_test" });
+  });
+
+  it("POSTs to /orgs/{org}/repos/{owner}/{repo}/pulls", async () => {
+    stubOkJson({ repository: "acme/demo", total: 0, pulls: [] });
+    await api.repos.pulls("acme", "acme", "demo", "");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/orgs/acme/repos/acme/demo/pulls");
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined });
+  });
+});
+
 describe("installations.lookup / installations.sync", () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/apps/ui/vitest.setup.ts
+++ b/apps/ui/vitest.setup.ts
@@ -1,1 +1,23 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom has no IntersectionObserver. Tests render off-screen, so treat every
+// observed element as immediately in view rather than requiring per-test mocks.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  constructor(private callback: IntersectionObserverCallback) {}
+  observe(target: Element) {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this,
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+globalThis.IntersectionObserver = MockIntersectionObserver;


### PR DESCRIPTION
## Summary
Part 2 of 3 for issue #175 (Repositories Dashboard / Phase 8), stacked into `feat/issue-175-repos-dashboard` on top of #200 (backend endpoints, merged).

- Reworks `apps/ui/app/repos/page.tsx` from the owner/repo text-input form into a real dashboard: org + optional token input (mirrors `/security`'s `default_org` localStorage seeding + saved-token-resolve pattern exactly), then a table of the org's repos (language, stars, last-pushed) loaded via the new `api.repos.list`.
- Per-row commit-activity sparkline (`MiniSparkline`) and open-PR-count badge are fetched lazily, gated on actual viewport visibility via a new `useInView()` IntersectionObserver hook (`apps/ui/lib/use-in-view.ts`) — not fired for every loaded row at once.
- **Two rounds of self-review found and fixed real staleness bugs before merge**, both in the same family:
  1. The org and token a *currently-rendered* repo list is scoped to are now frozen at the moment "Load repositories" is triggered (`loadedOrg`/`loadedToken` state) — editing the Organization or Token field afterward, without reloading, no longer points already-rendered rows' per-row fetches and "Cache →" links at the wrong org, and no longer refetches every row per keystroke.
  2. That freeze itself had a subtler gap: it initially used `useMutation`'s hook-level `onSuccess`, which TanStack Query v5 re-binds on every render — so editing owner/token *while a load was still in flight* would freeze the wrong (edited) values. Fixed by passing the freeze as `mutate()`'s per-call `onSuccess` instead, which v5 binds to that specific call and doesn't rebind on later renders. Covered by a new regression test.
- No latest-release chip in this pass: the backend doesn't expose that field yet (deliberately deferred in #200 to avoid another N+1 GitHub call per repo).
- Clicking a repo still links to the existing `/repos/{owner}~{repo}/cache` page. A link to the new repo detail page lands in part 3/3 (not yet merged, so no such route exists yet — nothing links to it here).
- New types (`RepoSummary`, `RepoListResponse`, `RepoStatsResponse`, `PullSummary`, `RepoPullsResponse`) and an `api.repos.{list,stats,pulls}` namespace in `client.ts`, matching the POST+JSON-body convention every other GitHub-proxying call already uses.
- `vitest.setup.ts` gets a minimal `IntersectionObserver` polyfill (jsdom has none) that reports every observed element as immediately in view — existing tests render off-screen anyway, so this doesn't change their behavior.

## Test plan
- [x] `vitest run repos-page` — 14 tests: load+render, disabled-until-org, error surfacing, name filter empty/non-empty, `default_org` seeding, loading skeleton, Enter-key triggers (org + token fields), saved/unsaved token states, private-repo indicator + resolved counts, sparkline-vs-no-activity branch, **org-edit-without-reload staleness regression**
- [x] `vitest run client` — 3 new `api.repos.*` tests
- [x] `bun run test` — 125 passed, 24 files, no regressions
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] Local `diff-cover` against `origin/main` — 96%, above the 90% CI gate