### PR TITLE
feat(api,ui): add Overview cockpit aggregate endpoint and trends (Phase 12)

### DIFF
--- a/apps/api/src/repositories/job_repo.py
+++ b/apps/api/src/repositories/job_repo.py
@@ -30,6 +30,17 @@ def list_jobs(db: Session, limit: int = 50) -> list[dict]:
     ]
 
 
+def list_recent_by_type(db: Session, job_type: str, limit: int = 20) -> list[dict]:
+    rows = (
+        db.query(Job)
+        .filter(Job.job_type == job_type)
+        .order_by(Job.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return [{"id": r.id, "status": r.status} for r in rows]
+
+
 def mark_done(db: Session, job_id: int, result: str) -> None:
     db.query(Job).filter(Job.id == job_id).update(
         {"status": "done", "result": result, "updated_at": func.now()}

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -1,21 +1,38 @@
+import asyncio
 import logging
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
 
 import anyio
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
-from src.repositories import installation_repo, org_membership_repo, org_repo, scan_results_repo
-from src.schemas.analytics import AnalyticsInput, AnalyticsResponse, ScanHistoryEntry
+from src.repositories import installation_repo, job_repo, org_membership_repo, org_repo, scan_results_repo
+from src.routers.github import _cached_events
+from src.schemas.analytics import (
+    AnalyticsInput,
+    AnalyticsResponse,
+    CockpitResponse,
+    OrgEventSummary,
+    PrWeekBucket,
+    ScanHistoryEntry,
+)
 from src.services.analytics_service import get_account_type, get_overview
+from src.services.github_client import GitHubClient, github_error as _github_error
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Bounds the per-repo fan-out in _safe_commit_activity_4w / _safe_total_cache_bytes --
+# each additional repo costs one more GitHub call, so large orgs are capped.
+_MAX_REPOS_FOR_AGGREGATES = 30
+_CACHE_JOB_TYPE = "github.clear_actions_cache"
 
 
 async def _run_overview(owner: str, token: str) -> AnalyticsResponse:
@@ -129,3 +146,178 @@ def personal_analytics_history(
     if not _user_can_read_history(db, user, owner):
         raise HTTPException(status_code=403, detail="You don't have access to this owner's scan history")
     return scan_results_repo.list_recent(db, owner=owner, limit=30)
+
+
+# ---------------------------------------------------------------------------
+# Overview cockpit (docs/plan.md Phase 12) -- aggregates DB reads plus several
+# independent GitHub calls into one response. Each GitHub-calling helper below
+# is best-effort except _safe_list_repos: a degraded cockpit (missing PR data
+# because search was rate-limited, say) is more useful to an org-health
+# dashboard than a 500/503 for the whole page, but nothing here is computable
+# without at least the repo list, so that one call is allowed to fail hard.
+# ---------------------------------------------------------------------------
+
+
+def _safe_list_repos(owner: str, token: str) -> list[dict]:
+    client = GitHubClient(token)
+    return client.request_paginated(f"/orgs/{owner}/repos", params={"type": "all", "sort": "pushed"})
+
+
+def _safe_member_count(owner: str, token: str) -> int:
+    try:
+        client = GitHubClient(token)
+        return len(client.request_paginated(f"/orgs/{owner}/members"))
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return 0
+
+
+def _safe_recent_events(owner: str, token: str) -> list[OrgEventSummary]:
+    try:
+        events = _cached_events(owner, token, per_page=10).events
+        return [OrgEventSummary(**e.model_dump()) for e in events[:5]]
+    except (httpx.HTTPStatusError, httpx.RequestError, HTTPException):
+        return []
+
+
+def _week_start(weeks_ago: int) -> date:
+    today = date.today()
+    start_of_this_week = today - timedelta(days=today.weekday())
+    return start_of_this_week - timedelta(weeks=weeks_ago)
+
+
+def _search_count(client: GitHubClient, query: str) -> int:
+    result = client.request("GET", "/search/issues", params={"q": query, "per_page": 1})
+    return result.get("total_count", 0) if isinstance(result, dict) else 0
+
+
+def _safe_open_pr_count(owner: str, token: str) -> int:
+    try:
+        client = GitHubClient(token)
+        return _search_count(client, f"org:{owner} type:pr state:open")
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return 0
+
+
+def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
+    try:
+        client = GitHubClient(token)
+        week_starts = [_week_start(weeks_ago) for weeks_ago in range(3, -1, -1)]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [
+                (
+                    start,
+                    pool.submit(_search_count, client, f"org:{owner} type:pr created:{start}..{start + timedelta(days=7)}"),
+                    pool.submit(_search_count, client, f"org:{owner} type:pr merged:{start}..{start + timedelta(days=7)}"),
+                )
+                for start in week_starts
+            ]
+            return [
+                PrWeekBucket(week=start.isoformat(), opened=opened_f.result(), merged=merged_f.result())
+                for start, opened_f, merged_f in futures
+            ]
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return []
+
+
+def _safe_commit_activity_4w(owner: str, token: str, repo_names: list[str]) -> list[int]:
+    # A single failing repo zeroes the whole aggregate rather than partially summing --
+    # simpler than reconciling "which repos contributed" and consistent with this
+    # function's own all-or-nothing best-effort contract to its caller.
+    try:
+        client = GitHubClient(token)
+        totals = [0, 0, 0, 0]
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [
+                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
+            ]
+            for future in futures:
+                weeks = future.result()
+                if isinstance(weeks, list) and len(weeks) >= 4:
+                    for i, week in enumerate(weeks[-4:]):
+                        totals[i] += week.get("total", 0)
+        return totals
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return [0, 0, 0, 0]
+
+
+def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> int:
+    try:
+        client = GitHubClient(token)
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [
+                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/actions/caches")
+                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
+            ]
+            results = [future.result() for future in futures]
+            return sum(
+                sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
+                for data in results
+                if isinstance(data, dict)
+            )
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return 0
+
+
+def _cache_job_success_rate(db: Session) -> float:
+    jobs = job_repo.list_recent_by_type(db, job_type=_CACHE_JOB_TYPE, limit=20)
+    done = sum(1 for j in jobs if j["status"] == "done")
+    failed = sum(1 for j in jobs if j["status"] == "failed")
+    return done / (done + failed) if (done + failed) else 0.0
+
+
+@router.get("/me/analytics/cockpit/{owner}", response_model=CockpitResponse)
+async def personal_analytics_cockpit(
+    owner: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = await anyio.to_thread.run_sync(
+            lambda: resolve_personal_token(
+                db, owner_user_id=user.id, account_login=owner, client_token=x_github_token
+            )
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    scans = scan_results_repo.list_recent(db, owner=owner, limit=10)
+    latest_score = scans[0]["score"] if scans else None
+    score_trend = [s["score"] for s in reversed(scans)]
+    cache_job_success_rate = _cache_job_success_rate(db)
+
+    try:
+        repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    repo_names = [r["name"] for r in repos]
+
+    (
+        member_count,
+        recent_events,
+        open_pr_count,
+        pr_merge_rate_4w,
+        commit_activity_4w,
+        total_cache_size_bytes,
+    ) = await asyncio.gather(
+        anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
+        anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
+        anyio.to_thread.run_sync(lambda: _safe_open_pr_count(owner, token)),
+        anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
+        anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w(owner, token, repo_names)),
+        anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
+    )
+
+    return CockpitResponse(
+        repo_count=len(repos),
+        member_count=member_count,
+        latest_score=latest_score,
+        score_trend=score_trend,
+        recent_events=recent_events,
+        open_pr_count=open_pr_count,
+        pr_merge_rate_4w=pr_merge_rate_4w,
+        commit_activity_4w=commit_activity_4w,
+        total_cache_size_bytes=total_cache_size_bytes,
+        cache_job_success_rate=cache_job_success_rate,
+    )

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -26,3 +26,32 @@ class ScanHistoryEntry(BaseModel):
     total_checks: int
     failed_checks: int
     created_at: datetime
+
+
+class OrgEventSummary(BaseModel):
+    id: str
+    type: str
+    actor: str
+    actor_avatar: str
+    repo: str
+    summary: str
+    created_at: datetime
+
+
+class PrWeekBucket(BaseModel):
+    week: str
+    opened: int
+    merged: int
+
+
+class CockpitResponse(BaseModel):
+    repo_count: int
+    member_count: int
+    latest_score: int | None
+    score_trend: list[int]
+    recent_events: list[OrgEventSummary]
+    open_pr_count: int
+    pr_merge_rate_4w: list[PrWeekBucket]
+    commit_activity_4w: list[int]
+    total_cache_size_bytes: int
+    cache_job_success_rate: float

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -1,0 +1,308 @@
+"""Tests for the Overview cockpit aggregate endpoint (docs/plan.md Phase 12)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import Job, User, get_db
+from src.repositories import scan_results_repo
+from src.routers.analytics import router
+
+_HTTP_ERROR = httpx.HTTPStatusError(
+    "boom",
+    request=httpx.Request("GET", "https://api.github.com/x"),
+    response=httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x")),
+)
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "cockpit@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
+    a = FastAPI()
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture()
+def http(app):
+    return TestClient(app)
+
+
+_DEFAULT_SAFE_MOCKS = {
+    "src.routers.analytics._safe_list_repos": {"return_value": [{"name": "api"}, {"name": "worker"}]},
+    "src.routers.analytics._safe_member_count": {"return_value": 12},
+    "src.routers.analytics._safe_recent_events": {"return_value": []},
+    "src.routers.analytics._safe_open_pr_count": {"return_value": 7},
+    "src.routers.analytics._safe_pr_merge_rate_4w": {"return_value": []},
+    "src.routers.analytics._safe_commit_activity_4w": {"return_value": [1, 2, 3, 4]},
+    "src.routers.analytics._safe_total_cache_bytes": {"return_value": 123456},
+}
+
+
+def _patch_all(overrides=None):
+    mocks = dict(_DEFAULT_SAFE_MOCKS)
+    if overrides:
+        mocks.update(overrides)
+    patchers = [patch(target, **kwargs) for target, kwargs in mocks.items()]
+    return patchers
+
+
+def _start_all(patchers):
+    for p in patchers:
+        p.start()
+
+
+def _stop_all(patchers):
+    for p in patchers:
+        p.stop()
+
+
+def test_cockpit_requires_auth(db):
+    a = FastAPI()
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    resp = TestClient(a).get("/me/analytics/cockpit/acme")
+    assert resp.status_code == 401
+
+
+def test_cockpit_no_token_available_returns_400(http):
+    resp = http.get("/me/analytics/cockpit/acme")
+    assert resp.status_code == 400
+
+
+def test_cockpit_success_all_sources(http, db, mock_user):
+    scan_results_repo.insert(db, owner="acme", score=70, total_checks=5, failed_checks=1, checks=[])
+    scan_results_repo.insert(db, owner="acme", score=85, total_checks=5, failed_checks=0, checks=[])
+    for status in ("done", "done", "done", "failed"):
+        job = Job(job_type="github.clear_actions_cache", payload="{}", status=status)
+        db.add(job)
+    db.commit()
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["repo_count"] == 2
+    assert body["member_count"] == 12
+    assert body["open_pr_count"] == 7
+    assert body["commit_activity_4w"] == [1, 2, 3, 4]
+    assert body["total_cache_size_bytes"] == 123456
+    assert body["latest_score"] == 85
+    assert body["score_trend"] == [70, 85]
+    assert body["cache_job_success_rate"] == 0.75
+
+
+def test_cockpit_no_scans_yet(http, db, mock_user):
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["latest_score"] is None
+    assert body["score_trend"] == []
+
+
+def test_cockpit_no_cache_jobs_yet(http, db, mock_user):
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    assert resp.json()["cache_job_success_rate"] == 0.0
+
+
+def test_cockpit_degrades_when_pr_search_fails(http, db, mock_user):
+    patchers = _patch_all({"src.routers.analytics._safe_open_pr_count": {"return_value": 0}})
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["open_pr_count"] == 0
+    assert body["member_count"] == 12  # other fields unaffected
+
+
+def test_cockpit_degrades_when_events_fetch_fails(http, db, mock_user):
+    patchers = _patch_all({"src.routers.analytics._safe_recent_events": {"return_value": []}})
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    assert resp.json()["recent_events"] == []
+
+
+def test_cockpit_fails_when_repo_list_fails(http, db, mock_user):
+    patchers = _patch_all({"src.routers.analytics._safe_list_repos": {"side_effect": _HTTP_ERROR}})
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 400
+
+
+def test_cockpit_falls_back_to_client_supplied_token_header(http, db, mock_user):
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        resp = http.get("/me/analytics/cockpit/acme", headers={"X-GitHub-Token": "ghp_client"})
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual _safe_* helpers' own try/except behavior
+# ---------------------------------------------------------------------------
+
+
+def test_safe_member_count_returns_zero_on_http_error():
+    from src.routers.analytics import _safe_member_count
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _HTTP_ERROR
+        assert _safe_member_count("acme", "ghp_test") == 0
+
+
+def test_safe_member_count_returns_zero_on_request_error():
+    from src.routers.analytics import _safe_member_count
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = httpx.RequestError("boom")
+        assert _safe_member_count("acme", "ghp_test") == 0
+
+
+def test_safe_open_pr_count_returns_zero_on_http_error():
+    from src.routers.analytics import _safe_open_pr_count
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _HTTP_ERROR
+        assert _safe_open_pr_count("acme", "ghp_test") == 0
+
+
+def test_safe_pr_merge_rate_4w_returns_empty_list_on_error():
+    from src.routers.analytics import _safe_pr_merge_rate_4w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_pr_merge_rate_4w("acme", "ghp_test") == []
+
+
+def test_safe_pr_merge_rate_4w_returns_four_chronological_buckets():
+    from src.routers.analytics import _safe_pr_merge_rate_4w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {"total_count": 3}
+        buckets = _safe_pr_merge_rate_4w("acme", "ghp_test")
+    assert len(buckets) == 4
+    weeks = [b.week for b in buckets]
+    assert weeks == sorted(weeks)
+    assert all(b.opened == 3 and b.merged == 3 for b in buckets)
+
+
+def test_safe_commit_activity_4w_returns_zeros_on_error():
+    from src.routers.analytics import _safe_commit_activity_4w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_commit_activity_4w("acme", "ghp_test", ["repo-a"]) == [0, 0, 0, 0]
+
+
+def test_safe_commit_activity_4w_sums_last_four_weeks_across_repos():
+    from src.routers.analytics import _safe_commit_activity_4w
+
+    weeks_a = [{"total": i} for i in range(52)]  # totals 0..51, last 4 are 48,49,50,51
+    weeks_b = [{"total": 1} for _ in range(52)]
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
+        totals = _safe_commit_activity_4w("acme", "ghp_test", ["repo-a", "repo-b"])
+    assert totals == [49, 50, 51, 52]
+
+
+def test_safe_total_cache_bytes_returns_zero_on_error():
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_total_cache_bytes("acme", "ghp_test", ["repo-a"]) == 0
+
+
+def test_safe_total_cache_bytes_sums_across_repos():
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [
+            {"actions_caches": [{"size_in_bytes": 100}, {"size_in_bytes": 50}]},
+            {"actions_caches": [{"size_in_bytes": 25}]},
+        ]
+        total = _safe_total_cache_bytes("acme", "ghp_test", ["repo-a", "repo-b"])
+    assert total == 175
+
+
+def test_cache_job_success_rate_mixed(db):
+    from src.routers.analytics import _cache_job_success_rate
+
+    for status in ("done", "done", "done", "failed"):
+        job = Job(job_type="github.clear_actions_cache", payload="{}", status=status)
+        db.add(job)
+    db.commit()
+    assert _cache_job_success_rate(db) == 0.75
+
+
+def test_cache_job_success_rate_zero_jobs(db):
+    from src.routers.analytics import _cache_job_success_rate
+
+    assert _cache_job_success_rate(db) == 0.0
+
+
+def test_cache_job_success_rate_ignores_other_job_types(db):
+    from src.routers.analytics import _cache_job_success_rate
+
+    job = Job(job_type="some.other.job", payload="{}", status="failed")
+    db.add(job)
+    db.commit()
+    assert _cache_job_success_rate(db) == 0.0

--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -30,6 +30,12 @@ function RefreshCountdown({ resetKey, seconds }: { resetKey: number; seconds: nu
 }
 
 export default function ActivityPage() {
+  // Marks all cockpit-sourced events as read so the sidebar's unread badge
+  // clears once the user has actually looked at this page.
+  useEffect(() => {
+    localStorage.setItem("activity_last_seen_at", new Date().toISOString())
+  }, [])
+
   const { data: jobs = [], isLoading: jobsLoading } = useQuery({
     queryKey: ["jobs"],
     queryFn: api.jobs.list,

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -5,9 +5,12 @@ import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { StatCard } from "@/components/stat-card"
-import { ActivityList } from "@/components/activity-list"
+import { EventActivityList } from "@/components/event-activity-list"
+import { AreaTimeChart } from "@/components/charts/area-time-chart"
+import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { ArrowRight } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
+import { CHART_COLORS } from "@/lib/charts/theme"
 
 const quickActions = [
   { label: "Run Security Scan",  href: "/security" },
@@ -15,11 +18,12 @@ const quickActions = [
   { label: "View Collaborators", href: "/collaborators" },
 ]
 
-function LiveStatCard({ label, loading, configured, value }: {
+function LiveStatCard({ label, loading, configured, value, trend }: {
   label: string
   loading: boolean
   configured: boolean
   value: number | undefined
+  trend?: number[]
 }) {
   if (!configured) {
     return (
@@ -34,36 +38,53 @@ function LiveStatCard({ label, loading, configured, value }: {
     )
   }
 
-  return <StatCard label={label} value={loading ? "…" : (value ?? "—")} />
+  return <StatCard label={label} value={loading ? "…" : (value ?? "—")} trend={trend} />
 }
 
 export default function OverviewPage() {
-  const { data: jobs = [], isLoading } = useQuery({
-    queryKey: ["jobs"],
-    queryFn: api.jobs.list,
-    refetchInterval: 15_000,
-  })
-
   const [org, setOrg] = useState("")
   useEffect(() => {
     setOrg(localStorage.getItem("default_org") || "")
   }, [])
 
+  // Not chained to the cockpit query below — both fire on mount. This one only
+  // drives the "not configured yet" CTA-card branch, matching the pre-cockpit
+  // behavior, so that empty state doesn't regress.
   const resolveQuery = useQuery({
     queryKey: ["tokens.resolve", org],
     queryFn: () => api.tokens.resolve(org),
     enabled: org.trim().length > 2,
     retry: false,
   })
-
   const configured = !!resolveQuery.data?.token
 
-  const overviewQuery = useQuery({
-    queryKey: ["analytics.overview", org],
-    queryFn: () => api.analytics.overview(org, resolveQuery.data!.token),
-    enabled: configured,
+  // Both queries fire as soon as `org` is known (no waterfall) — cockpit just
+  // waits for resolveQuery's fetch to settle (not to finish loading data through
+  // a dependent chain) so a saved PAT isn't missed on the very first request
+  // (queryKey excludes token, so a later-arriving token wouldn't otherwise
+  // trigger a refetch of an already-fired query).
+  const cockpitQuery = useQuery({
+    queryKey: ["analytics.cockpit", org],
+    queryFn: () => api.analytics.cockpit(org, resolveQuery.data?.token),
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
     retry: false,
+    refetchInterval: 30_000,
   })
+  const cockpit = cockpitQuery.data
+
+  const commitActivityData = (cockpit?.commit_activity_4w ?? []).map((value, i) => ({
+    week: `W${i + 1}`,
+    value,
+  }))
+  const scoreTrendData = (cockpit?.score_trend ?? []).map((value, i) => ({
+    week: `Scan ${i + 1}`,
+    value,
+  }))
+  const prMergeRateData = (cockpit?.pr_merge_rate_4w ?? []).map((b) => ({
+    name: b.week,
+    opened: b.opened,
+    merged: b.merged,
+  }))
 
   return (
     <>
@@ -72,44 +93,105 @@ export default function OverviewPage() {
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-px mb-6 border border-border bg-border">
         <LiveStatCard
           label="Repositories"
-          loading={overviewQuery.isLoading}
+          loading={cockpitQuery.isLoading}
           configured={configured}
-          value={overviewQuery.data?.repo_count}
+          value={cockpit?.repo_count}
         />
-        <StatCard label="Open PRs" value="N/A" />
+        <LiveStatCard
+          label="Open PRs"
+          loading={cockpitQuery.isLoading}
+          configured={configured}
+          value={cockpit?.open_pr_count}
+        />
         <LiveStatCard
           label="Security Score"
-          loading={overviewQuery.isLoading}
+          loading={cockpitQuery.isLoading}
           configured={configured}
-          value={overviewQuery.data?.score}
+          value={cockpit?.latest_score ?? undefined}
+          trend={cockpit?.score_trend}
         />
-        <StatCard label="Team Members" value="N/A" />
+        <LiveStatCard
+          label="Team Members"
+          loading={cockpitQuery.isLoading}
+          configured={configured}
+          value={cockpit?.member_count}
+        />
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="lg:col-span-2 card">
+      <div className="grid gap-4 lg:grid-cols-2 mb-6">
+        <div className="card">
           <div className="px-4 py-3 border-b border-border">
-            <span className="section-label">Recent Activity</span>
+            <span className="section-label">Commit Activity (4w)</span>
           </div>
-          <ActivityList jobs={jobs} isLoading={isLoading} limit={5} />
+          <div className="p-4">
+            {commitActivityData.length > 0 ? (
+              <AreaTimeChart data={commitActivityData} label="Commits" color={CHART_COLORS.primary} height={200} />
+            ) : (
+              <p className="text-sm text-muted-foreground">No commit activity yet</p>
+            )}
+          </div>
         </div>
 
         <div className="card">
           <div className="px-4 py-3 border-b border-border">
-            <span className="section-label">Quick Actions</span>
+            <span className="section-label">Security Score</span>
           </div>
-          <div className="p-2">
-            {quickActions.map((action) => (
-              <Link
-                key={action.href}
-                href={action.href}
-                className="flex items-center justify-between px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-elevated transition-colors group"
-              >
-                {action.label}
-                <ArrowRight className="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
-              </Link>
-            ))}
+          <div className="p-4">
+            {scoreTrendData.length > 1 ? (
+              <AreaTimeChart data={scoreTrendData} label="Score" color={CHART_COLORS.series[1]} height={200} />
+            ) : (
+              <p className="text-sm text-muted-foreground">Run more scans to see a trend</p>
+            )}
           </div>
+        </div>
+
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">PR Merge Rate (4w)</span>
+          </div>
+          <div className="p-4">
+            {prMergeRateData.length > 0 ? (
+              <BarGroupChart
+                data={prMergeRateData}
+                bars={[
+                  { key: "opened", color: CHART_COLORS.primary },
+                  { key: "merged", color: CHART_COLORS.series[1] },
+                ]}
+                height={200}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">No pull request activity yet</p>
+            )}
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">Recent Activity</span>
+          </div>
+          <EventActivityList
+            events={cockpit?.recent_events ?? []}
+            isLoading={cockpitQuery.isLoading}
+            limit={5}
+          />
+        </div>
+      </div>
+
+      <div className="card mb-6">
+        <div className="px-4 py-3 border-b border-border">
+          <span className="section-label">Quick Actions</span>
+        </div>
+        <div className="p-2">
+          {quickActions.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              className="flex items-center justify-between px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-elevated transition-colors group"
+            >
+              {action.label}
+              <ArrowRight className="size-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </Link>
+          ))}
         </div>
       </div>
     </>

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -20,17 +20,26 @@ import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 import type { MyOrgMembership } from "@/lib/api/types"
 
+const ACTIVITY_LAST_SEEN_KEY = "activity_last_seen_at"
+
+function healthDotColor(score: number | null | undefined): string | null {
+  if (score == null) return null
+  if (score >= 80) return "bg-green-400"
+  if (score >= 50) return "bg-yellow-400"
+  return "bg-red-400"
+}
+
 // Settings is no longer in the sidebar nav — it lives inside the profile dropdown.
 const groups = [
   [
     { title: "Overview",         href: "/" },
-    { title: "Activity",         href: "/activity" },
+    { title: "Activity",         href: "/activity", showUnreadBadge: true },
     { title: "Pull Requests",    href: "/pulls" },
     { title: "Releases",         href: "/releases" },
   ],
   [
     { title: "Repositories",     href: "/repos" },
-    { title: "Health & Security",href: "/security" },
+    { title: "Health & Security",href: "/security", showHealthDot: true },
   ],
   [
     { title: "Collaborators",    href: "/collaborators" },
@@ -167,6 +176,31 @@ export function AppSidebar() {
     ? `/settings/org/${encodeURIComponent(inviteTarget.org_login)}/members`
     : "/settings"
 
+  // Same resolve-then-use pattern as the Overview page — falls back to a saved
+  // PAT for orgs without a GitHub App installation.
+  const tokenQuery = useQuery({
+    queryKey: ["tokens.resolve", defaultOrg],
+    queryFn: () => api.tokens.resolve(defaultOrg),
+    enabled: defaultOrg.trim().length > 2,
+    retry: false,
+  })
+
+  // Same query key as the Overview page's cockpit query so TanStack Query dedupes
+  // the request when both are mounted (same dedup pattern as ["my-orgs"] above).
+  const { data: cockpit } = useQuery({
+    queryKey: ["analytics.cockpit", defaultOrg],
+    queryFn: () => api.analytics.cockpit(defaultOrg, tokenQuery.data?.token),
+    enabled: defaultOrg.trim().length > 2 && !tokenQuery.isLoading,
+    retry: false,
+    refetchInterval: 30_000,
+  })
+
+  const healthDot = healthDotColor(cockpit?.latest_score)
+  const lastSeenAt = typeof window !== "undefined" ? localStorage.getItem(ACTIVITY_LAST_SEEN_KEY) : null
+  const unreadCount = (cockpit?.recent_events ?? []).filter(
+    (e) => !lastSeenAt || e.created_at > lastSeenAt,
+  ).length
+
   // Close on click outside
   useEffect(() => {
     if (!open) return
@@ -240,6 +274,14 @@ export function AppSidebar() {
                           render={<Link href={item.href} />}
                         >
                           <span>{item.title}</span>
+                          {"showHealthDot" in item && item.showHealthDot && healthDot && (
+                            <span className={`ml-auto size-1.5 rounded-full ${healthDot}`} />
+                          )}
+                          {"showUnreadBadge" in item && item.showUnreadBadge && unreadCount > 0 && (
+                            <span className="ml-auto text-[0.625rem] font-medium bg-primary/20 text-primary rounded-full px-1.5 py-0.5 tabular-nums">
+                              {unreadCount}
+                            </span>
+                          )}
                         </SidebarMenuButton>
                       </SidebarMenuItem>
                     )

--- a/apps/ui/components/event-activity-list.tsx
+++ b/apps/ui/components/event-activity-list.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { relativeTime } from "@/lib/format"
+import type { OrgEvent } from "@/lib/api/types"
+
+interface EventActivityListProps {
+  events: OrgEvent[]
+  isLoading: boolean
+  limit?: number
+}
+
+/** Sibling to ActivityList, rendering GitHub org events instead of JobOut rows. */
+export function EventActivityList({ events, isLoading, limit }: EventActivityListProps) {
+  if (isLoading) {
+    return (
+      <div className="divide-y divide-border">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="px-4 py-3 flex items-center justify-between gap-4 animate-pulse">
+            <div className="flex flex-col gap-1.5">
+              <div className="h-3 w-40 bg-muted rounded-md" />
+              <div className="h-2.5 w-24 bg-muted/60 rounded-md" />
+            </div>
+            <div className="h-2.5 w-14 bg-muted/60 rounded-md" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  const visible = limit ? events.slice(0, limit) : events
+
+  if (visible.length === 0) {
+    return (
+      <div className="px-4 py-8">
+        <p className="text-sm text-muted-foreground font-mono">— no recent activity</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="divide-y divide-border">
+      {visible.map((event, i) => (
+        <div
+          key={event.id}
+          className="stagger-item px-4 py-3 flex items-start justify-between gap-4 hover:bg-elevated transition-colors duration-150 ease-(--ease-out)"
+          style={{ animationDelay: `${Math.min(i, 6) * 45}ms` }}
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm text-foreground/90 truncate">{event.actor}</span>
+              <span className="text-[0.6875rem] text-muted-foreground/80 truncate">{event.summary}</span>
+            </div>
+            <p className="text-[0.6875rem] text-muted-foreground/60 font-mono mt-0.5 truncate">
+              {event.repo}
+            </p>
+          </div>
+          <span className="text-[0.6875rem] text-muted-foreground whitespace-nowrap shrink-0 mt-0.5">
+            {relativeTime(event.created_at)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/ui/components/stat-card.tsx
+++ b/apps/ui/components/stat-card.tsx
@@ -1,14 +1,17 @@
+import { MiniSparkline } from "@/components/charts/mini-sparkline"
+
 interface StatCardProps {
   label: string
   value: string | number
   delta?: number   // optional % change vs last period; positive = up, negative = down
+  trend?: number[] // optional sparkline data, oldest first
 }
 
 /**
  * Compact stat card — label, a large tabular-nums value, and an optional
- * delta showing ↑/↓ trend vs last period.
+ * delta showing ↑/↓ trend vs last period, or a sparkline of recent history.
  */
-export function StatCard({ label, value, delta }: StatCardProps) {
+export function StatCard({ label, value, delta, trend }: StatCardProps) {
   return (
     <div className="bg-card border border-border rounded-md px-4 py-4">
       <p className="telemetry-label mb-2 block">
@@ -21,6 +24,11 @@ export function StatCard({ label, value, delta }: StatCardProps) {
         <p className={`text-xs mt-2 ${delta >= 0 ? "text-accent" : "text-destructive"}`}>
           {delta >= 0 ? "↑" : "↓"} {Math.abs(delta)}% vs last week
         </p>
+      )}
+      {trend && trend.length > 1 && (
+        <div className="mt-2 -mx-1">
+          <MiniSparkline data={trend} height={28} />
+        </div>
       )}
     </div>
   )

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -5,6 +5,7 @@ import type {
   CacheClearResponse,
   CacheListResponse,
   CheckValue,
+  CockpitResponse,
   InstallationLookup,
   InstallationMeta,
   InvitationCreateResponse,
@@ -79,9 +80,15 @@ async function post<T>(path: string, body: unknown, extraHeaders?: Record<string
   return handleResponse<T>(res)
 }
 
-async function get<T>(path: string): Promise<T> {
+// Carries an optional client-supplied PAT to GET endpoints via a header (never
+// a query string, which would leak into logs/browser history).
+function githubTokenHeader(token?: string): Record<string, string> | undefined {
+  return token ? { "X-GitHub-Token": token } : undefined
+}
+
+async function get<T>(path: string, extraHeaders?: Record<string, string>): Promise<T> {
   const res = await fetchWithTimeout(`${BASE}${path}`, {
-    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+    headers: { "Content-Type": "application/json", ...getAuthHeaders(), ...extraHeaders },
   })
   return handleResponse<T>(res)
 }
@@ -170,6 +177,10 @@ export const api = {
     },
     history: (owner: string) =>
       get<AnalyticsHistoryResponse>(`/me/analytics/history?owner=${encodeURIComponent(owner)}`),
+    // token is optional — same App-or-PAT fallback as the rest of this namespace,
+    // carried via header since this is a GET (see githubTokenHeader).
+    cockpit: (owner: string, token?: string) =>
+      get<CockpitResponse>(`/me/analytics/cockpit/${encodeURIComponent(owner)}`, githubTokenHeader(token)),
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -224,3 +224,22 @@ export interface InvitationPreview {
   org_login: string
   status: "pending" | "accepted" | "revoked"
 }
+
+export interface PrWeekBucket {
+  week: string
+  opened: number
+  merged: number
+}
+
+export interface CockpitResponse {
+  repo_count: number
+  member_count: number
+  latest_score: number | null
+  score_trend: number[]
+  recent_events: OrgEvent[]
+  open_pr_count: number
+  pr_merge_rate_4w: PrWeekBucket[]
+  commit_activity_4w: number[]
+  total_cache_size_bytes: number
+  cache_job_success_rate: number
+}

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -58,6 +58,11 @@ function renderSidebar() {
 
 // Mutable per-test fixture for the /me/orgs response; reset in beforeEach.
 let orgMemberships: { org_login: string; role: "admin" | "member" }[] = [];
+// Mutable per-test fixture for the cockpit response driving the health dot/badge.
+let cockpitResponse: {
+  latest_score: number | null;
+  recent_events: { id: string; type: string; actor: string; actor_avatar: string; repo: string; summary: string; created_at: string }[];
+} = { latest_score: null, recent_events: [] };
 
 describe("AppSidebar Invite members button", () => {
   beforeEach(() => {
@@ -65,6 +70,7 @@ describe("AppSidebar Invite members button", () => {
     replace.mockClear();
     localStorage.setItem(TOKEN_KEY, makeJwt());
     orgMemberships = [];
+    cockpitResponse = { latest_score: null, recent_events: [] };
 
     vi.stubGlobal(
       "matchMedia",
@@ -91,6 +97,25 @@ describe("AppSidebar Invite members button", () => {
         }
         if (url.endsWith("/me/orgs")) {
           return Promise.resolve(jsonResponse(orgMemberships));
+        }
+        if (url.endsWith("/tokens/resolve")) {
+          return Promise.resolve(jsonResponse({ detail: "No saved token for this org" }, 404));
+        }
+        if (url.includes("/me/analytics/cockpit/")) {
+          return Promise.resolve(
+            jsonResponse({
+              repo_count: 0,
+              member_count: 0,
+              latest_score: cockpitResponse.latest_score,
+              score_trend: [],
+              recent_events: cockpitResponse.recent_events,
+              open_pr_count: 0,
+              pr_merge_rate_4w: [],
+              commit_activity_4w: [],
+              total_cache_size_bytes: 0,
+              cache_job_success_rate: 0,
+            }),
+          );
         }
         return Promise.reject(new Error(`Unexpected fetch: ${url}`));
       }),
@@ -147,5 +172,131 @@ describe("AppSidebar Invite members button", () => {
 
     const link = await screen.findByRole("link", { name: /invite members/i });
     await waitFor(() => expect(link).toHaveAttribute("href", "/settings"));
+  });
+});
+
+describe("AppSidebar health dot and unread badge", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    replace.mockClear();
+    localStorage.setItem(TOKEN_KEY, makeJwt());
+    localStorage.setItem("default_org", "acme");
+    orgMemberships = [{ org_login: "acme", role: "admin" }];
+    cockpitResponse = { latest_score: null, recent_events: [] };
+
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          return Promise.resolve(
+            jsonResponse({ id: 1, email: "user@example.com", name: "User", is_workspace_admin: false }),
+          );
+        }
+        if (url.endsWith("/me/orgs")) {
+          return Promise.resolve(jsonResponse(orgMemberships));
+        }
+        if (url.endsWith("/tokens/resolve")) {
+          return Promise.resolve(jsonResponse({ detail: "No saved token for this org" }, 404));
+        }
+        if (url.includes("/me/analytics/cockpit/")) {
+          return Promise.resolve(
+            jsonResponse({
+              repo_count: 0,
+              member_count: 0,
+              latest_score: cockpitResponse.latest_score,
+              score_trend: [],
+              recent_events: cockpitResponse.recent_events,
+              open_pr_count: 0,
+              pr_merge_rate_4w: [],
+              commit_activity_4w: [],
+              total_cache_size_bytes: 0,
+              cache_job_success_rate: 0,
+            }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows no dot when there's no score yet", async () => {
+    renderSidebar();
+    const link = await screen.findByRole("link", { name: "Health & Security" });
+    expect(link.querySelector(".bg-green-400, .bg-yellow-400, .bg-red-400")).toBeNull();
+  });
+
+  it("shows a green dot for a high score", async () => {
+    cockpitResponse = { latest_score: 90, recent_events: [] };
+    renderSidebar();
+
+    const link = await screen.findByRole("link", { name: "Health & Security" });
+    await waitFor(() => expect(link.querySelector(".bg-green-400")).not.toBeNull());
+  });
+
+  it("shows a yellow dot for a mid score", async () => {
+    cockpitResponse = { latest_score: 60, recent_events: [] };
+    renderSidebar();
+
+    const link = await screen.findByRole("link", { name: "Health & Security" });
+    await waitFor(() => expect(link.querySelector(".bg-yellow-400")).not.toBeNull());
+  });
+
+  it("shows a red dot for a low score", async () => {
+    cockpitResponse = { latest_score: 20, recent_events: [] };
+    renderSidebar();
+
+    const link = await screen.findByRole("link", { name: "Health & Security" });
+    await waitFor(() => expect(link.querySelector(".bg-red-400")).not.toBeNull());
+  });
+
+  it("shows an unread badge counting events newer than the last-seen timestamp", async () => {
+    localStorage.setItem("activity_last_seen_at", "2026-07-01T00:00:00Z");
+    cockpitResponse = {
+      latest_score: null,
+      recent_events: [
+        { id: "1", type: "PushEvent", actor: "alice", actor_avatar: "", repo: "acme/api", summary: "pushed", created_at: "2026-07-15T00:00:00Z" },
+        { id: "2", type: "PushEvent", actor: "bob", actor_avatar: "", repo: "acme/api", summary: "pushed", created_at: "2026-06-01T00:00:00Z" },
+      ],
+    };
+    renderSidebar();
+
+    const link = await screen.findByRole("link", { name: /Activity/ });
+    await waitFor(() => expect(link).toHaveTextContent("1"));
+  });
+
+  it("shows no unread badge when there are no events newer than last-seen", async () => {
+    localStorage.setItem("activity_last_seen_at", "2026-07-20T00:00:00Z");
+    cockpitResponse = {
+      latest_score: null,
+      recent_events: [
+        { id: "1", type: "PushEvent", actor: "alice", actor_avatar: "", repo: "acme/api", summary: "pushed", created_at: "2026-07-15T00:00:00Z" },
+      ],
+    };
+    renderSidebar();
+
+    await screen.findByRole("link", { name: /Activity/ });
+    const link = screen.getByRole("link", { name: /Activity/ });
+    await waitFor(() => expect(link.querySelector(".bg-primary\\/20")).toBeNull());
   });
 });

--- a/apps/ui/tests/components/event-activity-list.test.tsx
+++ b/apps/ui/tests/components/event-activity-list.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { EventActivityList } from "@/components/event-activity-list";
+import type { OrgEvent } from "@/lib/api/types";
+
+const events: OrgEvent[] = [
+  { id: "1", type: "PushEvent", actor: "alice", actor_avatar: "", repo: "acme/api", summary: "pushed 3 commits to main", created_at: new Date().toISOString() },
+  { id: "2", type: "PullRequestEvent", actor: "bob", actor_avatar: "", repo: "acme/worker", summary: "opened PR #4", created_at: new Date().toISOString() },
+];
+
+describe("EventActivityList", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a loading skeleton", () => {
+    const { container } = render(<EventActivityList events={[]} isLoading />);
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("shows an empty state with no events", () => {
+    render(<EventActivityList events={[]} isLoading={false} />);
+    expect(screen.getByText("— no recent activity")).toBeInTheDocument();
+  });
+
+  it("renders each event's actor, summary, and repo", () => {
+    render(<EventActivityList events={events} isLoading={false} />);
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("pushed 3 commits to main")).toBeInTheDocument();
+    expect(screen.getByText("acme/api")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText("opened PR #4")).toBeInTheDocument();
+  });
+
+  it("truncates to the limit", () => {
+    render(<EventActivityList events={events} isLoading={false} limit={1} />);
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.queryByText("bob")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -2,20 +2,16 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const jobsListMock = vi.fn();
 const tokensResolveMock = vi.fn();
-const analyticsOverviewMock = vi.fn();
+const cockpitMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
-    jobs: {
-      list: (...args: unknown[]) => jobsListMock(...args),
-    },
     tokens: {
       resolve: (...args: unknown[]) => tokensResolveMock(...args),
     },
     analytics: {
-      overview: (...args: unknown[]) => analyticsOverviewMock(...args),
+      cockpit: (...args: unknown[]) => cockpitMock(...args),
     },
   },
 }));
@@ -33,12 +29,23 @@ function renderPage() {
   );
 }
 
-describe("OverviewPage stat cards", () => {
+const EMPTY_COCKPIT = {
+  repo_count: 0,
+  member_count: 0,
+  latest_score: null,
+  score_trend: [],
+  recent_events: [],
+  open_pr_count: 0,
+  pr_merge_rate_4w: [],
+  commit_activity_4w: [],
+  total_cache_size_bytes: 0,
+  cache_job_success_rate: 0,
+};
+
+describe("OverviewPage cockpit", () => {
   beforeEach(() => {
-    jobsListMock.mockReset();
     tokensResolveMock.mockReset();
-    analyticsOverviewMock.mockReset();
-    jobsListMock.mockResolvedValue([]);
+    cockpitMock.mockReset();
     localStorage.clear();
   });
 
@@ -47,15 +54,15 @@ describe("OverviewPage stat cards", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows Configure links for Repositories/Security Score when no org is configured", async () => {
+  it("shows Configure links for all 4 stat cards when no org is configured", async () => {
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getAllByText("Configure →")).toHaveLength(2);
+      expect(screen.getAllByText("Configure →")).toHaveLength(4);
     });
 
     expect(tokensResolveMock).not.toHaveBeenCalled();
-    expect(analyticsOverviewMock).not.toHaveBeenCalled();
+    expect(cockpitMock).not.toHaveBeenCalled();
 
     const configureLinks = screen.getAllByRole("link", { name: /Configure →/i });
     for (const link of configureLinks) {
@@ -63,43 +70,78 @@ describe("OverviewPage stat cards", () => {
     }
   });
 
-  it("shows a loading state once configured, then the real numbers", async () => {
+  it("fires a single cockpit call (no waterfall) and renders real values for all 4 cards", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
-
-    const gate = new Promise<{ owner: string; score: number; total_checks: number; failed_checks: number; repo_count: number; checks: [] }>(
-      (resolve) => {
-        setTimeout(() =>
-          resolve({ owner: "acme", score: 87, total_checks: 3, failed_checks: 1, repo_count: 12, checks: [] }), 10);
-      },
-    );
-    analyticsOverviewMock.mockReturnValue(gate);
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      repo_count: 12,
+      open_pr_count: 5,
+      latest_score: 87,
+      score_trend: [70, 80, 87],
+      member_count: 9,
+    });
 
     renderPage();
 
     await waitFor(() => {
-      expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", "ghp_test");
+      expect(cockpitMock).toHaveBeenCalledWith("acme", "ghp_test");
     });
 
     await waitFor(() => {
       expect(screen.getByText("12")).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
       expect(screen.getByText("87")).toBeInTheDocument();
+      expect(screen.getByText("9")).toBeInTheDocument();
     });
 
     expect(screen.queryAllByText("Configure →")).toHaveLength(0);
+    // A single cockpit call once the token-resolve fetch settles -- not a second
+    // waterfalled fetch for jobs/overview like the pre-cockpit page used to do.
+    expect(cockpitMock).toHaveBeenCalledTimes(1);
   });
 
-  it("always renders Open PRs and Team Members as N/A, regardless of org state", async () => {
+  it("renders empty states for charts and activity when the org has no data yet", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
-    analyticsOverviewMock.mockResolvedValue({
-      owner: "acme", score: 100, total_checks: 1, failed_checks: 0, repo_count: 1, checks: [],
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(cockpitMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("— no recent activity")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No commit activity yet")).toBeInTheDocument();
+    expect(screen.getByText("Run more scans to see a trend")).toBeInTheDocument();
+    expect(screen.getByText("No pull request activity yet")).toBeInTheDocument();
+  });
+
+  it("renders recent events in the activity panel", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      recent_events: [
+        {
+          id: "1",
+          type: "PushEvent",
+          actor: "alice",
+          actor_avatar: "",
+          repo: "acme/api",
+          summary: "pushed 3 commits to main",
+          created_at: "2026-07-18T00:00:00Z",
+        },
+      ],
     });
 
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getAllByText("N/A")).toHaveLength(2);
+      expect(screen.getByText("alice")).toBeInTheDocument();
     });
+    expect(screen.getByText("pushed 3 commits to main")).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/components/stat-card.test.tsx
+++ b/apps/ui/tests/components/stat-card.test.tsx
@@ -23,4 +23,18 @@ describe("StatCard", () => {
 
     expect(screen.getByText("↓ 3% vs last week")).toBeInTheDocument();
   });
+
+  it("renders a sparkline when trend data has more than one point", () => {
+    const { container } = render(<StatCard label="Score" value={87} trend={[70, 80, 87]} />);
+
+    expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+  });
+
+  it("omits the sparkline when trend has 0 or 1 points", () => {
+    const { container: zero } = render(<StatCard label="Score" value={87} trend={[]} />);
+    expect(zero.querySelector(".recharts-responsive-container")).not.toBeInTheDocument();
+
+    const { container: one } = render(<StatCard label="Score" value={87} trend={[87]} />);
+    expect(one.querySelector(".recharts-responsive-container")).not.toBeInTheDocument();
+  });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -158,6 +158,30 @@ describe("api.analytics value normalization", () => {
     expect(result.checks[0].value).toEqual({ type: "ratio", numerator: 1, denominator: 2 });
   });
 
+  it("GETs /me/analytics/cockpit/{owner} with no body and no token header when omitted", async () => {
+    stubOkJson({
+      repo_count: 1, member_count: 2, latest_score: 90, score_trend: [90],
+      recent_events: [], open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [],
+      total_cache_size_bytes: 0, cache_job_success_rate: 0,
+    });
+    await api.analytics.cockpit("acme");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/analytics/cockpit/acme");
+    expect(init.method).toBeUndefined();
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBeUndefined();
+  });
+
+  it("sends the token as an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({
+      repo_count: 1, member_count: 2, latest_score: 90, score_trend: [90],
+      recent_events: [], open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [],
+      total_cache_size_bytes: 0, cache_job_success_rate: 0,
+    });
+    await api.analytics.cockpit("acme", "ghp_test");
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+  });
+
   it("GETs /me/analytics/history?owner=... and returns the raw scan history", async () => {
     stubOkJson([{ id: 1, owner: "acme", score: 80, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" }]);
     const result = await api.analytics.history("acme");


### PR DESCRIPTION
## Why

\`docs/plan.md\`'s Phase 12 (\"Overview Cockpit\") was marked planned but unimplemented — the Overview page's stat cards were wired to a real security-score/repo-count fetch, but \"Open PRs\" and \"Team Members\" were hardcoded \`N/A\`, there were no trend charts, and the page did 2-3 separate waterfalled fetches (token resolve → analytics overview, plus a separate jobs poll) instead of one aggregate call. Closes #179.

## What changed

**Backend** — new \`GET /me/analytics/cockpit/{owner}\` in \`apps/api/src/routers/analytics.py\`, returning a \`CockpitResponse\` (repo/member counts, security score + last-10-scan trend, last-5 org events, open PR count + 4-week merge-rate buckets, 4-week commit velocity, cache size + cache-job success rate). DB reads (\`scan_results\`, \`jobs\`) happen inline; GitHub calls fan out concurrently via \`asyncio.gather\`. Every GitHub-calling helper except the initial repo-list fetch (\`_safe_member_count\`, \`_safe_recent_events\`, \`_safe_open_pr_count\`, \`_safe_pr_merge_rate_4w\`, \`_safe_commit_activity_4w\`, \`_safe_total_cache_bytes\`) degrades to a typed default (\`0\`, \`[]\`, \`0.0\`) on any GitHub error rather than failing the whole request — a degraded cockpit is more useful to a dashboard than a 500 for the whole page. Only the repo list is allowed to fail hard, since nothing else is computable without it.

Scope decisions, called out explicitly:
- **Personal-scoped only** (\`/me/...\`, not org-scoped) — the Overview page has only ever called \`/me/analytics/*\`; the org-scoped sibling endpoint is unused by any current UI path, so building against it would add dead surface.
- **No dependency on #178** (the separate Collaborators PR) — \`member_count\` is fetched independently here rather than importing from that PR's \`collab.py\` (confirmed it doesn't exist on \`main\` yet), so both PRs stay mergeable in either order.
- PR count/rate use GitHub's Search API (9 cheap \`per_page=1\` count-only calls) rather than N+1 per-repo pulls; commit-activity/cache-size fan out per-repo capped at 30 repos (no org-wide GitHub endpoint exists for either).
- Only the **Security Score** stat card gets a real sparkline (from \`score_trend\`) — Repos/Open PRs/Members have no time-series field in scope, so no trend is fabricated for the other three.
- **Learned from the #178 code review**: added an \`X-GitHub-Token\` header fallback (never a query string) so orgs relying on a saved PAT instead of a GitHub App installation aren't locked out of this endpoint the way #178's first draft locked them out of the Collaborators roster.

No schema migration — everything is a live GitHub read or a derived read from the existing \`scan_results\`/\`jobs\` tables.

**Frontend** — \`apps/ui/app/page.tsx\` replaces the old \`tokens.resolve → analytics.overview\` chain plus separate \`jobs\` poll with one \`analytics.cockpit\` query (both the token-resolve and cockpit queries still fire immediately on mount — cockpit just waits for the resolve fetch to *settle*, not a dependent waterfall, so a saved PAT isn't missed on the first request). Wires all 4 stat cards to real data and adds a 2×2 chart grid (Commit Activity / Security Score / PR Merge Rate — all reusing existing \`AreaTimeChart\`/\`BarGroupChart\` components — and Recent Activity via a new \`EventActivityList\`, a sibling to the existing job-based \`ActivityList\` rather than a generalized union type). \`StatCard\` gained an optional \`trend\` prop rendering the existing \`MiniSparkline\`. The sidebar (\`app-sidebar.tsx\`) gets a colored health dot on \"Health & Security\" (green ≥80 / yellow ≥50 / red <50 / none if no score yet) and an unread-count badge on \"Activity\", tracked via a \`localStorage\` last-seen timestamp that the Activity page now updates on mount.

## Test plan
- [x] \`pytest -q apps/api/tests/test_analytics_cockpit.py\` — 21 new tests (success-all-sources, no-scans-yet, no-cache-jobs-yet, per-source graceful degradation, hard-fail on repo-list failure, auth/token-resolution errors, PAT-header fallback, plus unit tests for each \`_safe_*\` helper's own try/except behavior) — all pass
- [x] \`pytest -q\` (full backend suite) — 365 passed
- [x] \`bun run typecheck && bun run lint\` — clean
- [x] \`bun run test\` — 199/199 pass (Overview page rewritten test suite, StatCard sparkline tests, new EventActivityList tests, AppSidebar health-dot/unread-badge tests, client.ts cockpit-call tests)
- [x] \`bun run build\` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)