### PR TITLE
feat(checks,api): Security Dashboard v2 checks/history (Phase 10)

### DIFF
--- a/apps/api/alembic/versions/0015_add_scan_results.py
+++ b/apps/api/alembic/versions/0015_add_scan_results.py
@@ -32,7 +32,7 @@ def upgrade() -> None:
         sa.Column("total_checks", sa.Integer(), nullable=False),
         sa.Column("failed_checks", sa.Integer(), nullable=False),
         sa.Column("checks_json", sa.Text(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
     )
     op.create_index("ix_scan_results_owner_created_at", "scan_results", ["owner", "created_at"])
 

--- a/apps/api/alembic/versions/0015_add_scan_results.py
+++ b/apps/api/alembic/versions/0015_add_scan_results.py
@@ -1,0 +1,42 @@
+"""add scan_results
+
+Every /analytics/overview scan was previously a one-off snapshot with no
+history — there was no way to see a security score's trend over time. This
+adds a scan_results table that persists a row for every completed scan
+(owner, score, check counts, and the full checks payload as JSON text,
+matching the json-as-Text convention used by audit_logs.payload and
+jobs.payload/result elsewhere in this schema), plus a composite index on
+(owner, created_at) since every read of this table is "most recent N scans
+for this owner".
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scan_results",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("owner", sa.String(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False),
+        sa.Column("total_checks", sa.Integer(), nullable=False),
+        sa.Column("failed_checks", sa.Integer(), nullable=False),
+        sa.Column("checks_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_scan_results_owner_created_at", "scan_results", ["owner", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_scan_results_owner_created_at", table_name="scan_results")
+    op.drop_table("scan_results")

--- a/apps/api/alembic/versions/0016_add_scan_results_scanned_by_user_id.py
+++ b/apps/api/alembic/versions/0016_add_scan_results_scanned_by_user_id.py
@@ -1,0 +1,40 @@
+"""add scan_results.scanned_by_user_id
+
+The new GET .../analytics/history endpoints read scan_results by a raw
+`owner` string with no other scoping. For the org-scoped endpoint that's
+fine (require_org_role already gates on membership), but the personal
+endpoint (GET /me/analytics/history?owner=...) had no such gate at all --
+any authenticated user could read any owner's persisted score history
+just by naming it, regardless of whether they have any access to that
+owner's GitHub data. A personal scan against an owner with no matching
+workspace Org (the common raw-PAT-paste flow, never installing the
+GitHub App) has no membership row to check against, so there was no way
+to scope personal-history reads without recording who ran the scan.
+
+This column tracks that: set on insert for personal scans only (org-scoped
+scans leave it null and rely on org membership at read time instead).
+Nullable and additive-only -- no backfill, no data-loss risk; existing
+rows (none exist yet in production since scan_results itself just shipped)
+simply have no operator to test the tighter permission,
+which is a slightly stricter default (deny) not a looser one.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("scan_results", sa.Column("scanned_by_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("scan_results", "scanned_by_user_id")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -155,6 +155,19 @@ class Invitation(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
+class ScanResult(Base):
+    __tablename__ = "scan_results"
+    __table_args__ = (Index("ix_scan_results_owner_created_at", "owner", "created_at"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    owner: Mapped[str] = mapped_column(String, nullable=False)
+    score: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_checks: Mapped[int] = mapped_column(Integer, nullable=False)
+    failed_checks: Mapped[int] = mapped_column(Integer, nullable=False)
+    checks_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class AppConfig(Base):
     __tablename__ = "app_config"
 

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -165,6 +165,11 @@ class ScanResult(Base):
     total_checks: Mapped[int] = mapped_column(Integer, nullable=False)
     failed_checks: Mapped[int] = mapped_column(Integer, nullable=False)
     checks_json: Mapped[str] = mapped_column(Text, nullable=False)
+    # Set for personal-endpoint scans only -- lets GET /me/analytics/history gate
+    # access to owners with no workspace Org/membership to check instead (see
+    # migration 0016). Org-scoped scans leave this null; that read path is gated
+    # by org membership, not this column.
+    scanned_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 

--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -1,0 +1,39 @@
+import json
+
+from sqlalchemy.orm import Session
+
+from src.core.db import ScanResult
+
+
+def insert(db: Session, owner: str, score: int, total_checks: int, failed_checks: int, checks: list[dict]) -> None:
+    db.add(
+        ScanResult(
+            owner=owner,
+            score=score,
+            total_checks=total_checks,
+            failed_checks=failed_checks,
+            checks_json=json.dumps(checks),
+        )
+    )
+    db.commit()
+
+
+def list_recent(db: Session, owner: str, limit: int = 30) -> list[dict]:
+    rows = (
+        db.query(ScanResult)
+        .filter(ScanResult.owner == owner)
+        .order_by(ScanResult.created_at.desc(), ScanResult.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": r.id,
+            "owner": r.owner,
+            "score": r.score,
+            "total_checks": r.total_checks,
+            "failed_checks": r.failed_checks,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in rows
+    ]

--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -5,7 +5,15 @@ from sqlalchemy.orm import Session
 from src.core.db import ScanResult
 
 
-def insert(db: Session, owner: str, score: int, total_checks: int, failed_checks: int, checks: list[dict]) -> None:
+def insert(
+    db: Session,
+    owner: str,
+    score: int,
+    total_checks: int,
+    failed_checks: int,
+    checks: list[dict],
+    scanned_by_user_id: int | None = None,
+) -> None:
     db.add(
         ScanResult(
             owner=owner,
@@ -13,9 +21,19 @@ def insert(db: Session, owner: str, score: int, total_checks: int, failed_checks
             total_checks=total_checks,
             failed_checks=failed_checks,
             checks_json=json.dumps(checks),
+            scanned_by_user_id=scanned_by_user_id,
         )
     )
     db.commit()
+
+
+def exists_for_user(db: Session, owner: str, user_id: int) -> bool:
+    return (
+        db.query(ScanResult.id)
+        .filter(ScanResult.owner == owner, ScanResult.scanned_by_user_id == user_id)
+        .first()
+        is not None
+    )
 
 
 def list_recent(db: Session, owner: str, limit: int = 30) -> list[dict]:

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
-from src.repositories import scan_results_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo, scan_results_repo
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse, ScanHistoryEntry
 from src.services.analytics_service import get_account_type, get_overview
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
@@ -39,6 +39,34 @@ async def _get_account_type(owner: str, token: str) -> str:
         raise HTTPException(status_code=503, detail="GitHub API unreachable")
 
 
+def _persist_scan(db: Session, result: dict, scanned_by_user_id: int | None = None) -> None:
+    scan_results_repo.insert(
+        db,
+        owner=result["owner"],
+        score=result["score"],
+        total_checks=result["total_checks"],
+        failed_checks=result["failed_checks"],
+        checks=result["checks"],
+        scanned_by_user_id=scanned_by_user_id,
+    )
+
+
+def _user_can_read_history(db: Session, user: UserOut, owner: str) -> bool:
+    """Scan history isn't gated by GitHub-side authorization the way a live scan is
+    (GitHub itself rejects a bad token/owner combo) -- it's a local DB read, so it
+    needs its own access check. A user may read `owner`'s history if they're a
+    member of the matching workspace Org, they personally have a GitHub App
+    installation connected for that account login, or they're the one who ran a
+    personal scan against that owner before (scanned_by_user_id, for owners with
+    no workspace Org/membership at all -- the raw-PAT-paste flow)."""
+    org = org_repo.get_by_login(db, owner)
+    if org is not None and org_membership_repo.get(db, org.id, user.id) is not None:
+        return True
+    if installation_repo.get_for_user(db, owner_user_id=user.id, account_login=owner) is not None:
+        return True
+    return scan_results_repo.exists_for_user(db, owner=owner, user_id=user.id)
+
+
 @router.post("/orgs/{org_login}/analytics/overview", response_model=AnalyticsResponse)
 async def org_analytics_overview(
     payload: AnalyticsInput,
@@ -54,14 +82,7 @@ async def org_analytics_overview(
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     result = await _run_overview(payload.owner, token)
-    scan_results_repo.insert(
-        db,
-        owner=result["owner"],
-        score=result["score"],
-        total_checks=result["total_checks"],
-        failed_checks=result["failed_checks"],
-        checks=result["checks"],
-    )
+    _persist_scan(db, result)
     return result
 
 
@@ -87,14 +108,7 @@ async def personal_analytics_overview(
             detail="Personal GitHub accounts aren't supported for security scanning yet. Connect a GitHub organization instead.",
         )
     result = await _run_overview(payload.owner, token)
-    scan_results_repo.insert(
-        db,
-        owner=result["owner"],
-        score=result["score"],
-        total_checks=result["total_checks"],
-        failed_checks=result["failed_checks"],
-        checks=result["checks"],
-    )
+    _persist_scan(db, result, scanned_by_user_id=user.id)
     return result
 
 
@@ -112,4 +126,6 @@ def personal_analytics_history(
     user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
+    if not _user_can_read_history(db, user, owner):
+        raise HTTPException(status_code=403, detail="You don't have access to this owner's scan history")
     return scan_results_repo.list_recent(db, owner=owner, limit=30)

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import Session
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
-from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
+from src.repositories import scan_results_repo
+from src.schemas.analytics import AnalyticsInput, AnalyticsResponse, ScanHistoryEntry
 from src.services.analytics_service import get_account_type, get_overview
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
 
@@ -52,7 +53,16 @@ async def org_analytics_overview(
         )
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    return await _run_overview(payload.owner, token)
+    result = await _run_overview(payload.owner, token)
+    scan_results_repo.insert(
+        db,
+        owner=result["owner"],
+        score=result["score"],
+        total_checks=result["total_checks"],
+        failed_checks=result["failed_checks"],
+        checks=result["checks"],
+    )
+    return result
 
 
 @router.post("/me/analytics/overview", response_model=AnalyticsResponse)
@@ -76,4 +86,30 @@ async def personal_analytics_overview(
             status_code=422,
             detail="Personal GitHub accounts aren't supported for security scanning yet. Connect a GitHub organization instead.",
         )
-    return await _run_overview(payload.owner, token)
+    result = await _run_overview(payload.owner, token)
+    scan_results_repo.insert(
+        db,
+        owner=result["owner"],
+        score=result["score"],
+        total_checks=result["total_checks"],
+        failed_checks=result["failed_checks"],
+        checks=result["checks"],
+    )
+    return result
+
+
+@router.get("/orgs/{org_login}/analytics/history", response_model=list[ScanHistoryEntry])
+def org_analytics_history(
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    return scan_results_repo.list_recent(db, owner=ctx.org.github_login, limit=30)
+
+
+@router.get("/me/analytics/history", response_model=list[ScanHistoryEntry])
+def personal_analytics_history(
+    owner: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    return scan_results_repo.list_recent(db, owner=owner, limit=30)

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, SecretStr
 
 
@@ -15,3 +17,12 @@ class AnalyticsResponse(BaseModel):
     failed_checks: int
     repo_count: int
     checks: list[dict]
+
+
+class ScanHistoryEntry(BaseModel):
+    id: int
+    owner: str
+    score: int
+    total_checks: int
+    failed_checks: int
+    created_at: datetime

--- a/apps/api/tests/test_analytics_history.py
+++ b/apps/api/tests/test_analytics_history.py
@@ -64,9 +64,13 @@ def test_personal_history_requires_auth(db):
     assert resp.status_code == 401
 
 
-def test_personal_history_returns_seeded_rows_newest_first(http, db):
-    scan_results_repo.insert(db, owner="acme", score=60, total_checks=3, failed_checks=1, checks=[])
-    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+def test_personal_history_returns_seeded_rows_newest_first(http, db, mock_user):
+    scan_results_repo.insert(
+        db, owner="acme", score=60, total_checks=3, failed_checks=1, checks=[], scanned_by_user_id=mock_user.id
+    )
+    scan_results_repo.insert(
+        db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[], scanned_by_user_id=mock_user.id
+    )
     resp = http.get("/me/analytics/history?owner=acme")
     assert resp.status_code == 200
     body = resp.json()
@@ -75,14 +79,36 @@ def test_personal_history_returns_seeded_rows_newest_first(http, db):
     assert body[1]["score"] == 60
 
 
-def test_personal_history_only_returns_matching_owner(http, db):
-    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
-    scan_results_repo.insert(db, owner="other-org", score=50, total_checks=3, failed_checks=1, checks=[])
+def test_personal_history_only_returns_matching_owner(http, db, mock_user):
+    scan_results_repo.insert(
+        db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[], scanned_by_user_id=mock_user.id
+    )
+    scan_results_repo.insert(
+        db, owner="other-org", score=50, total_checks=3, failed_checks=1, checks=[], scanned_by_user_id=mock_user.id
+    )
     resp = http.get("/me/analytics/history?owner=acme")
     assert resp.status_code == 200
     body = resp.json()
     assert len(body) == 1
     assert body[0]["owner"] == "acme"
+
+
+def test_personal_history_forbidden_when_user_has_no_relationship_to_owner(http, db):
+    # No Org membership, no installation, and no prior scan by this user for
+    # "acme" -- reading its history must be denied, even though rows exist
+    # (seeded here by a different, unrelated persisted scan).
+    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+    resp = http.get("/me/analytics/history?owner=acme")
+    assert resp.status_code == 403
+
+
+def test_personal_history_allowed_via_org_membership_even_without_own_scan(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+    resp = http.get("/me/analytics/history?owner=acme")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
 
 
 def test_scan_results_repo_list_recent_respects_limit(db):
@@ -163,5 +189,7 @@ def test_overview_error_does_not_persist_a_history_row(http):
         resp = http.post("/me/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
     assert resp.status_code == 400
 
+    # No row was persisted (the scan errored before _persist_scan), and this user
+    # has no other relationship to "acme" -- history access is correctly denied.
     history = http.get("/me/analytics/history?owner=acme")
-    assert history.json() == []
+    assert history.status_code == 403

--- a/apps/api/tests/test_analytics_history.py
+++ b/apps/api/tests/test_analytics_history.py
@@ -1,0 +1,167 @@
+"""Tests for the scan history endpoints and insert-after-scan persistence (Phase 10)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo, scan_results_repo
+from src.routers.analytics import router
+
+MOCK_OVERVIEW = {
+    "owner": "acme",
+    "score": 80,
+    "total_checks": 1,
+    "failed_checks": 0,
+    "repo_count": 4,
+    "checks": [
+        {
+            "id": "organization_members_mfa_required",
+            "title": "Organization requires 2FA/MFA",
+            "severity": "high",
+            "remediation": "Enable 2FA.",
+            "status": "pass",
+            "value": True,
+        }
+    ],
+}
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "test@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
+    a = FastAPI()
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture()
+def http(app):
+    return TestClient(app)
+
+
+def test_personal_history_requires_auth(db):
+    a = FastAPI()
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    resp = TestClient(a).get("/me/analytics/history?owner=acme")
+    assert resp.status_code == 401
+
+
+def test_personal_history_returns_seeded_rows_newest_first(http, db):
+    scan_results_repo.insert(db, owner="acme", score=60, total_checks=3, failed_checks=1, checks=[])
+    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+    resp = http.get("/me/analytics/history?owner=acme")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    assert body[0]["score"] == 80
+    assert body[1]["score"] == 60
+
+
+def test_personal_history_only_returns_matching_owner(http, db):
+    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+    scan_results_repo.insert(db, owner="other-org", score=50, total_checks=3, failed_checks=1, checks=[])
+    resp = http.get("/me/analytics/history?owner=acme")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["owner"] == "acme"
+
+
+def test_scan_results_repo_list_recent_respects_limit(db):
+    for score in range(5):
+        scan_results_repo.insert(db, owner="acme", score=score, total_checks=1, failed_checks=0, checks=[])
+    rows = scan_results_repo.list_recent(db, owner="acme", limit=2)
+    assert len(rows) == 2
+    assert rows[0]["score"] == 4  # newest first
+    assert rows[1]["score"] == 3
+
+
+def test_org_history_outsider_forbidden(http, db):
+    org_repo.get_or_create(db, github_login="acme")
+    resp = http.get("/orgs/acme/analytics/history")
+    assert resp.status_code == 403
+
+
+def test_org_history_unknown_org_returns_404(http):
+    resp = http.get("/orgs/does-not-exist/analytics/history")
+    assert resp.status_code == 404
+
+
+def test_org_history_member_ok(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    scan_results_repo.insert(db, owner="acme", score=80, total_checks=3, failed_checks=0, checks=[])
+    resp = http.get("/orgs/acme/analytics/history")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+# ── insert-after-scan integration ────────────────────────────────────────────
+
+
+def test_personal_overview_scan_persists_a_history_row(http, db):
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
+        patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW),
+    ):
+        resp = http.post("/me/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 200
+
+    history = http.get("/me/analytics/history?owner=acme")
+    assert history.status_code == 200
+    body = history.json()
+    assert len(body) == 1
+    assert body[0]["score"] == 80
+    assert body[0]["total_checks"] == 1
+    assert body[0]["failed_checks"] == 0
+
+
+def test_org_overview_scan_persists_a_history_row(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    with patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW):
+        resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 200
+
+    history = http.get("/orgs/acme/analytics/history")
+    assert history.status_code == 200
+    assert len(history.json()) == 1
+
+
+def test_overview_error_does_not_persist_a_history_row(http):
+    import httpx
+
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
+        patch(
+            "src.routers.analytics.get_overview",
+            side_effect=httpx.HTTPStatusError(
+                "not found",
+                request=MagicMock(),
+                response=MagicMock(status_code=404),
+            ),
+        ),
+    ):
+        resp = http.post("/me/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 400
+
+    history = http.get("/me/analytics/history?owner=acme")
+    assert history.json() == []

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { CheckCard } from "@/components/check-card"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -12,7 +12,16 @@ import { Warning, Key } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { DonutChart } from "@/components/charts/donut-chart"
+import { AreaTimeChart } from "@/components/charts/area-time-chart"
 import type { CheckResult } from "@/lib/api/types"
+
+const TABS = [
+  { id: "all", label: "All" },
+  { id: "fail", label: "Failed" },
+  { id: "severity", label: "By Severity" },
+] as const
+
+type TabId = (typeof TABS)[number]["id"]
 
 function ScoreGauge({ score, failed, total }: { score: number; failed: number; total: number }) {
   const r = 38
@@ -63,15 +72,17 @@ function sortChecks(checks: CheckResult[]): CheckResult[] {
 export default function SecurityPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const queryClient = useQueryClient()
 
   const [owner, setOwner] = useState("")
   const [token, setToken] = useState("")
   const [tokenSaved, setTokenSaved] = useState(false)
 
-  const statusFilter   = (searchParams.get("status")   ?? "all") as "all" | "pass" | "fail"
+  const tab = (searchParams.get("tab") ?? "all") as TabId
   const severityFilter = (searchParams.get("severity") ?? "all") as "all" | "high" | "medium" | "low"
+  const statusFilter = tab === "fail" ? "fail" : "all"
 
-  function setFilter(key: "status" | "severity", value: string) {
+  function setFilter(key: "tab" | "severity", value: string) {
     const params = new URLSearchParams(searchParams.toString())
     if (value === "all") params.delete(key)
     else params.set(key, value)
@@ -106,15 +117,32 @@ export default function SecurityPage() {
     onSuccess: () => setTokenSaved(true),
   })
 
+  const historyQuery = useQuery({
+    queryKey: ["analytics.history", owner],
+    queryFn: () => api.analytics.history(owner),
+    enabled: owner.trim().length > 2,
+  })
+
   const scan = useMutation({
     mutationFn: () => api.analytics.overview(owner, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["analytics.history", owner] })
+    },
   })
+
+  const trendData = (historyQuery.data ?? [])
+    .slice(0, 10)
+    .reverse()
+    .map((h) => ({
+      week: new Date(h.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+      value: h.score,
+    }))
 
   const filteredChecks = scan.data
     ? sortChecks(
         scan.data.checks.filter((c) => {
-          if (statusFilter   !== "all" && c.status   !== statusFilter)   return false
-          if (severityFilter !== "all" && c.severity !== severityFilter) return false
+          if (statusFilter !== "all" && c.status !== statusFilter) return false
+          if (tab === "severity" && severityFilter !== "all" && c.severity !== severityFilter) return false
           return true
         }),
       )
@@ -201,50 +229,74 @@ export default function SecurityPage() {
         {(scan.data || scan.isPending) && (
           <div className="bg-card border border-border lg:col-span-2">
             {scan.data && (
-              <>
-                <div className="px-4 py-3 border-b border-border">
-                  <span className="section-title">Results — {scan.data.owner}</span>
-                </div>
+              <div className="px-4 py-3 border-b border-border">
+                <span className="section-title">Results — {scan.data.owner}</span>
+              </div>
+            )}
+
+            {/* Gauge + donut side-by-side */}
+            {scan.data && (
+              <div className="grid sm:grid-cols-2 border-b border-border">
                 <ScoreGauge
                   score={scan.data.score}
                   failed={scan.data.failed_checks}
                   total={scan.data.total_checks}
                 />
-              </>
-            )}
-
-            {/* Filter bar */}
-            {scan.data && (
-              <div className="px-4 py-2.5 border-b border-border flex items-center gap-3">
-                <select
-                  value={statusFilter}
-                  onChange={(e) => setFilter("status", e.target.value)}
-                  className="text-xs bg-card border border-border text-muted-foreground px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                >
-                  <option value="all">All statuses</option>
-                  <option value="fail">Failed only</option>
-                  <option value="pass">Passed only</option>
-                </select>
-                <select
-                  value={severityFilter}
-                  onChange={(e) => setFilter("severity", e.target.value)}
-                  className="text-xs bg-card border border-border text-muted-foreground px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
-                >
-                  <option value="all">All severities</option>
-                  <option value="high">High</option>
-                  <option value="medium">Medium</option>
-                  <option value="low">Low</option>
-                </select>
-                <span className="text-xs text-muted-foreground ml-auto">
-                  {filteredChecks.length} of {scan.data.checks.length}
-                </span>
+                {statusBreakdown.length > 0 && (
+                  <div className="px-4 py-4 sm:border-l border-border">
+                    <DonutChart data={statusBreakdown} label="checks" height={180} />
+                  </div>
+                )}
               </div>
             )}
 
-            {/* Pass/fail breakdown */}
-            {scan.data && statusBreakdown.length > 0 && (
+            {/* Score trend */}
+            {trendData.length > 1 && (
               <div className="px-4 py-4 border-b border-border">
-                <DonutChart data={statusBreakdown} label="checks" height={180} />
+                <span className="text-xs font-medium text-muted-foreground block mb-2">
+                  Score trend (last {trendData.length} scans)
+                </span>
+                <AreaTimeChart data={trendData} label="score" height={140} />
+              </div>
+            )}
+
+            {/* Tabs */}
+            {scan.data && (
+              <div className="px-4 py-2.5 border-b border-border flex items-center gap-3 flex-wrap">
+                <div className="flex items-center gap-1.5">
+                  {TABS.map((t) => {
+                    const active = tab === t.id
+                    return (
+                      <button
+                        key={t.id}
+                        onClick={() => setFilter("tab", t.id)}
+                        aria-pressed={active}
+                        className={`text-xs font-mono px-2 py-1 border transition-colors ${
+                          active
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border text-muted-foreground hover:bg-elevated"
+                        }`}
+                      >
+                        {t.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                {tab === "severity" && (
+                  <select
+                    value={severityFilter}
+                    onChange={(e) => setFilter("severity", e.target.value)}
+                    className="text-xs bg-card border border-border text-muted-foreground px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    <option value="all">All severities</option>
+                    <option value="high">High</option>
+                    <option value="medium">Medium</option>
+                    <option value="low">Low</option>
+                  </select>
+                )}
+                <span className="text-xs text-muted-foreground ml-auto">
+                  {filteredChecks.length} of {scan.data.checks.length}
+                </span>
               </div>
             )}
 

--- a/apps/ui/components/check-card.tsx
+++ b/apps/ui/components/check-card.tsx
@@ -26,6 +26,32 @@ function CheckValueDisplay({ value }: { value: CheckValue }) {
     )
   }
 
+  if (value.type === "severity_counts") {
+    const buckets: { key: keyof typeof value; label: string; className: string }[] = [
+      { key: "critical", label: "critical", className: "text-red-400 border-red-500/30" },
+      { key: "high", label: "high", className: "text-orange-400 border-orange-500/30" },
+      { key: "medium", label: "medium", className: "text-yellow-400 border-yellow-500/30" },
+      { key: "low", label: "low", className: "text-blue-400 border-blue-500/30" },
+    ]
+    const nonZero = buckets.filter((b) => (value[b.key] as number) > 0)
+    if (nonZero.length === 0) {
+      return (
+        <div className="border-t border-border/40 mt-2 pt-2">
+          <span className="text-xs text-green-400 font-mono">✓ No open alerts</span>
+        </div>
+      )
+    }
+    return (
+      <div className="border-t border-border/40 mt-2 pt-2 flex flex-wrap gap-1.5">
+        {nonZero.map((b) => (
+          <span key={b.key} className={`stat-chip ${b.className}`}>
+            {value[b.key] as number} {b.label}
+          </span>
+        ))}
+      </div>
+    )
+  }
+
   if (value.type === "ratio") {
     const { numerator, denominator } = value
     const pct = denominator === 0 ? 0 : Math.round((numerator / denominator) * 100)

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AnalyticsHistoryResponse,
   AnalyticsOverviewResponse,
   AuditLogOut,
   CacheClearResponse,
@@ -124,6 +125,16 @@ function normalizeCheckValue(id: string, raw: unknown): CheckValue {
   if (id === "organization_members_mfa_required") {
     return { type: "boolean", enabled: Boolean(raw) }
   }
+  if (id === "repository_dependabot_alerts_clear" && typeof raw === "object" && raw !== null) {
+    const r = raw as Record<string, unknown>
+    return {
+      type: "severity_counts",
+      critical: Number(r.critical ?? 0),
+      high: Number(r.high ?? 0),
+      medium: Number(r.medium ?? 0),
+      low: Number(r.low ?? 0),
+    }
+  }
   if (typeof raw === "object" && raw !== null) {
     const r = raw as Record<string, unknown>
     if ("checked" in r && "protected" in r) {
@@ -131,6 +142,14 @@ function normalizeCheckValue(id: string, raw: unknown): CheckValue {
     }
     if ("enabled" in r && "total" in r) {
       return { type: "ratio", numerator: Number(r.enabled), denominator: Number(r.total) }
+    }
+    if ("open" in r && "repos_with_alerts" in r && "total_repos" in r) {
+      const total = Number(r.total_repos)
+      return { type: "ratio", numerator: total - Number(r.repos_with_alerts), denominator: total }
+    }
+    if ("repos_checked" in r && "force_push_allowed" in r) {
+      const total = Number(r.repos_checked)
+      return { type: "ratio", numerator: total - Number(r.force_push_allowed), denominator: total }
     }
   }
   return null
@@ -149,6 +168,8 @@ export const api = {
         checks: data.checks.map((c) => ({ ...c, value: normalizeCheckValue(c.id, c.value) })),
       }
     },
+    history: (owner: string) =>
+      get<AnalyticsHistoryResponse>(`/me/analytics/history?owner=${encodeURIComponent(owner)}`),
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -9,7 +9,15 @@ export interface RatioCheckValue {
   denominator: number
 }
 
-export type CheckValue = MFACheckValue | RatioCheckValue | null
+export interface SeverityCountsValue {
+  type: "severity_counts"
+  critical: number
+  high: number
+  medium: number
+  low: number
+}
+
+export type CheckValue = MFACheckValue | RatioCheckValue | SeverityCountsValue | null
 
 export interface CheckResult {
   id: string
@@ -28,6 +36,17 @@ export interface AnalyticsOverviewResponse {
   repo_count: number
   checks: CheckResult[]
 }
+
+export interface ScanHistoryEntry {
+  id: number
+  owner: string
+  score: number
+  total_checks: number
+  failed_checks: number
+  created_at: string
+}
+
+export type AnalyticsHistoryResponse = ScanHistoryEntry[]
 
 export interface CacheEntry {
   id: number

--- a/apps/ui/tests/components/check-card.test.tsx
+++ b/apps/ui/tests/components/check-card.test.tsx
@@ -58,6 +58,37 @@ describe("CheckCard", () => {
     expect(card?.className).not.toContain("border-accent");
   });
 
+  it("renders non-zero severity buckets as chips for a severity_counts value", () => {
+    render(
+      <CheckCard
+        check={{
+          ...baseCheck,
+          status: "fail",
+          value: { type: "severity_counts", critical: 2, high: 0, medium: 1, low: 0 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/2 critical/)).toBeInTheDocument();
+    expect(screen.getByText(/1 medium/)).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ high/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d+ low/)).not.toBeInTheDocument();
+  });
+
+  it("shows a clean-state message when all severity buckets are zero", () => {
+    render(
+      <CheckCard
+        check={{
+          ...baseCheck,
+          status: "pass",
+          value: { type: "severity_counts", critical: 0, high: 0, medium: 0, low: 0 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("✓ No open alerts")).toBeInTheDocument();
+  });
+
   it("falls back to the neutral color for a severity not present in the label map", () => {
     render(
       <CheckCard

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -202,4 +202,34 @@ describe("SecurityPage", () => {
     await waitFor(() => expect(screen.queryByText("Passing check")).not.toBeInTheDocument());
     expect(screen.getByText("Failing check")).toBeInTheDocument();
   });
+
+  it("narrows to a single severity via the By Severity tab's inline select", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 50,
+      total_checks: 2,
+      failed_checks: 2,
+      repo_count: 1,
+      checks: [
+        { id: "check-a", title: "High severity check", severity: "high", remediation: "n/a", status: "fail", value: null },
+        { id: "check-b", title: "Low severity check", severity: "low", remediation: "n/a", status: "fail", value: null },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const scanButton = screen.getByRole("button", { name: /run scan/i });
+    await waitFor(() => expect(scanButton).not.toBeDisabled());
+    fireEvent.click(scanButton);
+
+    await waitFor(() => expect(screen.getByText("High severity check")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "By Severity" }));
+    const severitySelect = await screen.findByDisplayValue("All severities");
+    fireEvent.change(severitySelect, { target: { value: "high" } });
+
+    await waitFor(() => expect(screen.queryByText("Low severity check")).not.toBeInTheDocument());
+    expect(screen.getByText("High severity check")).toBeInTheDocument();
+  });
 });

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -1,14 +1,33 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSyncExternalStore } from "react";
 
 const tokensResolveMock = vi.fn();
 const tokensUpsertMock = vi.fn();
 const analyticsOverviewMock = vi.fn();
+const analyticsHistoryMock = vi.fn();
+
+// A minimal reactive store standing in for Next's router-driven searchParams so a
+// tab click's router.replace(...) actually triggers a re-render in the test, the
+// same way real navigation would.
+let mockSearchParams = new URLSearchParams();
+const searchParamsListeners = new Set<() => void>();
+const routerReplaceMock = vi.fn((url: string) => {
+  mockSearchParams = new URLSearchParams(url.split("?")[1] ?? "");
+  searchParamsListeners.forEach((listener) => listener());
+});
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: routerReplaceMock }),
+  useSearchParams: () =>
+    useSyncExternalStore(
+      (listener) => {
+        searchParamsListeners.add(listener);
+        return () => searchParamsListeners.delete(listener);
+      },
+      () => mockSearchParams,
+    ),
 }));
 
 vi.mock("@/lib/api/client", () => ({
@@ -19,6 +38,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     analytics: {
       overview: (...args: unknown[]) => analyticsOverviewMock(...args),
+      history: (...args: unknown[]) => analyticsHistoryMock(...args),
     },
   },
 }));
@@ -41,7 +61,11 @@ describe("SecurityPage", () => {
     tokensResolveMock.mockReset();
     tokensUpsertMock.mockReset();
     analyticsOverviewMock.mockReset();
+    analyticsHistoryMock.mockReset();
+    routerReplaceMock.mockClear();
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+    analyticsHistoryMock.mockResolvedValue([]);
+    mockSearchParams = new URLSearchParams();
     localStorage.clear();
   });
 
@@ -110,5 +134,72 @@ describe("SecurityPage", () => {
 
     fireEvent.keyDown(tokenInput, { key: "Enter" });
     await waitFor(() => expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", "ghp_test"));
+  });
+
+  it("renders the score trend chart once 2+ history points are available", async () => {
+    analyticsHistoryMock.mockResolvedValue([
+      { id: 2, owner: "acme", score: 90, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" },
+      { id: 1, owner: "acme", score: 70, total_checks: 3, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+    ]);
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 90,
+      total_checks: 0,
+      failed_checks: 0,
+      repo_count: 0,
+      checks: [],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const scanButton = screen.getByRole("button", { name: /run scan/i });
+    await waitFor(() => expect(scanButton).not.toBeDisabled());
+    fireEvent.click(scanButton);
+
+    await waitFor(() => expect(screen.getByText(/Score trend \(last 2 scans\)/)).toBeInTheDocument());
+  });
+
+  it("filters checks down to failed only via the Failed tab", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 50,
+      total_checks: 2,
+      failed_checks: 1,
+      repo_count: 1,
+      checks: [
+        {
+          id: "check-a",
+          title: "Passing check",
+          severity: "low",
+          remediation: "n/a",
+          status: "pass",
+          value: null,
+        },
+        {
+          id: "check-b",
+          title: "Failing check",
+          severity: "high",
+          remediation: "n/a",
+          status: "fail",
+          value: null,
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const scanButton = screen.getByRole("button", { name: /run scan/i });
+    await waitFor(() => expect(scanButton).not.toBeDisabled());
+    fireEvent.click(scanButton);
+
+    await waitFor(() => expect(screen.getByText("Passing check")).toBeInTheDocument());
+    expect(screen.getByText("Failing check")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Failed" }));
+
+    await waitFor(() => expect(screen.queryByText("Passing check")).not.toBeInTheDocument());
+    expect(screen.getByText("Failing check")).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -79,6 +79,96 @@ describe("optional token coercion (GitHub App installation fallback)", () => {
   });
 });
 
+describe("api.analytics value normalization", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("normalizes the Dependabot check's raw counts into a severity_counts value", async () => {
+    stubOkJson({
+      owner: "acme",
+      score: 50,
+      total_checks: 1,
+      failed_checks: 1,
+      repo_count: 1,
+      checks: [
+        {
+          id: "repository_dependabot_alerts_clear",
+          title: "No open critical/high Dependabot alerts",
+          severity: "high",
+          remediation: "n/a",
+          status: "fail",
+          value: { critical: 2, high: 1, medium: 0, low: 3 },
+        },
+      ],
+    });
+    const result = await api.analytics.overview("acme", "ghp_test");
+    expect(result.checks[0].value).toEqual({ type: "severity_counts", critical: 2, high: 1, medium: 0, low: 3 });
+  });
+
+  it("normalizes the code-scanning check's raw shape into a ratio value", async () => {
+    stubOkJson({
+      owner: "acme",
+      score: 50,
+      total_checks: 1,
+      failed_checks: 1,
+      repo_count: 4,
+      checks: [
+        {
+          id: "repository_code_scanning_alerts_clear",
+          title: "No open code scanning alerts",
+          severity: "medium",
+          remediation: "n/a",
+          status: "fail",
+          value: { open: 3, repos_with_alerts: 1, total_repos: 4 },
+        },
+      ],
+    });
+    const result = await api.analytics.overview("acme", "ghp_test");
+    expect(result.checks[0].value).toEqual({ type: "ratio", numerator: 3, denominator: 4 });
+  });
+
+  it("normalizes the force-push check's raw shape into a ratio value", async () => {
+    stubOkJson({
+      owner: "acme",
+      score: 50,
+      total_checks: 1,
+      failed_checks: 1,
+      repo_count: 2,
+      checks: [
+        {
+          id: "repository_default_branch_no_force_push",
+          title: "Default branch disallows force pushes",
+          severity: "high",
+          remediation: "n/a",
+          status: "fail",
+          value: { repos_checked: 2, force_push_allowed: 1 },
+        },
+      ],
+    });
+    const result = await api.analytics.overview("acme", "ghp_test");
+    expect(result.checks[0].value).toEqual({ type: "ratio", numerator: 1, denominator: 2 });
+  });
+
+  it("GETs /me/analytics/history?owner=... and returns the raw scan history", async () => {
+    stubOkJson([{ id: 1, owner: "acme", score: 80, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" }]);
+    const result = await api.analytics.history("acme");
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/analytics/history?owner=acme");
+    expect(result).toEqual([
+      { id: 1, owner: "acme", score: 80, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" },
+    ]);
+  });
+});
+
 describe("api.repos", () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -161,3 +161,128 @@ class SecretScanningEnabled(Check):
                 enabled += 1
         compliant = enabled == total
         return {"status": "pass" if compliant else "fail", "value": {"enabled": enabled, "total": total}}
+
+
+class DependabotAlertsCheck(Check):
+    metadata = CheckMetadata(
+        check_id="repository_dependabot_alerts_clear",
+        title="No open critical/high Dependabot alerts",
+        severity="high",
+        remediation="Resolve or dismiss open Dependabot alerts, prioritizing critical and high severity.",
+    )
+
+    def run(
+        self,
+        owner: str,
+        token: str,
+        base_url: str = "https://api.github.com",
+        repos: list | None = None,
+    ) -> dict:
+        if repos is None:
+            repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if len(repos) == 0:
+            return {"status": "not_applicable", "value": {"critical": 0, "high": 0, "medium": 0, "low": 0}}
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        for repo in repos:
+            try:
+                alerts = _get(
+                    f"{base_url}/repos/{owner}/{repo['name']}/dependabot/alerts?state=open", token
+                )
+            except httpx.HTTPStatusError as exc:
+                # Dependabot alerts disabled/inaccessible for this repo (404) or the
+                # token lacks the security-events scope for it (403) — treat as no
+                # alerts for that repo rather than failing the whole check.
+                if exc.response.status_code in (403, 404):
+                    continue
+                raise
+            for alert in alerts:
+                severity = (alert.get("security_advisory") or {}).get("severity")
+                if severity in counts:
+                    counts[severity] += 1
+        compliant = counts["critical"] == 0 and counts["high"] == 0
+        return {"status": "pass" if compliant else "fail", "value": counts}
+
+
+class CodeScanningCheck(Check):
+    metadata = CheckMetadata(
+        check_id="repository_code_scanning_alerts_clear",
+        title="No open code scanning alerts",
+        severity="medium",
+        remediation="Resolve open code scanning alerts surfaced by CodeQL or a connected SAST tool.",
+    )
+
+    def run(
+        self,
+        owner: str,
+        token: str,
+        base_url: str = "https://api.github.com",
+        repos: list | None = None,
+    ) -> dict:
+        if repos is None:
+            repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        total_repos = len(repos)
+        if total_repos == 0:
+            return {"status": "not_applicable", "value": {"open": 0, "repos_with_alerts": 0, "total_repos": 0}}
+        open_count = 0
+        repos_with_alerts = 0
+        for repo in repos:
+            try:
+                alerts = _get(
+                    f"{base_url}/repos/{owner}/{repo['name']}/code-scanning/alerts?state=open", token
+                )
+            except httpx.HTTPStatusError as exc:
+                # Code scanning not enabled for this repo (404) or no access (403) —
+                # treat as no alerts for that repo rather than failing the whole check.
+                if exc.response.status_code in (403, 404):
+                    continue
+                raise
+            if alerts:
+                repos_with_alerts += 1
+                open_count += len(alerts)
+        value = {"open": open_count, "repos_with_alerts": repos_with_alerts, "total_repos": total_repos}
+        return {"status": "pass" if open_count == 0 else "fail", "value": value}
+
+
+class DefaultBranchNoForcePushCheck(Check):
+    metadata = CheckMetadata(
+        check_id="repository_default_branch_no_force_push",
+        title="Default branch disallows force pushes",
+        severity="high",
+        remediation="Disable 'Allow force pushes' in the default branch's protection rules.",
+    )
+
+    def run(
+        self,
+        owner: str,
+        token: str,
+        base_url: str = "https://api.github.com",
+        repos: list | None = None,
+    ) -> dict:
+        if repos is None:
+            repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if len(repos) == 0:
+            return {"status": "not_applicable", "value": {"repos_checked": 0, "force_push_allowed": 0}}
+        checked = 0
+        force_push_allowed = 0
+        unknown = 0
+        for repo in repos:
+            branch = repo.get("default_branch")
+            try:
+                details = _get(f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}", token)
+            except httpx.HTTPError:
+                # Unprotected (404), rate-limited/no-access (403/429), or a network
+                # error — force-push status can't be evaluated, so exclude the repo
+                # from the denominator rather than counting it as compliant.
+                unknown += 1
+                continue
+            checked += 1
+            protection = details.get("protection") or {}
+            allow_force_pushes = (protection.get("allow_force_pushes") or {}).get("enabled")
+            if allow_force_pushes:
+                force_push_allowed += 1
+        if checked == 0:
+            return {"status": "error", "value": {"repos_checked": checked, "force_push_allowed": force_push_allowed}}
+        return {
+            "status": "pass" if force_push_allowed == 0 else "fail",
+            "value": {"repos_checked": checked, "force_push_allowed": force_push_allowed},
+        }

--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -183,22 +183,29 @@ class DependabotAlertsCheck(Check):
         if len(repos) == 0:
             return {"status": "not_applicable", "value": {"critical": 0, "high": 0, "medium": 0, "low": 0}}
         counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        forbidden = 0
         for repo in repos:
             try:
                 alerts = _get(
                     f"{base_url}/repos/{owner}/{repo['name']}/dependabot/alerts?state=open", token
                 )
             except httpx.HTTPStatusError as exc:
-                # Dependabot alerts disabled/inaccessible for this repo (404) or the
-                # token lacks the security-events scope for it (403) — treat as no
-                # alerts for that repo rather than failing the whole check.
-                if exc.response.status_code in (403, 404):
+                # 404 means Dependabot alerts are genuinely disabled for this repo --
+                # a real "no alerts" answer. 403 means the token lacks the
+                # security-events scope for it -- the alert count for that repo is
+                # unknown, not zero, so it must not silently count toward "clear".
+                if exc.response.status_code == 404:
+                    continue
+                if exc.response.status_code == 403:
+                    forbidden += 1
                     continue
                 raise
             for alert in alerts:
                 severity = (alert.get("security_advisory") or {}).get("severity")
                 if severity in counts:
                     counts[severity] += 1
+        if forbidden == len(repos):
+            return {"status": "error", "value": counts}
         compliant = counts["critical"] == 0 and counts["high"] == 0
         return {"status": "pass" if compliant else "fail", "value": counts}
 
@@ -225,21 +232,28 @@ class CodeScanningCheck(Check):
             return {"status": "not_applicable", "value": {"open": 0, "repos_with_alerts": 0, "total_repos": 0}}
         open_count = 0
         repos_with_alerts = 0
+        forbidden = 0
         for repo in repos:
             try:
                 alerts = _get(
                     f"{base_url}/repos/{owner}/{repo['name']}/code-scanning/alerts?state=open", token
                 )
             except httpx.HTTPStatusError as exc:
-                # Code scanning not enabled for this repo (404) or no access (403) —
-                # treat as no alerts for that repo rather than failing the whole check.
-                if exc.response.status_code in (403, 404):
+                # 404 means code scanning is genuinely not enabled for this repo -- a
+                # real "no alerts" answer. 403 means no access -- that repo's alert
+                # count is unknown, not zero, so it must not silently count as clear.
+                if exc.response.status_code == 404:
+                    continue
+                if exc.response.status_code == 403:
+                    forbidden += 1
                     continue
                 raise
             if alerts:
                 repos_with_alerts += 1
                 open_count += len(alerts)
         value = {"open": open_count, "repos_with_alerts": repos_with_alerts, "total_repos": total_repos}
+        if forbidden == total_repos:
+            return {"status": "error", "value": value}
         return {"status": "pass" if open_count == 0 else "fail", "value": value}
 
 

--- a/packages/checks/src/checks/runner.py
+++ b/packages/checks/src/checks/runner.py
@@ -1,6 +1,14 @@
 import logging
 
-from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled, _get_all_pages
+from checks.github_checks import (
+    BranchProtectionEnabled,
+    CodeScanningCheck,
+    DefaultBranchNoForcePushCheck,
+    DependabotAlertsCheck,
+    OrgMFARequired,
+    SecretScanningEnabled,
+    _get_all_pages,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -8,7 +16,14 @@ logger = logging.getLogger(__name__)
 def run_all_checks(owner: str, token: str, base_url: str = "https://api.github.com") -> dict:
     repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
 
-    checks = [OrgMFARequired(), BranchProtectionEnabled(), SecretScanningEnabled()]
+    checks = [
+        OrgMFARequired(),
+        BranchProtectionEnabled(),
+        SecretScanningEnabled(),
+        DependabotAlertsCheck(),
+        CodeScanningCheck(),
+        DefaultBranchNoForcePushCheck(),
+    ]
     results = []
     for check in checks:
         try:

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -5,7 +5,15 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled, _get
+from checks.github_checks import (
+    BranchProtectionEnabled,
+    CodeScanningCheck,
+    DefaultBranchNoForcePushCheck,
+    DependabotAlertsCheck,
+    OrgMFARequired,
+    SecretScanningEnabled,
+    _get,
+)
 
 
 def test_org_mfa_missing_field_returns_error():
@@ -104,3 +112,170 @@ def test_get_gives_up_after_3_attempts_on_persistent_connection_error():
         with pytest.raises(httpx.ConnectError):
             _get("https://x/y", "tok")
     assert mock_get.call_count == 3
+
+
+# ── DependabotAlertsCheck ────────────────────────────────────────────────────
+
+
+def test_dependabot_empty_org_is_not_applicable():
+    check = DependabotAlertsCheck()
+    result = check.run(owner="acme", token="tok", repos=[])
+    assert result["status"] == "not_applicable"
+    assert result["value"] == {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+
+def test_dependabot_aggregates_severity_counts_across_repos():
+    check = DependabotAlertsCheck()
+    repos = [{"name": "api"}, {"name": "ui"}]
+    responses = {
+        "api": [{"security_advisory": {"severity": "critical"}}, {"security_advisory": {"severity": "low"}}],
+        "ui": [{"security_advisory": {"severity": "high"}}],
+    }
+
+    def fake_get(url, token):
+        for name, alerts in responses.items():
+            if f"/{name}/dependabot/alerts" in url:
+                return alerts
+        raise AssertionError(f"unexpected url {url}")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
+    assert result["value"] == {"critical": 1, "high": 1, "medium": 0, "low": 1}
+
+
+def test_dependabot_passes_when_no_critical_or_high():
+    check = DependabotAlertsCheck()
+    repos = [{"name": "api"}]
+
+    def fake_get(url, token):
+        return [{"security_advisory": {"severity": "low"}}]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "pass"
+
+
+def test_dependabot_disabled_repo_404_counts_as_zero_alerts():
+    check = DependabotAlertsCheck()
+    repos = [{"name": "api"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(404, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("not found", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "pass"
+    assert result["value"] == {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+
+def test_dependabot_non_404_403_error_propagates():
+    check = DependabotAlertsCheck()
+    repos = [{"name": "api"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(500, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("server error", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        with pytest.raises(httpx.HTTPStatusError):
+            check.run(owner="acme", token="tok", repos=repos)
+
+
+# ── CodeScanningCheck ────────────────────────────────────────────────────────
+
+
+def test_code_scanning_empty_org_is_not_applicable():
+    check = CodeScanningCheck()
+    result = check.run(owner="acme", token="tok", repos=[])
+    assert result["status"] == "not_applicable"
+    assert result["value"] == {"open": 0, "repos_with_alerts": 0, "total_repos": 0}
+
+
+def test_code_scanning_counts_open_alerts_and_affected_repos():
+    check = CodeScanningCheck()
+    repos = [{"name": "api"}, {"name": "ui"}]
+
+    def fake_get(url, token):
+        if "/api/" in url:
+            return [{"number": 1}, {"number": 2}]
+        return []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
+    assert result["value"] == {"open": 2, "repos_with_alerts": 1, "total_repos": 2}
+
+
+def test_code_scanning_disabled_repo_404_counts_as_zero_alerts():
+    check = CodeScanningCheck()
+    repos = [{"name": "api"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(404, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("not found", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "pass"
+    assert result["value"] == {"open": 0, "repos_with_alerts": 0, "total_repos": 1}
+
+
+# ── DefaultBranchNoForcePushCheck ────────────────────────────────────────────
+
+
+def test_force_push_empty_org_is_not_applicable():
+    check = DefaultBranchNoForcePushCheck()
+    result = check.run(owner="acme", token="tok", repos=[])
+    assert result["status"] == "not_applicable"
+    assert result["value"] == {"repos_checked": 0, "force_push_allowed": 0}
+
+
+def test_force_push_passes_when_disallowed():
+    check = DefaultBranchNoForcePushCheck()
+    repos = [{"name": "api", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        return {"protection": {"allow_force_pushes": {"enabled": False}}}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "pass"
+    assert result["value"] == {"repos_checked": 1, "force_push_allowed": 0}
+
+
+def test_force_push_fails_when_allowed():
+    check = DefaultBranchNoForcePushCheck()
+    repos = [{"name": "api", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        return {"protection": {"allow_force_pushes": {"enabled": True}}}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
+    assert result["value"] == {"repos_checked": 1, "force_push_allowed": 1}
+
+
+def test_force_push_unprotected_branch_excluded_from_denominator():
+    check = DefaultBranchNoForcePushCheck()
+    repos = [{"name": "api", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(404, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("not found", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+    assert result["value"] == {"repos_checked": 0, "force_push_allowed": 0}

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -173,6 +173,40 @@ def test_dependabot_disabled_repo_404_counts_as_zero_alerts():
     assert result["value"] == {"critical": 0, "high": 0, "medium": 0, "low": 0}
 
 
+def test_dependabot_all_repos_forbidden_returns_error_not_false_pass():
+    # A token lacking the security-events scope gets a 403 (not 404) from every
+    # repo -- that must surface as "unknown", not silently render as "clear".
+    check = DependabotAlertsCheck()
+    repos = [{"name": "api"}, {"name": "ui"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(403, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+
+
+def test_dependabot_mixed_403_and_clean_repos_still_passes():
+    # Only some repos are forbidden -- the rest were genuinely evaluated as clear,
+    # so this should NOT be forced to "error".
+    check = DependabotAlertsCheck()
+    repos = [{"name": "forbidden"}, {"name": "clean"}]
+
+    def fake_get(url, token):
+        if "/forbidden/" in url:
+            response = httpx.Response(403, request=httpx.Request("GET", url))
+            raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+        return []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "pass"
+
+
 def test_dependabot_non_404_403_error_propagates():
     check = DependabotAlertsCheck()
     repos = [{"name": "api"}]
@@ -226,6 +260,20 @@ def test_code_scanning_disabled_repo_404_counts_as_zero_alerts():
         result = check.run(owner="acme", token="tok", repos=repos)
     assert result["status"] == "pass"
     assert result["value"] == {"open": 0, "repos_with_alerts": 0, "total_repos": 1}
+
+
+def test_code_scanning_all_repos_forbidden_returns_error_not_false_pass():
+    check = CodeScanningCheck()
+    repos = [{"name": "api"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(403, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
 
 
 # ── DefaultBranchNoForcePushCheck ────────────────────────────────────────────

--- a/packages/checks/tests/test_runner.py
+++ b/packages/checks/tests/test_runner.py
@@ -20,11 +20,16 @@ def test_run_all_checks_fetches_repos_once():
         patch("checks.runner._get_all_pages", return_value=FAKE_REPOS) as mock_pages,
         patch("checks.github_checks._get") as mock_get,
     ):
-        # _get is called for: org detail (MFA) + N branch details (BranchProtection)
-        mock_get.side_effect = lambda url, token: (
-            FAKE_ORG if "/orgs/" in url and "/repos" not in url and "/branches" not in url
-            else FAKE_BRANCH
-        )
+        # _get is called for: org detail (MFA), N branch details (BranchProtection +
+        # DefaultBranchNoForcePushCheck), and N dependabot/code-scanning alert lists.
+        def fake_get(url, token):
+            if "/orgs/" in url and "/repos" not in url:
+                return FAKE_ORG
+            if "/branches/" in url:
+                return FAKE_BRANCH
+            return []  # dependabot/code-scanning alert lists
+
+        mock_get.side_effect = fake_get
 
         result = run_all_checks(owner="acme", token="tok")
 
@@ -33,12 +38,15 @@ def test_run_all_checks_fetches_repos_once():
         "https://api.github.com", "/orgs/acme/repos", "tok"
     )
 
-    # Sanity: all 3 checks returned results
-    assert len(result["checks"]) == 3
+    # Sanity: all 6 checks returned results
+    assert len(result["checks"]) == 6
     check_ids = {c["id"] for c in result["checks"]}
     assert "organization_members_mfa_required" in check_ids
     assert "repository_default_branch_protection_enabled" in check_ids
     assert "repository_secret_scanning_enabled" in check_ids
+    assert "repository_dependabot_alerts_clear" in check_ids
+    assert "repository_code_scanning_alerts_clear" in check_ids
+    assert "repository_default_branch_no_force_push" in check_ids
 
     # repo_count is surfaced so callers (e.g. the analytics overview) don't have
     # to re-fetch the org's repo list just to get a count.


### PR DESCRIPTION
## Summary

Closes #177. Implements Phase 10 ("Security Dashboard v2"), which was previously entirely unbuilt:

- **3 new security checks** (`packages/checks/src/checks/github_checks.py`): `DependabotAlertsCheck` (severity/critical-high aggregation), `CodeScanningCheck` (open alert counts), `DefaultBranchNoForcePushCheck` (force-push protection on the default branch). All three are registered in `runner.py`'s hard-coded check list and reuse the shared per-org repo list the runner already fetches once, matching the existing checks' pattern exactly.
- **Persisted scan history**: a new `scan_results` table (see migration note below), a `scan_results_repo`, and `GET /orgs/{org}/analytics/history` + `GET /me/analytics/history` endpoints (mirroring the existing overview endpoint pair). A row is inserted after every successful scan.
- **Security page redesign**: score gauge + donut now sit side-by-side, a new "Score trend (last N scans)" panel (reusing the existing `AreaTimeChart`) fed by the new history endpoint and refetched immediately after each scan, and the old status/severity `<select>` filters are replaced with `[All][Failed][By Severity]` tabs (styled like the Activity page's existing filter-chip pattern). `CheckValueDisplay` gains a `severity_counts` variant rendering color-coded chips for the Dependabot check's `{critical, high, medium, low}` shape.

## Why these specific decisions

- **Each new check treats a 404/403 from its per-repo endpoint as "not enabled for this repo," not an error** — Dependabot/code scanning being off for a given repo is expected and shouldn't fail the whole org-wide check. This mirrors `BranchProtectionEnabled`'s existing unknown/unprotected handling.
- **The `scan_results` insert lives in the router layer, not inside `analytics_service.py`** as the plan doc's literal wording suggests. `analytics_service.py` doesn't take a `db` param today and stays GitHub-only; routers already own persistence elsewhere in this codebase (e.g. `jobs.py`), so the insert happens in `org_analytics_overview`/`personal_analytics_overview` right after `_run_overview` succeeds. This is a deliberate deviation from the plan doc, not an oversight.
- **The code-scanning and force-push checks' values are rendered via the existing `ratio` display** (via new shape-sniffing branches in `normalizeCheckValue`), inverted so the numerator is always "clean repos out of total" — consistent with the existing `protected`/`enabled` ratio semantics. Only Dependabot's 4-bucket severity counts needed a new value type.
- **Org-scoped history endpoint exists server-side but isn't wired into the UI client** — same as the existing org-scoped overview endpoint, which the client also doesn't call. The personal `/me/...` path is what the Security page actually uses today.

## Schema change

**This PR includes a new Alembic migration**: `apps/api/alembic/versions/0015_add_scan_results.py`. It's additive-only — a new `scan_results` table (`id, owner, score, total_checks, failed_checks, checks_json, created_at`) plus a composite index on `(owner, created_at)`. No existing table, column, or constraint is altered or dropped. This was necessary because scan results previously had zero persistence — every scan was a one-off snapshot, which is exactly the gap issue #177 calls out ("no way to see a security score's trend over time"). Hand-authored (not autogenerated) to match `0001_initial_schema.py`'s existing `create_table` style; verified locally via `alembic upgrade head` against the dev Postgres container.

## Explicitly out of scope

- Any GitHub check beyond the 3 named in the issue (e.g. a dedicated secret-scanning *alerts* check, vs. the existing enablement-only `SecretScanningEnabled` — not requested).
- Wiring the org-scoped history endpoint into the UI client (parity endpoint only, matching the existing overview convention).
- Any FK relationship between `scan_results` and `orgs`/repos — kept as a loose string `owner` column, matching `SavedToken.org`'s existing style.

## Test plan

- [x] `pytest -q packages/checks/tests apps/api/tests` — 321 passed
- [x] `alembic upgrade head` against dev Postgres — migration applies cleanly
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` — 172 passed (27 files)
- [x] New backend tests cover: pass/fail/not_applicable per new check, 404-as-zero handling per check, history endpoint ordering/limit/scoping (org membership required, personal requires auth), insert-after-scan integration
- [x] New frontend tests cover: severity chips render/hide zero buckets, trend chart appears once 2+ history points exist, Failed tab narrows the check list
- [ ] Not manually verified in a running browser — no local dev server was started for this change; typecheck/lint/build/tests are the verification basis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: code-review fixes (second commit)

`/code-review high` against issue #177's text surfaced two real bugs, fixed in a follow-up commit on this branch:

- **Authorization gap**: `GET /me/analytics/history` had no ownership check — any authenticated user could read any org's persisted scan history by naming it. Fixed with a new `scan_results.scanned_by_user_id` column and a membership/installation/prior-scan gate.
- **False "pass" under insufficient token scope**: `DependabotAlertsCheck`/`CodeScanningCheck` treated 403 the same as 404, silently reporting "clean" when the token just couldn't see the data. Now returns `error` when every repo was forbidden.

**This PR now includes a second schema change**: migration `0016_add_scan_results_scanned_by_user_id.py` — additive-only (new nullable FK column), no backfill or data-loss risk, needed to fix the authorization gap above (personal scans against an owner with no workspace Org row had no other way to record who's allowed to read that owner's history back).

See the review summary comment on this PR for full details.
