### PR TITLE
feat(api,ui): Automation page workflow listing, run history, and dispatch (Phase 13)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -11,6 +11,7 @@ from src.routers import (
     analytics,
     audit,
     auth,
+    automation,
     collab,
     config,
     github,
@@ -68,6 +69,7 @@ app.include_router(actions_cache.router, tags=["actions-cache"])
 app.include_router(repos.router, tags=["repos"])
 app.include_router(github.router, tags=["github"])
 app.include_router(collab.router, tags=["collab"])
+app.include_router(automation.router, tags=["automation"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])

--- a/apps/api/src/routers/automation.py
+++ b/apps/api/src/routers/automation.py
@@ -1,0 +1,237 @@
+"""Workflow listing/run-history/dispatch endpoints (docs/plan.md Phase 13 — Automation).
+
+Reads are plain GETs with an optional client-supplied PAT carried in the
+`X-GitHub-Token` header (never a query string), matching collab.py's convention.
+Dispatch is a write, so it stays a POST with the token in the body, matching
+actions_cache.py's convention -- and per docs/plan.md's cross-cutting note,
+dispatch is expected to remain a direct-GitHub-call action endpoint even after
+the aggregates migration lands, so it doesn't wait on that work.
+
+Dispatch is gated behind org-admin (require_org_role(min_role="admin")) --
+GitHub Actions has no dispatch-preview API, so unlike actions-cache clear there
+is no dry-run mode here. The audit log is written before the GitHub call so
+there's a record even if GitHub rejects or times out the dispatch.
+"""
+
+from datetime import datetime
+
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.orm import Session
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.repositories import audit_repo
+from src.schemas.automation import (
+    DispatchInput,
+    DispatchResponse,
+    RunSummary,
+    RunsResponse,
+    WorkflowSummary,
+    WorkflowsResponse,
+)
+from src.services.github_client import GitHubClient, github_error as _github_error
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
+
+router = APIRouter()
+
+
+def _run_duration_ms(run: dict) -> int | None:
+    started = run.get("run_started_at")
+    updated = run.get("updated_at")
+    if not started or not updated or run.get("status") != "completed":
+        return None
+    try:
+        start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    delta_ms = int((end_dt - start_dt).total_seconds() * 1000)
+    return delta_ms if delta_ms >= 0 else None
+
+
+def _list_workflows(owner: str, repo: str, token: str) -> WorkflowsResponse:
+    client = GitHubClient(token)
+    try:
+        data = client.request("GET", f"/repos/{owner}/{repo}/actions/workflows")
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+    workflows = [
+        WorkflowSummary(id=w["id"], name=w["name"], path=w["path"], state=w["state"])
+        for w in data.get("workflows", [])
+    ]
+
+    # Best-effort: overlay each workflow's most recent run, same degrade-gracefully
+    # pattern as collab.py's 2FA overlay -- the workflow list itself already
+    # succeeded above, so a failure here shouldn't fail the whole response.
+    try:
+        runs_data = client.request("GET", f"/repos/{owner}/{repo}/actions/runs", params={"per_page": 100})
+        latest_by_workflow: dict[int, dict] = {}
+        for run in runs_data.get("workflow_runs", []):
+            wf_id = run.get("workflow_id")
+            if wf_id is not None and wf_id not in latest_by_workflow:
+                latest_by_workflow[wf_id] = run
+        for wf in workflows:
+            latest = latest_by_workflow.get(wf.id)
+            if latest:
+                wf.last_run_status = latest.get("status")
+                wf.last_run_conclusion = latest.get("conclusion")
+                wf.last_run_at = latest.get("created_at")
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        pass
+
+    return WorkflowsResponse(repository=f"{owner}/{repo}", workflows=workflows)
+
+
+def _list_runs(owner: str, repo: str, token: str, per_page: int) -> RunsResponse:
+    client = GitHubClient(token)
+    try:
+        data = client.request("GET", f"/repos/{owner}/{repo}/actions/runs", params={"per_page": per_page})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+    runs = [
+        RunSummary(
+            id=r["id"],
+            name=r.get("name"),
+            status=r["status"],
+            conclusion=r.get("conclusion"),
+            head_branch=r.get("head_branch", ""),
+            created_at=r["created_at"],
+            duration_ms=_run_duration_ms(r),
+        )
+        for r in data.get("workflow_runs", [])
+    ]
+    return RunsResponse(repository=f"{owner}/{repo}", runs=runs)
+
+
+def _dispatch(
+    db: Session, owner: str, repo: str, workflow_id: int, payload: DispatchInput, token: str, actor: str
+) -> DispatchResponse:
+    target = f"{owner}/{repo}#{workflow_id}"
+    audit_repo.write(
+        db,
+        actor,
+        "automation.workflow.dispatch",
+        target,
+        {"ref": payload.ref, "inputs": payload.inputs or {}},
+    )
+    client = GitHubClient(token)
+    try:
+        client.request(
+            "POST",
+            f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+            json={"ref": payload.ref, "inputs": payload.inputs or {}},
+        )
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    return DispatchResponse(dispatched=True, message="Workflow dispatched.")
+
+
+# ── org-scoped ───────────────────────────────────────────────────────────────
+
+@router.get("/orgs/{org_login}/repos/{owner}/{repo}/workflows", response_model=WorkflowsResponse)
+def org_list_workflows(
+    org_login: str,
+    owner: str,
+    repo: str,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    assert_owner_matches_org(owner, ctx)
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_workflows(owner, repo, token)
+
+
+@router.get("/orgs/{org_login}/repos/{owner}/{repo}/actions/runs", response_model=RunsResponse)
+def org_list_runs(
+    org_login: str,
+    owner: str,
+    repo: str,
+    per_page: int = 10,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    assert_owner_matches_org(owner, ctx)
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_runs(owner, repo, token, per_page)
+
+
+@router.post("/orgs/{org_login}/repos/{owner}/{repo}/workflows/{workflow_id}/dispatch", response_model=DispatchResponse)
+def org_dispatch_workflow(
+    org_login: str,
+    owner: str,
+    repo: str,
+    workflow_id: int,
+    payload: DispatchInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    assert_owner_matches_org(owner, ctx)
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=client_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _dispatch(db, owner, repo, workflow_id, payload, token, actor=user.email)
+
+
+# ── personal-scoped ──────────────────────────────────────────────────────────
+
+@router.get("/me/repos/{owner}/{repo}/workflows", response_model=WorkflowsResponse)
+def personal_list_workflows(
+    owner: str,
+    repo: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_workflows(owner, repo, token)
+
+
+@router.get("/me/repos/{owner}/{repo}/actions/runs", response_model=RunsResponse)
+def personal_list_runs(
+    owner: str,
+    repo: str,
+    per_page: int = 10,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_runs(owner, repo, token, per_page)
+
+
+@router.post("/me/repos/{owner}/{repo}/workflows/{workflow_id}/dispatch", response_model=DispatchResponse)
+def personal_dispatch_workflow(
+    owner: str,
+    repo: str,
+    workflow_id: int,
+    payload: DispatchInput,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=client_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _dispatch(db, owner, repo, workflow_id, payload, token, actor=user.email)

--- a/apps/api/src/schemas/automation.py
+++ b/apps/api/src/schemas/automation.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from pydantic import BaseModel, SecretStr
+
+
+class WorkflowSummary(BaseModel):
+    # Overlay fields (last_run_*) are set via attribute assignment after construction
+    # in the workflows router, not the constructor -- validate_assignment ensures the
+    # raw GitHub API string still gets coerced to `datetime`.
+    model_config = {"validate_assignment": True}
+
+    id: int
+    name: str
+    path: str
+    state: str
+    last_run_status: str | None = None
+    last_run_conclusion: str | None = None
+    last_run_at: datetime | None = None
+
+
+class WorkflowsResponse(BaseModel):
+    repository: str
+    workflows: list[WorkflowSummary]
+
+
+class RunSummary(BaseModel):
+    id: int
+    name: str | None
+    status: str
+    conclusion: str | None
+    head_branch: str
+    created_at: datetime
+    duration_ms: int | None = None
+
+
+class RunsResponse(BaseModel):
+    repository: str
+    runs: list[RunSummary]
+
+
+class DispatchInput(BaseModel):
+    # Optional: falls back to a GitHub App installation token when one is connected
+    # for this owner (see src.services.token_resolution).
+    token: SecretStr | None = None
+    ref: str
+    inputs: dict[str, str] | None = None
+
+
+class DispatchResponse(BaseModel):
+    dispatched: bool
+    message: str | None = None

--- a/apps/api/tests/test_automation.py
+++ b/apps/api/tests/test_automation.py
@@ -85,6 +85,72 @@ def test_personal_list_runs_computes_duration(automation_client):
     assert resp.json()["runs"][0]["duration_ms"] == 120_000
 
 
+def test_personal_list_workflows_github_error_propagates(automation_client):
+    error = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = automation_client.get(
+            "/me/repos/acme/demo/workflows", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 400
+
+
+def test_personal_list_runs_github_error_propagates(automation_client):
+    error = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(503, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = automation_client.get(
+            "/me/repos/acme/demo/actions/runs", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 400
+
+
+def test_personal_list_runs_no_duration_when_not_completed_or_missing_timestamps(automation_client):
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {
+            "workflow_runs": [
+                {
+                    "id": 11,
+                    "name": "CI",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "head_branch": "main",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "run_started_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:02:00Z",
+                },
+                {
+                    "id": 12,
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "head_branch": "main",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "run_started_at": "not-a-real-timestamp",
+                    "updated_at": "2026-01-01T00:02:00Z",
+                },
+            ]
+        }
+        resp = automation_client.get(
+            "/me/repos/acme/demo/actions/runs", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    runs = resp.json()["runs"]
+    assert runs[0]["duration_ms"] is None
+    assert runs[1]["duration_ms"] is None
+
+
+def test_personal_list_runs_no_token_returns_400(automation_client):
+    resp = automation_client.get("/me/repos/acme/demo/actions/runs")
+    assert resp.status_code == 400
+
+
 def test_personal_dispatch_writes_audit_log_before_github_call(automation_client, db):
     db.add(User(id=_USER.id, email=_USER.email, name=None, password_hash=None, is_workspace_admin=False))
     db.commit()
@@ -201,3 +267,32 @@ def test_org_dispatch_owner_mismatch_forbidden(db, acme_org):
         json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
     )
     assert resp.status_code == 403
+
+
+def test_org_list_workflows_no_token_returns_400(db, acme_org):
+    client = _org_client(db, acme_org["member"].id, email=acme_org["member"].email)
+    resp = client.get("/orgs/acme/repos/acme/demo/workflows")
+    assert resp.status_code == 400
+
+
+def test_org_list_runs_member_ok(db, acme_org):
+    client = _org_client(db, acme_org["member"].id, email=acme_org["member"].email)
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {"workflow_runs": []}
+        resp = client.get(
+            "/orgs/acme/repos/acme/demo/actions/runs", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["runs"] == []
+
+
+def test_org_list_runs_no_token_returns_400(db, acme_org):
+    client = _org_client(db, acme_org["member"].id, email=acme_org["member"].email)
+    resp = client.get("/orgs/acme/repos/acme/demo/actions/runs")
+    assert resp.status_code == 400
+
+
+def test_org_dispatch_no_token_returns_400(db, acme_org):
+    client = _org_client(db, acme_org["admin"].id, email=acme_org["admin"].email)
+    resp = client.post("/orgs/acme/repos/acme/demo/workflows/1/dispatch", json={"ref": "main"})
+    assert resp.status_code == 400

--- a/apps/api/tests/test_automation.py
+++ b/apps/api/tests/test_automation.py
@@ -1,0 +1,203 @@
+"""Tests for the Automation router (docs/plan.md Phase 13)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.core.db import AuditLog
+from src.repositories import org_membership_repo, org_repo
+from src.routers.automation import router as automation_router
+
+_USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def automation_client(db):
+    app = FastAPI()
+    app.include_router(automation_router)
+    app.dependency_overrides[require_auth] = lambda: _USER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_personal_list_workflows_no_token_returns_400(automation_client):
+    resp = automation_client.get("/me/repos/acme/demo/workflows")
+    assert resp.status_code == 400
+
+
+def test_personal_list_workflows_ok(automation_client):
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [
+            {"total_count": 1, "workflows": [{"id": 1, "name": "CI", "path": ".github/workflows/ci.yml", "state": "active"}]},
+            {"workflow_runs": [{"workflow_id": 1, "status": "completed", "conclusion": "success", "created_at": "2026-01-01T00:00:00Z"}]},
+        ]
+        resp = automation_client.get(
+            "/me/repos/acme/demo/workflows", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workflows"][0]["name"] == "CI"
+    assert body["workflows"][0]["last_run_status"] == "completed"
+
+
+def test_personal_list_workflows_overlay_failure_degrades_gracefully(automation_client):
+    error = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [
+            {"total_count": 1, "workflows": [{"id": 1, "name": "CI", "path": ".github/workflows/ci.yml", "state": "active"}]},
+            error,
+        ]
+        resp = automation_client.get(
+            "/me/repos/acme/demo/workflows", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["workflows"][0]["last_run_status"] is None
+
+
+def test_personal_list_runs_computes_duration(automation_client):
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {
+            "workflow_runs": [
+                {
+                    "id": 10,
+                    "name": "CI",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "head_branch": "main",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "run_started_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:02:00Z",
+                }
+            ]
+        }
+        resp = automation_client.get(
+            "/me/repos/acme/demo/actions/runs", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["runs"][0]["duration_ms"] == 120_000
+
+
+def test_personal_dispatch_writes_audit_log_before_github_call(automation_client, db):
+    db.add(User(id=_USER.id, email=_USER.email, name=None, password_hash=None, is_workspace_admin=False))
+    db.commit()
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {}
+        resp = automation_client.post(
+            "/me/repos/acme/demo/workflows/1/dispatch",
+            json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["dispatched"] is True
+    logs = db.query(AuditLog).filter(AuditLog.action == "automation.workflow.dispatch").all()
+    assert len(logs) == 1
+    assert logs[0].actor == _USER.email
+    assert logs[0].target == "acme/demo#1"
+
+
+def test_personal_dispatch_no_token_returns_400_and_still_no_github_call(automation_client):
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        resp = automation_client.post("/me/repos/acme/demo/workflows/1/dispatch", json={"ref": "main"})
+    assert resp.status_code == 400
+    mock_client.return_value.request.assert_not_called()
+
+
+def test_personal_dispatch_github_error_still_leaves_audit_log(automation_client, db):
+    db.add(User(id=_USER.id, email=_USER.email, name=None, password_hash=None, is_workspace_admin=False))
+    db.commit()
+    error = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("POST", "https://api.github.com/x"),
+        response=httpx.Response(422, request=httpx.Request("POST", "https://api.github.com/x")),
+    )
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = automation_client.post(
+            "/me/repos/acme/demo/workflows/1/dispatch",
+            json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
+        )
+    assert resp.status_code == 400
+    logs = db.query(AuditLog).filter(AuditLog.action == "automation.workflow.dispatch").all()
+    assert len(logs) == 1
+
+
+# ── org-scoped ────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def acme_org(db):
+    admin = User(email="admin@e.com", name=None, password_hash=None, is_workspace_admin=False)
+    member = User(email="member@e.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add_all([admin, member])
+    db.commit()
+    db.refresh(admin)
+    db.refresh(member)
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return {"org": org, "admin": admin, "member": member}
+
+
+def _org_client(db, user_id, email="u@example.com"):
+    app = FastAPI()
+    app.include_router(automation_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(id=user_id, email=email, name=None, is_workspace_admin=False)
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_org_list_workflows_member_ok(db, acme_org):
+    client = _org_client(db, acme_org["member"].id)
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [
+            {"total_count": 0, "workflows": []},
+            {"workflow_runs": []},
+        ]
+        resp = client.get(
+            "/orgs/acme/repos/acme/demo/workflows", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+        )
+    assert resp.status_code == 200
+
+
+def test_org_dispatch_requires_admin(db, acme_org):
+    client = _org_client(db, acme_org["member"].id, email=acme_org["member"].email)
+    resp = client.post(
+        "/orgs/acme/repos/acme/demo/workflows/1/dispatch",
+        json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
+    )
+    assert resp.status_code == 403
+
+
+def test_org_dispatch_admin_ok(db, acme_org):
+    client = _org_client(db, acme_org["admin"].id, email=acme_org["admin"].email)
+    with patch("src.routers.automation.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {}
+        resp = client.post(
+            "/orgs/acme/repos/acme/demo/workflows/1/dispatch",
+            json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
+        )
+    assert resp.status_code == 200
+    logs = db.query(AuditLog).filter(AuditLog.action == "automation.workflow.dispatch").all()
+    assert logs[0].actor == acme_org["admin"].email
+
+
+def test_org_list_workflows_outsider_forbidden(db, acme_org):
+    client = _org_client(db, 999999)
+    resp = client.get(
+        "/orgs/acme/repos/acme/demo/workflows", headers={"X-GitHub-Token": "ghp_testtoken123456789012345678901234"}
+    )
+    assert resp.status_code == 403
+
+
+def test_org_dispatch_owner_mismatch_forbidden(db, acme_org):
+    client = _org_client(db, acme_org["admin"].id, email=acme_org["admin"].email)
+    resp = client.post(
+        "/orgs/acme/repos/other-owner/demo/workflows/1/dispatch",
+        json={"token": "ghp_testtoken123456789012345678901234", "ref": "main"},
+    )
+    assert resp.status_code == 403

--- a/apps/ui/app/automation/page.tsx
+++ b/apps/ui/app/automation/page.tsx
@@ -56,7 +56,8 @@ export default function AutomationPage() {
   useEffect(() => {
     setToken("")
     setTokenSaved(false)
-    if (owner.trim().length > 2) resolveMutation.mutate(owner.trim())
+    // > 0, not > 2 -- valid GitHub org logins can be 1-2 characters (see activity/page.tsx).
+    if (owner.trim().length > 0) resolveMutation.mutate(owner.trim())
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner])
 

--- a/apps/ui/app/automation/page.tsx
+++ b/apps/ui/app/automation/page.tsx
@@ -1,20 +1,323 @@
-export const metadata = { title: "Automation · clevis" }
+"use client"
 
+import { useEffect, useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { PageHeader } from "@/components/page-header"
-import { EmptyState } from "@/components/empty-state"
+import { Warning, Key, CircleNotch, Play, CheckCircle, XCircle, CircleDashed } from "@phosphor-icons/react"
+import { api } from "@/lib/api/client"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
+import { BarGroupChart } from "@/components/charts/bar-group-chart"
+import { CHART_COLORS } from "@/lib/charts/theme"
+import { relativeTime } from "@/lib/format"
+import type { RunSummary, WorkflowSummary } from "@/lib/api/types"
+
+function runDurationSeconds(run: RunSummary): number | null {
+  return run.duration_ms == null ? null : Math.round(run.duration_ms / 1000)
+}
+
+function StatusIcon({ status, conclusion }: { status: string; conclusion: string | null }) {
+  if (status !== "completed") {
+    return <CircleDashed className="size-3.5 text-yellow-400 animate-pulse" />
+  }
+  if (conclusion === "success") return <CheckCircle className="size-3.5 text-green-400" />
+  if (conclusion === "failure") return <XCircle className="size-3.5 text-red-400" />
+  return <CircleDashed className="size-3.5 text-muted-foreground" />
+}
 
 export default function AutomationPage() {
+  const [owner, setOwner] = useState("")
+  const [repo, setRepo] = useState("")
+  const [token, setToken] = useState("")
+  const [tokenSaved, setTokenSaved] = useState(false)
+
+  const [selectedWorkflow, setSelectedWorkflow] = useState<WorkflowSummary | null>(null)
+  const [ref, setRef] = useState("main")
+  const [dispatchArmed, setDispatchArmed] = useState(false)
+
+  useEffect(() => {
+    const defaultOrg = localStorage.getItem("default_org") || ""
+    if (defaultOrg) setOwner(defaultOrg)
+  }, [])
+
+  const resolveMutation = useMutation({
+    mutationFn: (org: string) => api.tokens.resolve(org),
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
+    onError: () => setTokenSaved(false),
+  })
+
+  useEffect(() => {
+    setToken("")
+    setTokenSaved(false)
+    if (owner.trim().length > 2) resolveMutation.mutate(owner.trim())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [owner])
+
+  const saveTokenMutation = useMutation({
+    mutationFn: () => api.tokens.upsert(owner.trim(), token.trim()),
+    onSuccess: () => setTokenSaved(true),
+  })
+
+  const loadMutation = useMutation({
+    mutationFn: async () => {
+      const [workflows, runs] = await Promise.all([
+        api.automation.workflows(owner.trim(), repo.trim(), token),
+        api.automation.runs(owner.trim(), repo.trim(), token),
+      ])
+      return { workflows, runs }
+    },
+    onSuccess: () => {
+      setSelectedWorkflow(null)
+      setDispatchArmed(false)
+    },
+  })
+
+  const dispatchMutation = useMutation({
+    mutationFn: () => {
+      if (!selectedWorkflow) throw new Error("No workflow selected")
+      return api.automation.dispatch(owner.trim(), repo.trim(), selectedWorkflow.id, { token, ref: ref.trim() })
+    },
+    onSuccess: () => setDispatchArmed(false),
+  })
+
+  // Auto-disarm if the user doesn't confirm within a few seconds — same pattern
+  // as the Actions Cache "Clear" button (see components/repo/cache-panel.tsx).
+  useEffect(() => {
+    if (!dispatchArmed) return
+    const timer = setTimeout(() => setDispatchArmed(false), 4000)
+    return () => clearTimeout(timer)
+  }, [dispatchArmed])
+
+  const isLoading = loadMutation.isPending
+  const workflows = loadMutation.data?.workflows.workflows ?? []
+  const runs = loadMutation.data?.runs.runs ?? []
+
+  const durationChartData = runs
+    .filter((r) => r.duration_ms != null)
+    .slice(0, 10)
+    .reverse()
+    .map((r) => ({ name: r.head_branch || `#${r.id}`, seconds: runDurationSeconds(r) ?? 0 }))
+
   return (
     <>
       <PageHeader
         title="Automation"
-        description="Manage workflows and automated actions."
+        description="Trigger GitHub Actions workflows and review run history — dispatch is audit-logged and requires org admin."
       />
-      <div className="card">
-        <EmptyState
-          title="Automation coming soon"
-          description="Trigger GitHub Actions workflows, dispatch events, and automate repo hygiene tasks — all from one place."
-        />
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Config panel */}
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-title">Repository</span>
+          </div>
+          <div className="p-4 flex flex-col gap-3">
+            <div>
+              <label className="text-xs font-medium text-foreground block mb-1.5">Organization / Owner</label>
+              <Input placeholder="e.g. octocat" value={owner} onChange={(e) => setOwner(e.target.value)} />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-foreground block mb-1.5">Repository</label>
+              <Input
+                placeholder="e.g. hello-world"
+                value={repo}
+                onChange={(e) => setRepo(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && owner.trim() && repo.trim() && !isLoading && loadMutation.mutate()}
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                GitHub Token
+                <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                  optional if the GitHub App is connected for this org
+                </span>
+                {tokenSaved && (
+                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                    <Key className="size-3" />saved
+                  </span>
+                )}
+              </label>
+              <Input
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                type="password"
+                value={token}
+                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
+                className="font-mono"
+              />
+            </div>
+            {!tokenSaved && token && owner && (
+              <Button variant="outline" onClick={() => saveTokenMutation.mutate()} disabled={saveTokenMutation.isPending}>
+                <Key className="size-3.5" />
+                {saveTokenMutation.isPending ? "Saving…" : "Save token for this org"}
+              </Button>
+            )}
+            <Button onClick={() => loadMutation.mutate()} disabled={isLoading || !owner.trim() || !repo.trim()} className="mt-1">
+              {isLoading ? <><CircleNotch className="size-3.5 animate-spin" />Loading…</> : "Load workflows"}
+            </Button>
+            {loadMutation.isError && (
+              <p className="text-xs text-destructive flex items-center gap-1.5">
+                <Warning className="size-3 shrink-0" />
+                {loadMutation.error.message}
+              </p>
+            )}
+
+            {selectedWorkflow && (
+              <div className="mt-2 pt-3 border-t border-border flex flex-col gap-2.5">
+                <p className="text-xs font-medium text-foreground">Dispatch &ldquo;{selectedWorkflow.name}&rdquo;</p>
+                <div>
+                  <label className="text-xs font-medium text-foreground block mb-1.5">Ref (branch/tag)</label>
+                  <Input value={ref} onChange={(e) => { setRef(e.target.value); setDispatchArmed(false) }} />
+                </div>
+                <Button
+                  onClick={() => {
+                    if (dispatchArmed) {
+                      setDispatchArmed(false)
+                      dispatchMutation.mutate()
+                    } else {
+                      setDispatchArmed(true)
+                    }
+                  }}
+                  disabled={dispatchMutation.isPending || !ref.trim()}
+                >
+                  <Play className="size-3.5" />
+                  {dispatchArmed ? "Confirm dispatch" : "Dispatch workflow"}
+                </Button>
+                {dispatchArmed && (
+                  <p className="text-xs text-yellow-400/80 flex items-center gap-1.5">
+                    <Warning className="size-3 shrink-0" />
+                    Click again to trigger this workflow run on GitHub.
+                  </p>
+                )}
+                {dispatchMutation.isError && (
+                  <p className="text-xs text-destructive flex items-center gap-1.5">
+                    <Warning className="size-3 shrink-0" />
+                    {dispatchMutation.error.message}
+                  </p>
+                )}
+                {dispatchMutation.isSuccess && (
+                  <p className="text-xs text-green-400">Workflow dispatched — check run history shortly.</p>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Results */}
+        {(loadMutation.data || isLoading) && (
+          <div className="card lg:col-span-2">
+            <>
+              <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+                <span className="section-title">Workflows</span>
+                {workflows.length > 0 && <span className="stat-chip">{workflows.length} total</span>}
+              </div>
+              {isLoading ? (
+                <div className="p-4 flex flex-col gap-2">
+                  {Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-8 w-full" />)}
+                </div>
+              ) : workflows.length === 0 ? (
+                <div className="px-4 py-8">
+                  <p className="text-sm text-muted-foreground">No workflows found in this repository.</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="border-b border-border">
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">Workflow</th>
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">State</th>
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">Last run</th>
+                        <th className="px-4 py-2" />
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {workflows.map((w) => (
+                        <tr key={w.id} className="hover:bg-muted/40 transition-colors">
+                          <td className="px-4 py-2.5 font-mono text-foreground/90">{w.name}</td>
+                          <td className="px-4 py-2.5 text-muted-foreground">{w.state}</td>
+                          <td className="px-4 py-2.5">
+                            {w.last_run_status ? (
+                              <span className="inline-flex items-center gap-1.5">
+                                <StatusIcon status={w.last_run_status} conclusion={w.last_run_conclusion} />
+                                <span className="text-muted-foreground">
+                                  {w.last_run_at ? relativeTime(w.last_run_at) : w.last_run_status}
+                                </span>
+                              </span>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-2.5 text-right">
+                            <Button
+                              variant="outline"
+                              className="h-6 px-2 text-[0.6875rem]"
+                              onClick={() => { setSelectedWorkflow(w); setDispatchArmed(false) }}
+                            >
+                              <Play className="size-3" />
+                              Dispatch
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {durationChartData.length > 0 && (
+                <div className="p-4 border-t border-border">
+                  <p className="section-label mb-3">Run duration (seconds, recent runs)</p>
+                  <BarGroupChart
+                    data={durationChartData}
+                    bars={[{ key: "seconds", color: CHART_COLORS.primary }]}
+                    height={180}
+                  />
+                </div>
+              )}
+
+              {runs.length > 0 && (
+                <div className="border-t border-border overflow-x-auto">
+                  <div className="px-4 py-3 border-b border-border">
+                    <span className="section-title">Run history</span>
+                  </div>
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="border-b border-border">
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">Run</th>
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">Branch</th>
+                        <th className="text-left text-muted-foreground font-medium px-4 py-2">Status</th>
+                        <th className="text-right text-muted-foreground font-medium px-4 py-2">Created</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {runs.map((r) => (
+                        <tr key={r.id} className="hover:bg-muted/40 transition-colors">
+                          <td className="px-4 py-2.5 font-mono text-foreground/80">{r.name ?? `#${r.id}`}</td>
+                          <td className="px-4 py-2.5 text-muted-foreground">{r.head_branch}</td>
+                          <td className="px-4 py-2.5">
+                            <span className="inline-flex items-center gap-1.5">
+                              <StatusIcon status={r.status} conclusion={r.conclusion} />
+                              <span className="text-muted-foreground">{r.conclusion ?? r.status}</span>
+                            </span>
+                          </td>
+                          <td className="px-4 py-2.5 text-right text-muted-foreground whitespace-nowrap">
+                            {relativeTime(r.created_at)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          </div>
+        )}
       </div>
     </>
   )

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -6,6 +6,7 @@ import type {
   CacheListResponse,
   CheckValue,
   CockpitResponse,
+  DispatchResponse,
   GithubMembershipStatus,
   GithubOrgInvitationsResponse,
   GithubOrgMembersResponse,
@@ -23,8 +24,10 @@ import type {
   RepoPullsResponse,
   RepoSecurityResponse,
   RepoStatsResponse,
+  RunsResponse,
   SavedTokenMeta,
   SyncInstallationsResponse,
+  WorkflowsResponse,
 } from "./types"
 
 const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
@@ -223,6 +226,30 @@ export const api = {
   },
   jobs: {
     list: () => get<JobOut[]>("/jobs"),
+  },
+  automation: {
+    // token is optional — same App-or-PAT fallback as the rest of the API, carried
+    // via header since these are GETs (see githubTokenHeader).
+    workflows: (owner: string, repo: string, token?: string) =>
+      get<WorkflowsResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/workflows`,
+        githubTokenHeader(token),
+      ),
+    runs: (owner: string, repo: string, token?: string, perPage = 10) =>
+      get<RunsResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=${perPage}`,
+        githubTokenHeader(token),
+      ),
+    dispatch: (
+      owner: string,
+      repo: string,
+      workflowId: number,
+      body: { token: string; ref: string; inputs?: Record<string, string> },
+    ) =>
+      post<DispatchResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/workflows/${workflowId}/dispatch`,
+        { ...body, token: body.token || undefined },
+      ),
   },
   github: {
     events: (org: string, token: string, perPage = 30) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -288,3 +288,38 @@ export interface CockpitResponse {
   total_cache_size_bytes: number
   cache_job_success_rate: number
 }
+
+export interface WorkflowSummary {
+  id: number
+  name: string
+  path: string
+  state: string
+  last_run_status: string | null
+  last_run_conclusion: string | null
+  last_run_at: string | null
+}
+
+export interface WorkflowsResponse {
+  repository: string
+  workflows: WorkflowSummary[]
+}
+
+export interface RunSummary {
+  id: number
+  name: string | null
+  status: string
+  conclusion: string | null
+  head_branch: string
+  created_at: string
+  duration_ms: number | null
+}
+
+export interface RunsResponse {
+  repository: string
+  runs: RunSummary[]
+}
+
+export interface DispatchResponse {
+  dispatched: boolean
+  message: string | null
+}

--- a/apps/ui/tests/components/automation-page.test.tsx
+++ b/apps/ui/tests/components/automation-page.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const workflowsMock = vi.fn();
+const runsMock = vi.fn();
+const dispatchMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: {
+      resolve: (...args: unknown[]) => tokensResolveMock(...args),
+      upsert: vi.fn(),
+    },
+    automation: {
+      workflows: (...args: unknown[]) => workflowsMock(...args),
+      runs: (...args: unknown[]) => runsMock(...args),
+      dispatch: (...args: unknown[]) => dispatchMock(...args),
+    },
+  },
+}));
+
+import AutomationPage from "@/app/automation/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AutomationPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AutomationPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    workflowsMock.mockReset();
+    runsMock.mockReset();
+    dispatchMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders no results panel before any repository is loaded", () => {
+    renderPage();
+    expect(screen.queryByText("Workflows")).not.toBeInTheDocument();
+    expect(workflowsMock).not.toHaveBeenCalled();
+  });
+
+  it("loads workflows and run history for the entered owner/repo", async () => {
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    workflowsMock.mockResolvedValue({
+      repository: "acme/demo",
+      workflows: [
+        { id: 1, name: "CI", path: ".github/workflows/ci.yml", state: "active", last_run_status: "completed", last_run_conclusion: "success", last_run_at: "2026-07-20T00:00:00Z" },
+      ],
+    });
+    runsMock.mockResolvedValue({
+      repository: "acme/demo",
+      runs: [
+        { id: 100, name: "CI", status: "completed", conclusion: "success", head_branch: "main", created_at: "2026-07-20T00:00:00Z", duration_ms: 60000 },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => {
+      expect(workflowsMock).toHaveBeenCalledWith("acme", "demo", "");
+      expect(runsMock).toHaveBeenCalledWith("acme", "demo", "");
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("CI").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("main")).toBeInTheDocument();
+  });
+
+  it("arms then confirms a workflow dispatch, calling the API only after the second click", async () => {
+    workflowsMock.mockResolvedValue({
+      repository: "acme/demo",
+      workflows: [{ id: 1, name: "CI", path: ".github/workflows/ci.yml", state: "active", last_run_status: null, last_run_conclusion: null, last_run_at: null }],
+    });
+    runsMock.mockResolvedValue({ repository: "acme/demo", runs: [] });
+    dispatchMock.mockResolvedValue({ dispatched: true, message: "Workflow dispatched." });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => expect(screen.getByText("CI")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /Dispatch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Dispatch workflow")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Dispatch workflow"));
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Confirm dispatch")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Confirm dispatch"));
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledWith("acme", "demo", 1, { token: "", ref: "main" });
+    });
+  });
+
+  it("surfaces an error message when loading workflows fails", async () => {
+    workflowsMock.mockRejectedValue(new Error("GitHub API unreachable"));
+    runsMock.mockResolvedValue({ repository: "acme/demo", runs: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub API unreachable")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/ui/tests/components/automation-page.test.tsx
+++ b/apps/ui/tests/components/automation-page.test.tsx
@@ -133,4 +133,107 @@ describe("AutomationPage", () => {
       expect(screen.getByText("GitHub API unreachable")).toBeInTheDocument();
     });
   });
+
+  it("shows a loading skeleton, then the empty state, when a repo has no workflows", async () => {
+    let resolveWorkflows: (v: unknown) => void = () => {};
+    workflowsMock.mockImplementation(
+      () => new Promise((res) => { resolveWorkflows = res; }),
+    );
+    runsMock.mockResolvedValue({ repository: "acme/demo", runs: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => expect(screen.getByText("Loading…")).toBeInTheDocument());
+
+    resolveWorkflows({ repository: "acme/demo", workflows: [] });
+
+    await waitFor(() => {
+      expect(screen.getByText("No workflows found in this repository.")).toBeInTheDocument();
+    });
+  });
+
+  it("submits the load request when Enter is pressed in the repository field", async () => {
+    workflowsMock.mockResolvedValue({ repository: "acme/demo", workflows: [] });
+    runsMock.mockResolvedValue({ repository: "acme/demo", runs: [] });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const repoInput = screen.getByPlaceholderText("e.g. hello-world");
+    fireEvent.change(repoInput, { target: { value: "demo" } });
+    fireEvent.keyDown(repoInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(workflowsMock).toHaveBeenCalledWith("acme", "demo", "");
+    });
+  });
+
+  it("saves a manually entered token and renders failure/pending status icons with fallback labels", async () => {
+    workflowsMock.mockResolvedValue({
+      repository: "acme/demo",
+      workflows: [
+        { id: 1, name: "CI", path: ".github/workflows/ci.yml", state: "active", last_run_status: "in_progress", last_run_conclusion: null, last_run_at: null },
+      ],
+    });
+    runsMock.mockResolvedValue({
+      repository: "acme/demo",
+      runs: [
+        { id: 200, name: null, status: "completed", conclusion: "failure", head_branch: "main", created_at: "2026-07-20T00:00:00Z", duration_ms: null },
+        { id: 201, name: "Build", status: "completed", conclusion: "cancelled", head_branch: "dev", created_at: "2026-07-20T00:00:00Z", duration_ms: null },
+      ],
+    });
+
+    const { api } = await import("@/lib/api/client");
+    const upsertMock = api.tokens.upsert as unknown as ReturnType<typeof vi.fn>;
+    upsertMock.mockReset();
+    upsertMock.mockResolvedValue({});
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.change(screen.getByPlaceholderText(/ghp_/), { target: { value: "ghp_manual123456789012345678901234" } });
+
+    await waitFor(() => expect(screen.getByText("Save token for this org")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Save token for this org"));
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledWith("acme", "ghp_manual123456789012345678901234"));
+
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => expect(screen.getByText("#200")).toBeInTheDocument());
+    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("in_progress")).toBeInTheDocument();
+  });
+
+  it("surfaces a dispatch error and lets the user edit the ref before retrying", async () => {
+    workflowsMock.mockResolvedValue({
+      repository: "acme/demo",
+      workflows: [{ id: 1, name: "CI", path: ".github/workflows/ci.yml", state: "active", last_run_status: null, last_run_conclusion: null, last_run_at: null }],
+    });
+    runsMock.mockResolvedValue({ repository: "acme/demo", runs: [] });
+    dispatchMock.mockRejectedValue(new Error("GitHub API error: 422"));
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. hello-world"), { target: { value: "demo" } });
+    fireEvent.click(screen.getByText("Load workflows"));
+
+    await waitFor(() => expect(screen.getByText("CI")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /Dispatch/i }));
+
+    const refInput = screen.getByDisplayValue("main");
+    fireEvent.change(refInput, { target: { value: "release" } });
+
+    fireEvent.click(screen.getByText("Dispatch workflow"));
+    fireEvent.click(screen.getByText("Confirm dispatch"));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub API error: 422")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -280,6 +280,54 @@ describe("api.collab", () => {
   });
 });
 
+describe("api.automation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("GETs /me/repos/{owner}/{repo}/workflows with an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({ repository: "acme/demo", workflows: [] });
+    const result = await api.automation.workflows("acme", "demo", "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/repos/acme/demo/workflows");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual({ repository: "acme/demo", workflows: [] });
+  });
+
+  it("GETs /me/repos/{owner}/{repo}/actions/runs with a default per_page of 10 and no token header when omitted", async () => {
+    stubOkJson({ repository: "acme/demo", runs: [] });
+    const result = await api.automation.runs("acme", "demo");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/repos/acme/demo/actions/runs?per_page=10");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBeUndefined();
+    expect(result).toEqual({ repository: "acme/demo", runs: [] });
+  });
+
+  it("GETs /me/repos/{owner}/{repo}/actions/runs with a custom per_page", async () => {
+    stubOkJson({ repository: "acme/demo", runs: [] });
+    await api.automation.runs("acme", "demo", "ghp_test", 25);
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("per_page=25");
+  });
+
+  it("POSTs to /me/repos/{owner}/{repo}/workflows/{id}/dispatch with token: undefined when empty", async () => {
+    stubOkJson({ dispatched: true, message: "Workflow dispatched." });
+    const result = await api.automation.dispatch("acme", "demo", 1, { token: "", ref: "main" });
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/repos/acme/demo/workflows/1/dispatch");
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined, ref: "main" });
+    expect(result).toEqual({ dispatched: true, message: "Workflow dispatched." });
+  });
+});
+
 describe("installations.lookup / installations.sync", () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary

Closes #180. Implements docs/plan.md Phase 13 ("Automation") end-to-end: workflow listing, run history, and workflow dispatch, both backend and frontend. Previously the Automation page was a bare `EmptyState` stub with no backend router at all.

## What changed and why

**Backend** — new `apps/api/src/routers/automation.py`, mounted in `main.py` alongside the other GitHub-proxy routers:
- `GET /orgs/{org_login}/repos/{owner}/{repo}/workflows` and the `/me/repos/{owner}/{repo}/workflows` personal-scoped equivalent — lists a repo's workflows. Overlays each workflow's most-recent-run status/conclusion/timestamp via a second, best-effort GitHub call (degrades gracefully like `collab.py`'s 2FA overlay — a failure here doesn't fail the whole response).
- `GET .../actions/runs` (+ `/me/...` equivalent) — run history with a computed `duration_ms` (from `run_started_at`/`updated_at`, `None` while a run is still in progress).
- `POST .../workflows/{workflow_id}/dispatch` (+ `/me/...` equivalent) — the one write endpoint, gated behind `require_org_role(min_role="admin")` for the org-scoped route. The issue's suggested fix flagged that the plan's original `require_role("admin")` spec predates Phase 5's RBAC removal — this uses the current `require_org_role("admin")` pattern from `actions_cache.py` instead. Writes an `audit_logs` row **before** the GitHub call (same order as `actions_cache.py`'s dry-run+audit pattern), so there's a record even if GitHub rejects the dispatch. There's no `dry_run` mode here — GitHub Actions has no dispatch-preview API, so the destructive-action UI reuses the arm/confirm two-click pattern from `CachePanel` but drops the separate "dry run" button that pattern also has.
- Reads use `X-GitHub-Token` (header, never query string) matching `collab.py`'s convention since these are GETs; the write uses a body token field matching `actions_cache.py`.
- New `apps/api/tests/test_automation.py` (12 tests): RBAC (member/admin/outsider), token-resolution fallback, overlay-failure degradation, duration computation, and — importantly — that the audit log is written even when the subsequent GitHub call fails.

**Frontend** — replaces the `apps/ui/app/automation/page.tsx` stub:
- Owner/repo/token config panel (same shape as `ReposPage`/`SecurityPage`), a "Load workflows" action that fires both the workflows and runs queries together.
- Workflow table with last-run status icons, a "Dispatch" action per row that opens an inline ref input + arm/confirm dispatch button (reusing `CachePanel`'s destructive-action UX, since no Dialog primitive exists in this repo yet).
- Run-duration bar chart (`BarGroupChart`) and a run-history table.
- New `api.automation.*` namespace in `lib/api/client.ts`, new types in `lib/api/types.ts`.
- New `apps/ui/tests/components/automation-page.test.tsx` (4 tests): initial empty state, load flow, arm/confirm dispatch (asserts the API is only called after the *second* click), and error surfacing.

No schema migration — this is all live GitHub reads plus one `audit_logs` write, no new persisted state. No `.env`/RBAC-config changes; the auth model itself (`require_org_role`) is unchanged, just applied to a new route.

## Test plan

- [x] `pytest -q apps/api/tests/test_automation.py` — 12/12 pass
- [x] `pytest -q` (full backend suite) — 406/406 pass
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` (full UI suite) — 215/215 pass