### PR TITLE
fix(auth): close OAuth login-CSRF and account-takeover gaps, fix org-rename crash

### DIFF
--- a/apps/api/src/core/rate_limit.py
+++ b/apps/api/src/core/rate_limit.py
@@ -15,6 +15,7 @@ _DEFAULT_WINDOW_SECONDS = 60
 
 _lock = Lock()
 _buckets: dict[str, tuple[int, float]] = {}
+_account_buckets: dict[str, tuple[int, float]] = {}
 
 
 def _client_key(request: Request) -> str:
@@ -41,3 +42,24 @@ def rate_limit(max_requests: int = _DEFAULT_MAX_REQUESTS, window_seconds: int = 
             )
 
     return _dependency
+
+
+def check_account_rate_limit(
+    key: str, *, max_requests: int = _DEFAULT_MAX_REQUESTS, window_seconds: int = _DEFAULT_WINDOW_SECONDS
+) -> None:
+    """Same fixed-window limiter as rate_limit(), but keyed by a caller-supplied identifier
+    (e.g. the submitted login email, lowercased) instead of client IP. Closes the gap where
+    an attacker spread across many source IPs could brute-force a single account without
+    ever tripping the per-IP bucket. Same in-memory/per-process limitation as rate_limit()."""
+    now = time.monotonic()
+    with _lock:
+        count, window_start = _account_buckets.get(key, (0, now))
+        if now - window_start >= window_seconds:
+            count, window_start = 0, now
+        count += 1
+        _account_buckets[key] = (count, window_start)
+    if count > max_requests:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many requests, please try again later",
+        )

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import GitHubInstallation
@@ -42,7 +43,22 @@ def upsert(
         owner_user_id=owner_user_id,
     )
     db.add(row)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent sync for the same org/account (unique constraint) --
+        # fall back to updating the row the other request just inserted.
+        db.rollback()
+        existing = query.first()
+        if existing is None:
+            raise
+        existing.account_type = account_type
+        existing.auth_mode = auth_mode
+        existing.installation_id = installation_id
+        existing.token_ref = token_ref
+        db.commit()
+        db.refresh(existing)
+        return existing
     db.refresh(row)
     return row
 

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -12,6 +12,10 @@ def get_by_id(db: Session, org_id: int) -> Org | None:
     return db.query(Org).filter(Org.id == org_id).first()
 
 
+def get_by_org_id(db: Session, github_org_id: int) -> Org | None:
+    return db.query(Org).filter(Org.github_org_id == github_org_id).first()
+
+
 def get_or_create(db: Session, github_login: str, github_org_id: int | None = None) -> Org:
     org = get_by_login(db, github_login)
     if org is not None:
@@ -20,14 +24,29 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             db.commit()
             db.refresh(org)
         return org
+
+    if github_org_id is not None:
+        # The org may have been renamed on GitHub since we last saw it -- github_org_id
+        # is the stable identity, github_login isn't. Resolve by id and update the login
+        # in place rather than trying (and failing) to insert a second row for the same id.
+        org = get_by_org_id(db, github_org_id)
+        if org is not None:
+            if org.github_login != github_login:
+                org.github_login = github_login
+                db.commit()
+                db.refresh(org)
+            return org
+
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
     try:
         db.commit()
     except IntegrityError:
-        # Lost a race with a concurrent insert of the same github_login (unique constraint).
+        # Lost a race with a concurrent insert of the same github_login or github_org_id.
         db.rollback()
         org = get_by_login(db, github_login)
+        if org is None and github_org_id is not None:
+            org = get_by_org_id(db, github_org_id)
         if org is None:
             raise
         return org

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -10,8 +10,9 @@ Endpoints:
   POST /auth/me/revoke-sessions Invalidates all previously issued JWTs for the caller
   GET  /auth/setup-required Returns { setup_required: bool } for the UI routing decision
 
-/auth/login and /auth/register are rate-limited per client IP (see src.core.rate_limit)
-to blunt credential-stuffing / registration-spam attempts.
+/auth/login and /auth/register are rate-limited per client IP (see src.core.rate_limit);
+/auth/login is additionally rate-limited per submitted email, so an attacker spread across
+many source IPs can't bypass the IP-keyed limit by targeting one account.
 """
 
 from datetime import datetime
@@ -25,13 +26,19 @@ from sqlalchemy.orm import Session
 from src.core.app_config import get_config
 from src.core.auth import UserOut, clear_session_cookie, create_access_token, require_auth
 from src.core.db import Org, User, get_db
-from src.core.rate_limit import rate_limit
+from src.core.rate_limit import check_account_rate_limit, rate_limit
 from src.repositories import invitation_repo
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MIN_PASSWORD_LEN = 12
+
+# Fixed hash checked when no real user/password_hash exists, so a login attempt for a
+# nonexistent email still pays the same bcrypt cost as a real one -- otherwise response
+# timing alone (short-circuit vs. a real ~100-300ms bcrypt check) reveals whether an
+# email is registered.
+_DUMMY_PASSWORD_HASH = bcrypt.hashpw(b"clevis-timing-safety-dummy", bcrypt.gensalt()).decode()
 
 
 def _hash_password(password: str) -> str:
@@ -40,6 +47,7 @@ def _hash_password(password: str) -> str:
 
 def _verify_password(password: str, password_hash: str | None) -> bool:
     if not password_hash:
+        bcrypt.checkpw(password.encode(), _DUMMY_PASSWORD_HASH.encode())
         return False
     return bcrypt.checkpw(password.encode(), password_hash.encode())
 
@@ -188,8 +196,15 @@ def logout(response: Response):
 @router.post("/login", response_model=TokenResponse, dependencies=[Depends(rate_limit())])
 def login(body: LoginRequest, db: Session = Depends(get_db)):
     """Returns a JWT on valid credentials. Always returns 401 on failure (no field leaking)."""
+    # Per-account limit, in addition to the per-IP one above -- an attacker spread across
+    # many source IPs targeting one victim's password wouldn't otherwise trip anything.
+    check_account_rate_limit(f"login:{body.email.lower()}")
     user = db.query(User).filter(User.email == body.email).first()
-    if not user or not _verify_password(body.password, user.password_hash):
+    # Call _verify_password unconditionally (not "not user or not _verify_password(...)")
+    # -- that would short-circuit on a nonexistent user and skip bcrypt entirely, which is
+    # exactly the timing side-channel _verify_password's dummy-hash path exists to close.
+    password_ok = _verify_password(body.password, user.password_hash if user else None)
+    if not user or not password_ok:
         raise HTTPException(status_code=401, detail="Invalid credentials")
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -1,19 +1,26 @@
 """GitHub OAuth sign-in router — /auth/github/*.
 
-  GET /auth/github/login     -> 307 redirect to GitHub's authorize page (with a signed CSRF state)
+  GET /auth/github/login     -> 307 redirect to GitHub's authorize page (with a browser-bound
+                                CSRF state -- see src.services.github_oauth)
   GET /auth/github/callback  -> verify state, exchange code, fetch identity, find-or-create the
                                 local user, sync verified GitHub org-admin memberships, set the
                                 httpOnly session cookie, redirect to the UI
 
-Find-or-create policy: link to an existing user by GitHub id, else by verified email (preserving
-that user's role); otherwise create a new user — the first-ever user becomes the workspace admin,
-mirroring the email/password setup flow. See src.services.org_provisioning for how org-admin
-membership is auto-granted based on verified GitHub org-admin status.
+Find-or-create policy: link to an existing user by GitHub id; otherwise create a new user (the
+first-ever user becomes the workspace admin, mirroring the email/password setup flow). We
+deliberately do NOT fall back to matching by email -- self-registration (POST /auth/register)
+has no email-ownership verification anywhere in this app, so auto-linking onto an existing
+account by email match alone would let an attacker who pre-registers a victim's email silently
+inherit that victim's real GitHub identity (and whatever org-admin access it earns via
+src.services.org_provisioning) the next time the victim signs in with GitHub, while the attacker
+keeps their own password on the shared account. If GitHub reports an email that already belongs
+to a different local account, the callback redirects with an explanatory error instead of
+linking; the user needs to sign in with their password first.
 """
 
 import logging
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -40,13 +47,16 @@ def _ui_login_error_redirect(error_code: str) -> RedirectResponse:
     return RedirectResponse(f"{base}/login?error={error_code}", status_code=303)
 
 
+class EmailAlreadyRegistered(Exception):
+    """GitHub reported a verified email that already belongs to a different local account
+    with no GitHub identity linked. See the module docstring for why we refuse to
+    auto-link in this case instead of silently taking over that account."""
+
+
 def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> User:
     user = db.query(User).filter(User.github_user_id == identity.github_user_id).first()
-    if user is None:
-        user = db.query(User).filter(User.email == identity.email).first()
     if user is not None:
-        # Link / refresh the GitHub identity on the existing user; keep their role.
-        user.github_user_id = identity.github_user_id
+        # Returning GitHub user -- refresh their profile fields, keep their role.
         user.github_login = identity.login
         user.avatar_url = identity.avatar_url
         if not user.name and identity.name:
@@ -54,6 +64,10 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
         db.commit()
         db.refresh(user)
         return user
+
+    if db.query(User).filter(User.email == identity.email).first() is not None:
+        raise EmailAlreadyRegistered(identity.email)
+
     is_workspace_admin = db.query(User).count() == 0
     user = User(
         email=identity.email,
@@ -70,14 +84,32 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
     return user
 
 
+def _clear_state_cookie(response: Response) -> None:
+    response.delete_cookie(key=github_oauth.STATE_COOKIE_NAME, domain=settings.session_cookie_domain, path="/")
+
+
 @router.get("/login")
 def github_login(request: Request):
     try:
-        state = github_oauth.sign_state()
+        state, nonce = github_oauth.sign_state()
         url = github_oauth.build_authorize_url(state=state, redirect_uri=_callback_url(request))
     except github_oauth.GitHubOAuthNotConfigured:
         return _ui_login_error_redirect("github_not_configured")
-    return RedirectResponse(url, status_code=307)
+    response = RedirectResponse(url, status_code=307)
+    # Binds `state` to this browser -- must be SameSite=Lax (not Strict) so it's still sent
+    # on the top-level GET redirect back from github.com, regardless of how the instance's
+    # main session_cookie_samesite is configured.
+    response.set_cookie(
+        key=github_oauth.STATE_COOKIE_NAME,
+        value=nonce,
+        max_age=github_oauth.STATE_COOKIE_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=settings.session_cookie_secure,
+        samesite="lax",
+        domain=settings.session_cookie_domain,
+        path="/",
+    )
+    return response
 
 
 @router.get("/callback", name="github_callback", dependencies=[Depends(rate_limit())])
@@ -87,19 +119,32 @@ def github_callback(
     state: str | None = None,
     db: Session = Depends(get_db),
 ):
-    if not code or not state or not github_oauth.verify_state(state):
-        return _ui_login_error_redirect("github_invalid_state")
+    cookie_nonce = request.cookies.get(github_oauth.STATE_COOKIE_NAME)
+    if not code or not state or not github_oauth.verify_state(state, cookie_nonce=cookie_nonce):
+        error_response = _ui_login_error_redirect("github_invalid_state")
+        _clear_state_cookie(error_response)
+        return error_response
     try:
         user_token = github_oauth.exchange_code_for_token(code, redirect_uri=_callback_url(request))
         identity = github_oauth.fetch_identity(user_token)
     except github_oauth.GitHubOAuthNotConfigured:
-        return _ui_login_error_redirect("github_not_configured")
+        error_response = _ui_login_error_redirect("github_not_configured")
+        _clear_state_cookie(error_response)
+        return error_response
     except github_oauth.GitHubOAuthError as exc:
         logger.warning("GitHub OAuth callback failed: %s", exc)
-        return _ui_login_error_redirect("github_oauth_failed")
-    user = find_or_create_user(db, identity)
+        error_response = _ui_login_error_redirect("github_oauth_failed")
+        _clear_state_cookie(error_response)
+        return error_response
+    try:
+        user = find_or_create_user(db, identity)
+    except EmailAlreadyRegistered:
+        error_response = _ui_login_error_redirect("github_email_registered")
+        _clear_state_cookie(error_response)
+        return error_response
     org_provisioning.sync_org_admin_memberships(db, user, user_token)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     response = RedirectResponse(_ui_redirect_target(), status_code=303)
     set_session_cookie(response, token)
+    _clear_state_cookie(response)
     return response

--- a/apps/api/src/services/github_oauth.py
+++ b/apps/api/src/services/github_oauth.py
@@ -2,7 +2,13 @@
 
 Stateless pieces of the OAuth web flow:
   - `sign_state` / `verify_state` — a short-lived CSRF state token (HS256 with AUTH_SECRET), so we
-    don't need server-side session storage between the redirect and the callback.
+    don't need server-side session storage between the redirect and the callback. The state JWT
+    embeds a random nonce that the router also stores in a short-lived cookie on the browser
+    (see `src.routers.github_auth`); `verify_state` requires both to match, which binds the state
+    to the browser that started the flow -- without this, any validly-signed state token could be
+    replayed from a different browser (login-CSRF: an attacker completes their own OAuth flow,
+    then gets a victim to open the resulting callback URL, logging the victim into the attacker's
+    account).
   - `build_authorize_url` — where we send the browser to start the flow.
   - `exchange_code_for_token` — swap the callback `code` for a GitHub *user* access token.
   - `fetch_identity` — read the user's profile + primary verified email.
@@ -13,6 +19,8 @@ GITHUB_APP_CLIENT_ID / GITHUB_APP_CLIENT_SECRET (see `src.core.config.Settings`)
 
 from __future__ import annotations
 
+import hmac
+import secrets
 import time
 from dataclasses import dataclass
 from urllib.parse import urlencode
@@ -26,6 +34,11 @@ _OAUTH_SCOPE = "read:user user:email read:org"
 _STATE_TTL_SECONDS = 600  # 10 minutes between /login and /callback
 _STATE_ALG = "HS256"
 _STATE_PURPOSE = "github_oauth"
+
+# Cookie carrying the per-flow nonce that binds `state` to the browser that started it.
+# Exported so the router can use the same name for both setting and reading the cookie.
+STATE_COOKIE_NAME = "clevis_oauth_state"
+STATE_COOKIE_MAX_AGE_SECONDS = _STATE_TTL_SECONDS
 
 
 class GitHubOAuthNotConfigured(RuntimeError):
@@ -56,18 +69,27 @@ def _web_base() -> str:
     return base
 
 
-def sign_state(*, now: int | None = None) -> str:
+def sign_state(*, now: int | None = None) -> tuple[str, str]:
+    """Returns (state, nonce). Callers must also set `nonce` as the STATE_COOKIE_NAME
+    cookie value on the browser and pass it back into verify_state() as cookie_nonce."""
     issued = int(now if now is not None else time.time())
-    payload = {"iat": issued, "exp": issued + _STATE_TTL_SECONDS, "purpose": _STATE_PURPOSE}
-    return jwt.encode(payload, settings.auth_secret.get_secret_value(), algorithm=_STATE_ALG)
+    nonce = secrets.token_urlsafe(24)
+    payload = {"iat": issued, "exp": issued + _STATE_TTL_SECONDS, "purpose": _STATE_PURPOSE, "nonce": nonce}
+    state = jwt.encode(payload, settings.auth_secret.get_secret_value(), algorithm=_STATE_ALG)
+    return state, nonce
 
 
-def verify_state(state: str) -> bool:
+def verify_state(state: str, *, cookie_nonce: str | None = None) -> bool:
     try:
         payload = jwt.decode(state, settings.auth_secret.get_secret_value(), algorithms=[_STATE_ALG])
     except jwt.InvalidTokenError:
         return False
-    return payload.get("purpose") == _STATE_PURPOSE
+    if payload.get("purpose") != _STATE_PURPOSE:
+        return False
+    token_nonce = payload.get("nonce")
+    if not token_nonce or not cookie_nonce or not hmac.compare_digest(token_nonce, cookie_nonce):
+        return False
+    return True
 
 
 def build_authorize_url(*, state: str, redirect_uri: str) -> str:

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -2,12 +2,14 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import bcrypt
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth, require_workspace_admin
 from src.core.db import get_db
+from src.core.rate_limit import _account_buckets as _account_rate_limit_buckets
 from src.core.rate_limit import _buckets as _rate_limit_buckets
 from src.repositories import invitation_repo, org_repo
 from src.routers.auth import router as auth_router
@@ -18,12 +20,15 @@ from src.routers.config import router as config_router
 
 @pytest.fixture(autouse=True)
 def _reset_rate_limiter():
-    """/auth/login and /auth/register are rate-limited per client IP via a module-level
-    in-memory bucket that persists across tests in the same process — reset it so one
-    test's request volume can't tip a later, unrelated test over the threshold."""
+    """/auth/login and /auth/register are rate-limited per client IP, and /auth/login is
+    additionally rate-limited per submitted email, both via module-level in-memory buckets
+    that persist across tests in the same process — reset both so one test's request
+    volume can't tip a later, unrelated test over the threshold."""
     _rate_limit_buckets.clear()
+    _account_rate_limit_buckets.clear()
     yield
     _rate_limit_buckets.clear()
+    _account_rate_limit_buckets.clear()
 
 
 @pytest.fixture()
@@ -153,6 +158,27 @@ def test_login_unknown_email(auth_client):
         "/auth/login", json={"email": "nobody@example.com", "password": "supersecret1234"}
     )
     assert resp.status_code == 401
+
+
+def test_login_unknown_email_still_pays_the_bcrypt_cost(auth_client):
+    # Regression test: a nonexistent email used to short-circuit before bcrypt ran, so
+    # response timing alone revealed whether an email was registered. Must now always
+    # run one bcrypt check, same as the real-account path.
+    with patch("src.routers.auth.bcrypt.checkpw", wraps=bcrypt.checkpw) as mock_checkpw:
+        resp = auth_client.post(
+            "/auth/login", json={"email": "nobody@example.com", "password": "supersecret1234"}
+        )
+    assert resp.status_code == 401
+    mock_checkpw.assert_called_once()
+
+
+def test_login_applies_a_per_account_rate_limit(auth_client):
+    with patch("src.routers.auth.check_account_rate_limit") as mock_limit:
+        auth_client.post(
+            "/auth/login", json={"email": "Someone@Example.com", "password": "supersecret1234"}
+        )
+    # Lowercased so "Someone@Example.com" and "someone@example.com" share a bucket.
+    mock_limit.assert_called_once_with("login:someone@example.com")
 
 
 def test_login_github_only_user_returns_401(auth_client, db):

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -1,6 +1,7 @@
 """Tests for the GitHub OAuth router + find-or-create (DB-backed)."""
 
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi import FastAPI
@@ -9,7 +10,7 @@ from pydantic import SecretStr
 
 from src.core.config import settings
 from src.core.db import User, get_db
-from src.routers.github_auth import find_or_create_user
+from src.routers.github_auth import EmailAlreadyRegistered, find_or_create_user
 from src.routers.github_auth import router as gh_router
 from src.services.github_oauth import GitHubIdentity
 
@@ -24,7 +25,10 @@ def gh_app(db):
 
 @pytest.fixture()
 def gh_client(gh_app):
-    return TestClient(gh_app)
+    # https base_url so Secure-flagged cookies (session + OAuth state, both set with
+    # secure=settings.session_cookie_secure which defaults True) actually round-trip
+    # through the client's cookie jar across requests, matching real browser behavior.
+    return TestClient(gh_app, base_url="https://testserver")
 
 
 @pytest.fixture()
@@ -54,15 +58,33 @@ def test_second_user_is_member(db):
     assert second.is_workspace_admin is False
 
 
-def test_links_existing_email_user_and_keeps_role(db):
+def test_refuses_to_auto_link_an_existing_email_registered_account(db):
+    # Regression test for the account-takeover fix: self-registration has no email
+    # verification anywhere in this app, so silently linking a GitHub identity onto an
+    # existing account by email match alone would let an attacker who pre-registered a
+    # victim's email inherit the victim's real GitHub identity. Must raise, not link.
     existing = User(email="owner@example.com", name="Owner", password_hash="x", is_workspace_admin=True)
     db.add(existing)
     db.commit()
     db.refresh(existing)
-    linked = find_or_create_user(db, _identity(github_user_id=555, email="owner@example.com"))
-    assert linked.id == existing.id
-    assert linked.github_user_id == 555
-    assert linked.is_workspace_admin is True
+
+    with pytest.raises(EmailAlreadyRegistered):
+        find_or_create_user(db, _identity(github_user_id=555, email="owner@example.com"))
+
+    db.refresh(existing)
+    assert existing.github_user_id is None
+    assert db.query(User).count() == 1
+
+
+def test_unrelated_email_still_creates_a_new_user(db):
+    existing = User(email="owner@example.com", name="Owner", password_hash="x", is_workspace_admin=True)
+    db.add(existing)
+    db.commit()
+
+    created = find_or_create_user(db, _identity(github_user_id=555, email="someone-else@example.com"))
+    assert created.id != existing.id
+    assert created.github_user_id == 555
+    assert db.query(User).count() == 2
 
 
 def test_idempotent_by_github_id(db):
@@ -78,6 +100,7 @@ def test_login_redirects_to_github(gh_client, oauth_configured):
     resp = gh_client.get("/auth/github/login", follow_redirects=False)
     assert resp.status_code == 307
     assert resp.headers["location"].startswith("https://github.com/login/oauth/authorize")
+    assert "clevis_oauth_state" in resp.headers.get("set-cookie", "")
 
 
 def test_login_unconfigured_redirects_to_ui_with_error(gh_client, monkeypatch):
@@ -109,6 +132,23 @@ def test_callback_rejects_bad_state(gh_client):
     assert resp.headers["location"].endswith("/login?error=github_invalid_state")
 
 
+def test_callback_redirects_with_error_when_email_already_registered(gh_client, db):
+    existing = User(email="octo@example.com", name="Owner", password_hash="x", is_workspace_admin=True)
+    db.add(existing)
+    db.commit()
+
+    with (
+        patch("src.routers.github_auth.github_oauth.verify_state", return_value=True),
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+    ):
+        resp = gh_client.get("/auth/github/callback?code=c&state=s", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_email_registered")
+    db.refresh(existing)
+    assert existing.github_user_id is None
+
+
 def test_callback_redirects_to_ui_on_oauth_error(gh_client):
     from src.services.github_oauth import GitHubOAuthError
 
@@ -119,3 +159,56 @@ def test_callback_redirects_to_ui_on_oauth_error(gh_client):
         resp = gh_client.get("/auth/github/callback?code=c&state=s", follow_redirects=False)
     assert resp.status_code == 303
     assert resp.headers["location"].endswith("/login?error=github_oauth_failed")
+
+
+# ── state cookie binding (regression tests for the OAuth login-CSRF fix) ────────
+
+def _extract_state(login_resp) -> str:
+    return parse_qs(urlparse(login_resp.headers["location"]).query)["state"][0]
+
+
+def test_full_flow_succeeds_when_the_state_cookie_matches(gh_client, db, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login", follow_redirects=False)
+    state = _extract_state(login_resp)
+
+    with (
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
+    ):
+        # Same client/cookie jar as /login -- the browser that started the flow.
+        resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "clevis_session" in resp.headers.get("set-cookie", "")
+
+
+def test_replaying_a_captured_state_from_a_different_browser_is_rejected(gh_client, db, oauth_configured):
+    # Simulates the attack this fix closes: an attacker captures a valid (code, state)
+    # pair from their own OAuth flow and gets a victim to open the callback URL. The
+    # victim's browser never had the matching clevis_oauth_state cookie set.
+    login_resp = gh_client.get("/auth/github/login", follow_redirects=False)
+    state = _extract_state(login_resp)
+    gh_client.cookies.delete("clevis_oauth_state")
+
+    resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_invalid_state")
+    assert db.query(User).count() == 0
+
+
+def test_callback_clears_the_state_cookie_on_success(gh_client, db, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login", follow_redirects=False)
+    state = _extract_state(login_resp)
+
+    with (
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
+    ):
+        resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    # There are two Set-Cookie headers on this response (session + state-cookie-clear) --
+    # use get_list so the second one isn't dropped by a naive single-value lookup.
+    set_cookies = resp.headers.get_list("set-cookie")
+    state_cookie_headers = [c for c in set_cookies if c.startswith("clevis_oauth_state=")]
+    assert len(state_cookie_headers) == 1
+    assert "Max-Age=0" in state_cookie_headers[0]

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -12,6 +12,7 @@ from src.core.config import settings
 from src.core.db import User, get_db
 from src.routers.github_auth import EmailAlreadyRegistered, find_or_create_user
 from src.routers.github_auth import router as gh_router
+from src.services import github_oauth
 from src.services.github_oauth import GitHubIdentity
 
 
@@ -147,6 +148,20 @@ def test_callback_redirects_with_error_when_email_already_registered(gh_client, 
     assert resp.headers["location"].endswith("/login?error=github_email_registered")
     db.refresh(existing)
     assert existing.github_user_id is None
+
+
+def test_callback_redirects_to_ui_when_oauth_becomes_unconfigured_mid_flow(gh_client):
+    # e.g. an admin cleared GITHUB_APP_CLIENT_ID/SECRET between /login and /callback.
+    with (
+        patch("src.routers.github_auth.github_oauth.verify_state", return_value=True),
+        patch(
+            "src.routers.github_auth.github_oauth.exchange_code_for_token",
+            side_effect=github_oauth.GitHubOAuthNotConfigured("not configured"),
+        ),
+    ):
+        resp = gh_client.get("/auth/github/callback?code=c&state=s", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_not_configured")
 
 
 def test_callback_redirects_to_ui_on_oauth_error(gh_client):

--- a/apps/api/tests/test_github_oauth.py
+++ b/apps/api/tests/test_github_oauth.py
@@ -21,15 +21,27 @@ def oauth_configured(monkeypatch):
 
 
 def test_state_roundtrip():
-    state = github_oauth.sign_state()
-    assert github_oauth.verify_state(state) is True
+    state, nonce = github_oauth.sign_state()
+    assert github_oauth.verify_state(state, cookie_nonce=nonce) is True
 
 
 def test_state_rejects_tampered_and_expired():
-    assert github_oauth.verify_state("not-a-token") is False
+    assert github_oauth.verify_state("not-a-token", cookie_nonce="whatever") is False
     # exp in the past -> invalid
-    expired = github_oauth.sign_state(now=1_000_000)
-    assert github_oauth.verify_state(expired) is False
+    expired, nonce = github_oauth.sign_state(now=1_000_000)
+    assert github_oauth.verify_state(expired, cookie_nonce=nonce) is False
+
+
+def test_state_rejects_missing_or_mismatched_cookie_nonce():
+    # Regression test for the OAuth login-CSRF gap: a validly-signed, unexpired state
+    # must still be rejected if it isn't paired with the browser's own nonce cookie.
+    state, nonce = github_oauth.sign_state()
+    assert github_oauth.verify_state(state, cookie_nonce=None) is False
+    assert github_oauth.verify_state(state, cookie_nonce="some-other-nonce") is False
+    # A state token minted for a *different* flow (different nonce) must not validate
+    # against this browser's cookie either.
+    other_state, _ = github_oauth.sign_state()
+    assert github_oauth.verify_state(other_state, cookie_nonce=nonce) is False
 
 
 def test_build_authorize_url(oauth_configured):

--- a/apps/api/tests/test_github_oauth.py
+++ b/apps/api/tests/test_github_oauth.py
@@ -1,8 +1,10 @@
 """Unit tests for the GitHub OAuth helpers (no DB, httpx mocked)."""
 
+import time
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
+import jwt
 import pytest
 from pydantic import SecretStr
 
@@ -30,6 +32,18 @@ def test_state_rejects_tampered_and_expired():
     # exp in the past -> invalid
     expired, nonce = github_oauth.sign_state(now=1_000_000)
     assert github_oauth.verify_state(expired, cookie_nonce=nonce) is False
+
+
+def test_state_rejects_wrong_purpose():
+    # A token signed with our own secret but for a different purpose (or forged with a
+    # mismatched purpose claim) must not validate as an OAuth state.
+    now = int(time.time())
+    other_purpose_token = jwt.encode(
+        {"iat": now, "exp": now + 600, "purpose": "not-github-oauth", "nonce": "n"},
+        settings.auth_secret.get_secret_value(),
+        algorithm="HS256",
+    )
+    assert github_oauth.verify_state(other_purpose_token, cookie_nonce="n") is False
 
 
 def test_state_rejects_missing_or_mismatched_cookie_nonce():

--- a/apps/api/tests/test_installation_repo.py
+++ b/apps/api/tests/test_installation_repo.py
@@ -1,0 +1,79 @@
+"""Tests for src.repositories.installation_repo.upsert, focused on the concurrent-sync
+race path (see apps/api/tests/test_installations.py for router-level coverage)."""
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Query
+
+from src.repositories import installation_repo, org_repo
+
+
+def _acme_org_id(db) -> int:
+    # github_installations.org_id has a foreign key to orgs.id -- needs a real row.
+    return org_repo.get_or_create(db, github_login="acme").id
+
+
+def test_upsert_creates_new_row(db):
+    org_id = _acme_org_id(db)
+    row = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    assert row.account_login == "acme"
+    assert row.installation_id == 1
+
+
+def test_upsert_updates_existing_row(db):
+    org_id = _acme_org_id(db)
+    installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    updated = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=2, org_id=org_id
+    )
+    assert updated.installation_id == 2
+
+
+def test_upsert_falls_back_to_update_on_concurrent_sync_race(db):
+    # Simulates two near-simultaneous syncs for the same org/account: this call's initial
+    # existence check misses (the other request's row hasn't committed yet from this call's
+    # point of view), so it attempts an insert -- which collides on the real unique
+    # constraint once the other request's commit has actually landed. Must recover by
+    # updating the row that's actually there, not raise an unhandled IntegrityError.
+    org_id = _acme_org_id(db)
+    existing = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = installation_repo.upsert(
+            db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=2, org_id=org_id
+        )
+
+    assert result.id == existing.id
+    assert result.installation_id == 2
+
+
+def test_upsert_reraises_when_the_integrity_error_was_not_actually_a_race(db):
+    # A different IntegrityError (here: a foreign-key violation from a nonexistent org_id)
+    # also lands in the except block, but the re-query genuinely finds nothing to fall back
+    # to (no row was ever inserted) -- must re-raise rather than silently swallow it.
+    with pytest.raises(IntegrityError):
+        installation_repo.upsert(
+            db,
+            account_login="acme",
+            account_type="Organization",
+            auth_mode="app",
+            installation_id=1,
+            org_id=999999,
+        )

--- a/apps/api/tests/test_org_repo.py
+++ b/apps/api/tests/test_org_repo.py
@@ -1,0 +1,43 @@
+"""Tests for src.repositories.org_repo.get_or_create."""
+
+from src.repositories import org_repo
+
+
+def test_creates_new_org(db):
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    assert org.github_login == "acme"
+    assert org.github_org_id == 1
+
+
+def test_idempotent_by_login(db):
+    first = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    second = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    assert second.id == first.id
+
+
+def test_backfills_github_org_id_on_existing_login_only_row(db):
+    existing = org_repo.get_or_create(db, github_login="acme")
+    assert existing.github_org_id is None
+    updated = org_repo.get_or_create(db, github_login="acme", github_org_id=42)
+    assert updated.id == existing.id
+    assert updated.github_org_id == 42
+
+
+def test_org_rename_resolves_by_github_org_id_instead_of_crashing(db):
+    # Regression test: an org renamed on GitHub keeps the same github_org_id but a new
+    # github_login. get_or_create must find it by id and update the login, not attempt
+    # a second insert that collides with the github_org_id unique constraint.
+    original = org_repo.get_or_create(db, github_login="old-name", github_org_id=99)
+
+    renamed = org_repo.get_or_create(db, github_login="new-name", github_org_id=99)
+
+    assert renamed.id == original.id
+    assert renamed.github_login == "new-name"
+    assert org_repo.get_by_login(db, "old-name") is None
+    assert org_repo.get_by_login(db, "new-name").id == original.id
+
+
+def test_different_orgs_stay_separate(db):
+    acme = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    globex = org_repo.get_or_create(db, github_login="globex", github_org_id=2)
+    assert acme.id != globex.id

--- a/apps/api/tests/test_org_repo.py
+++ b/apps/api/tests/test_org_repo.py
@@ -1,5 +1,9 @@
 """Tests for src.repositories.org_repo.get_or_create."""
 
+from unittest.mock import patch
+
+from sqlalchemy.orm import Query
+
 from src.repositories import org_repo
 
 
@@ -35,6 +39,33 @@ def test_org_rename_resolves_by_github_org_id_instead_of_crashing(db):
     assert renamed.github_login == "new-name"
     assert org_repo.get_by_login(db, "old-name") is None
     assert org_repo.get_by_login(db, "new-name").id == original.id
+
+
+def test_get_or_create_falls_back_to_org_id_lookup_on_concurrent_insert_race(db):
+    # Simulates two near-simultaneous get_or_create calls with the same github_org_id: this
+    # call's initial get_by_org_id lookup misses (the other request hasn't committed yet
+    # from this call's point of view), so it attempts an insert -- which collides on the
+    # real unique constraint once the other request's row is actually there. The except
+    # block's get_by_login also misses (different login than what's stored), so it must
+    # fall back to get_by_org_id to find the row, not raise.
+    existing = org_repo.get_or_create(db, github_login="old-name", github_org_id=7)
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        # The 1st call is get_by_login (real miss, different login) -- let it through.
+        # The 2nd call is get_by_org_id in the pre-insert check -- fake a miss to force
+        # the insert attempt into a real collision.
+        if calls["n"] == 2:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = org_repo.get_or_create(db, github_login="new-name-2", github_org_id=7)
+
+    assert result.id == existing.id
 
 
 def test_different_orgs_stay_separate(db):

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,5 +1,7 @@
 """Tests for the in-memory fixed-window rate limiter."""
 
+from unittest.mock import patch
+
 import pytest
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -72,3 +74,16 @@ def test_check_account_rate_limit_scoped_per_key():
     check_account_rate_limit("acct-b", max_requests=1)
     with pytest.raises(HTTPException):
         check_account_rate_limit("acct-a", max_requests=1)
+
+
+def test_check_account_rate_limit_resets_after_the_window_elapses():
+    with patch("src.core.rate_limit.time.monotonic", return_value=0.0):
+        check_account_rate_limit("acct-window", max_requests=1, window_seconds=60)
+    # Still within the window -- a second call already exceeds max_requests=1.
+    with patch("src.core.rate_limit.time.monotonic", return_value=30.0):
+        with pytest.raises(HTTPException):
+            check_account_rate_limit("acct-window", max_requests=1, window_seconds=60)
+    # Past the window -- the bucket resets instead of continuing to accumulate,
+    # so this must succeed rather than 429 again.
+    with patch("src.core.rate_limit.time.monotonic", return_value=61.0):
+        check_account_rate_limit("acct-window", max_requests=1, window_seconds=60)

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,9 +1,10 @@
 """Tests for the in-memory fixed-window rate limiter."""
 
-from fastapi import Depends, FastAPI
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from src.core.rate_limit import rate_limit
+from src.core.rate_limit import check_account_rate_limit, rate_limit
 
 
 def _app(path: str, max_requests: int, window_seconds: int = 60) -> FastAPI:
@@ -48,3 +49,26 @@ def test_rate_limit_scoped_per_path():
     assert client.get("/a").status_code == 200
     assert client.get("/b").status_code == 200
     assert client.get("/a").status_code == 429
+
+
+# ── check_account_rate_limit ─────────────────────────────────────────────────
+
+def test_check_account_rate_limit_allows_up_to_max_requests():
+    check_account_rate_limit("acct-allow", max_requests=2)
+    check_account_rate_limit("acct-allow", max_requests=2)
+
+
+def test_check_account_rate_limit_blocks_after_max_requests():
+    check_account_rate_limit("acct-block", max_requests=2)
+    check_account_rate_limit("acct-block", max_requests=2)
+    with pytest.raises(HTTPException) as exc_info:
+        check_account_rate_limit("acct-block", max_requests=2)
+    assert exc_info.value.status_code == 429
+
+
+def test_check_account_rate_limit_scoped_per_key():
+    """Two independently-limited keys don't share a bucket."""
+    check_account_rate_limit("acct-a", max_requests=1)
+    check_account_rate_limit("acct-b", max_requests=1)
+    with pytest.raises(HTTPException):
+        check_account_rate_limit("acct-a", max_requests=1)

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -32,6 +32,7 @@ const GITHUB_ERROR_MESSAGES: Record<string, string> = {
   github_not_configured: "GitHub sign-in isn't set up on this server yet. Use email and password, or ask an admin to configure it.",
   github_invalid_state: "Your GitHub sign-in attempt expired or was invalid. Please try again.",
   github_oauth_failed: "GitHub sign-in failed. Please try again.",
+  github_email_registered: "An account already exists with this email. Sign in with your password below.",
 }
 
 function githubErrorMessage(code: string | null): string {

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -17,11 +17,27 @@ import type { InstallationMeta, MyOrgMembership, SavedTokenMeta } from "@/lib/ap
 // ── Profile section ──────────────────────────────────────────────────────────
 
 function ProfileSection() {
-  const { user, updateUser } = useAuth()
+  const { user, updateUser, logout } = useAuth()
   const [name, setName] = useState(user?.name || "")
   const [org, setOrg] = useState("")
   const [saved, setSaved] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const [revokeArmed, setRevokeArmed] = useState(false)
+
+  const revokeSessions = useMutation({
+    mutationFn: () => api.auth.revokeSessions(),
+    // Bumping token_version invalidates this device's own token too, so finish by
+    // logging out locally rather than leaving the UI in a now-unauthenticated state.
+    onSuccess: () => logout(),
+  })
+
+  // Auto-disarm if the user doesn't confirm within a few seconds, matching the
+  // cache-clear confirm pattern (components/repo/cache-panel.tsx).
+  useEffect(() => {
+    if (!revokeArmed) return
+    const timer = setTimeout(() => setRevokeArmed(false), 4000)
+    return () => clearTimeout(timer)
+  }, [revokeArmed])
 
   useEffect(() => {
     setName(user?.name || "")
@@ -82,6 +98,32 @@ function ProfileSection() {
         </div>
         <Button onClick={save} disabled={isSaving} className="mt-1 w-fit">
           {buttonContent}
+        </Button>
+      </div>
+      <div className="px-4 py-3 border-t border-border flex flex-col gap-2 items-start">
+        <p className="text-xs text-muted-foreground max-w-sm">
+          Invalidates every session on every device, including this one — signs you out
+          everywhere. Use this if a device was lost or a session token may have leaked.
+        </p>
+        <Button
+          variant="destructive"
+          onClick={() => {
+            if (revokeArmed) {
+              setRevokeArmed(false)
+              revokeSessions.mutate()
+            } else {
+              setRevokeArmed(true)
+            }
+          }}
+          disabled={revokeSessions.isPending}
+        >
+          {revokeSessions.isPending ? (
+            <><CircleNotch className="size-3.5 animate-spin" />Signing out…</>
+          ) : revokeArmed ? (
+            "Click again to confirm"
+          ) : (
+            "Sign out of all devices"
+          )}
         </Button>
       </div>
     </div>

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -246,5 +246,6 @@ export const api = {
       }>("/auth/register", { email, password, name }),
     patchMe: (name: string) =>
       patch<{ id: number; email: string; name: string | null; is_workspace_admin: boolean }>("/auth/me", { name }),
+    revokeSessions: () => post<{ ok: boolean }>("/auth/me/revoke-sessions", {}),
   },
 }

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -7,6 +7,7 @@ const installationsListMock = vi.fn();
 const tokensListMock = vi.fn();
 const configGetAllMock = vi.fn();
 const patchMeMock = vi.fn();
+const revokeSessionsMock = vi.fn();
 const configUpdateMock = vi.fn();
 const routerReplace = vi.fn();
 let searchParams = new URLSearchParams();
@@ -25,7 +26,10 @@ vi.mock("@/lib/api/client", () => ({
       getAll: (...args: unknown[]) => configGetAllMock(...args),
       update: (...args: unknown[]) => configUpdateMock(...args),
     },
-    auth: { patchMe: (...args: unknown[]) => patchMeMock(...args) },
+    auth: {
+      patchMe: (...args: unknown[]) => patchMeMock(...args),
+      revokeSessions: (...args: unknown[]) => revokeSessionsMock(...args),
+    },
   },
 }));
 
@@ -81,6 +85,7 @@ describe("SettingsPage", () => {
     tokensListMock.mockReset();
     configGetAllMock.mockReset();
     patchMeMock.mockReset();
+    revokeSessionsMock.mockReset();
     configUpdateMock.mockReset();
     routerReplace.mockClear();
     searchParams = new URLSearchParams();
@@ -184,5 +189,26 @@ describe("SettingsPage", () => {
       expect(screen.getByText("GitHub App installation connected.")).toBeInTheDocument();
     });
     expect(routerReplace).toHaveBeenCalledWith("/settings");
+  });
+
+  it("requires a second click to confirm revoking all sessions, then calls the endpoint", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+    revokeSessionsMock.mockResolvedValue({ ok: true });
+
+    renderPage();
+
+    const revokeButton = await screen.findByRole("button", { name: /sign out of all devices/i });
+    fireEvent.click(revokeButton);
+    expect(revokeSessionsMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: /click again to confirm/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /click again to confirm/i }));
+
+    await waitFor(() => expect(revokeSessionsMock).toHaveBeenCalledTimes(1));
+    // logout() clears the token, which removes the authenticated Settings page entirely.
+    await waitFor(() => expect(localStorage.getItem(TOKEN_KEY)).toBeNull());
   });
 });


### PR DESCRIPTION
## Summary

Fixes from a full audit of authentication (GitHub OAuth, email/password, sessions, RBAC). Five separate issues, each its own commit.

### Sensitive surfaces (per AGENTS.md)
This PR touches auth, token/session handling, and RBAC-adjacent code across every commit. No migrations. No changes to `require_org_role`/`require_auth`/`require_workspace_admin` themselves, no bypass of any existing guardrail.

### 1. Org-rename crash in GitHub OAuth login (`5cf1367`)
`org_repo.get_or_create` looked up by `github_login` only. If an org was renamed on GitHub since Clevis last saw it (same `github_org_id`, new login — that id is DB-unique), the insert for the new login collided with the existing row and the exception handler's re-query (by the new login) still found nothing, so it re-raised. `/auth/github/callback` 500s, the org-admin membership never gets created, and it fails identically on every retry. This is the most likely explanation for an org admin never seeing their org as "connected" after signing in with GitHub.

### 2. GitHub sign-in login-CSRF (`0219f12`)
OAuth `state` was checked for signature/expiry/purpose only — never bound to the browser that started the flow. An attacker could start their own OAuth flow, capture a valid `(code, state)` pair from their own callback, and get a victim to open that URL; the victim's browser would receive a session cookie for the attacker's account. Fixed by binding `state` to a nonce also set as a short-lived, httpOnly, `SameSite=Lax` cookie on `/login`, required to match on `/callback`.

### 3. Account-takeover via silent email-linking (`0219f12`, same commit as #2 — both touch the same callback flow)
`find_or_create_user` silently linked an incoming GitHub identity onto any existing account with a matching email. Self-registration (`POST /auth/register`) has no email-ownership verification anywhere in this app, so an attacker could pre-register a victim's email, then inherit the victim's real GitHub identity (and whatever org-admin access it earns) the next time the victim signed in with GitHub — while keeping their own password on the shared account. Fixed by refusing to auto-link; an email match with no GitHub identity yet redirects with an explanatory error instead ("sign in with your password first"). A deliberately scoped-down fix — a full self-service "connect GitHub to my existing account" flow would need a new authenticated linking flow (mirroring the existing install-callback ticket pattern), which is more surface area than this bug-fix PR should carry.

### 4 & 5. Login timing side-channel + per-account rate limiting (`c021851`)
A nonexistent email short-circuited before bcrypt ran, so response timing alone revealed whether an email was registered — worse, the login endpoint's own `not user or not _verify_password(...)` short-circuited around even a fixed-cost check. Fixed so `_verify_password` always runs bcrypt (against a dummy hash when there's no real one) as an unconditional statement. Also added a per-submitted-email rate-limit bucket alongside the existing per-IP one, since an attacker spread across multiple source IPs could otherwise brute-force one account without ever tripping the IP-keyed limit.

### 6. GitHub App installation-sync race (`02ae77c`)
Same class of bug as #1: `installation_repo.upsert` had no protection against a concurrent insert, raising an unhandled `IntegrityError` (raw 500) instead of falling back to an update.

### 7. Unreachable session-revocation endpoint (`35e4f8c`)
`POST /auth/me/revoke-sessions` — the only way to invalidate a leaked/stolen JWT before its 30-day expiry — had zero frontend callers. Added a "Sign out of all devices" action in Settings.

### Known, deliberately deferred (not in this PR)
`/auth/setup`'s first-run check-then-insert isn't atomic — two concurrent `POST /auth/setup` calls before either commits could both create an admin. No natural DB constraint catches this without a schema migration (e.g. a partial unique index on `is_workspace_admin WHERE true`), and this is a narrow first-boot-only window. Flagging it here rather than rushing a migration into a bug-fix PR, per AGENTS.md's migration guardrail.

## Test plan
- [x] `pytest -q` — 297 passed, no regressions
- [x] `cd apps/ui && bun run check` — typecheck/lint/build clean
- [x] `cd apps/ui && bun run test` — 161 passed, no regressions
- [x] New regression tests for every fix: org-rename resolution, OAuth state cookie-mismatch rejection, email-link refusal, bcrypt-always-runs, per-account rate limit, concurrent installation sync, and the new Settings action