### PR TITLE
feat(api,ui): CEO/dev cockpit cards and My View panel (Phase 14)

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import anyio
 import httpx
@@ -16,9 +16,16 @@ from src.routers.github import _cached_events
 from src.schemas.analytics import (
     AnalyticsInput,
     AnalyticsResponse,
+    AtRiskRepo,
     CockpitResponse,
+    IssueSummary,
+    MilestoneSummary,
+    MyViewResponse,
     OrgEventSummary,
+    PRSummary,
+    PrCycleTimeWeek,
     PrWeekBucket,
+    RunSummaryLite,
     ScanHistoryEntry,
 )
 from src.services.analytics_service import get_account_type, get_overview
@@ -259,6 +266,147 @@ def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> in
         return 0
 
 
+def _milestone_state(due_on: str | None, progress_pct: float) -> str:
+    if not due_on:
+        return "on_track"
+    try:
+        due = datetime.fromisoformat(due_on.replace("Z", "+00:00"))
+    except ValueError:
+        return "on_track"
+    now = datetime.now(timezone.utc)
+    if due < now:
+        return "overdue"
+    if due - now < timedelta(days=7) and progress_pct < 70:
+        return "at_risk"
+    return "on_track"
+
+
+def _safe_milestones(owner: str, token: str, repo_names: list[str]) -> tuple[list[MilestoneSummary], list[AtRiskRepo]]:
+    """Fetches each repo's open milestones, best-effort per repo (one slow/broken repo
+    doesn't blank out every other repo's milestones, unlike _safe_commit_activity_4w's
+    all-or-nothing contract -- milestone data is naturally per-repo and independent)."""
+    client = GitHubClient(token)
+    milestones: list[MilestoneSummary] = []
+
+    def _fetch(repo: str) -> list[dict]:
+        try:
+            return client.request("GET", f"/repos/{owner}/{repo}/milestones", params={"state": "open"})
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return []
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(_fetch, repo): repo for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]}
+        for future, repo in futures.items():
+            for m in future.result():
+                open_issues = m.get("open_issues", 0)
+                closed_issues = m.get("closed_issues", 0)
+                total = open_issues + closed_issues
+                progress_pct = round((closed_issues / total) * 100, 1) if total else 0.0
+                due_on = m.get("due_on")
+                milestones.append(
+                    MilestoneSummary(
+                        repo=repo,
+                        title=m.get("title", ""),
+                        due_on=due_on,
+                        open_issues=open_issues,
+                        closed_issues=closed_issues,
+                        progress_pct=progress_pct,
+                        state=_milestone_state(due_on, progress_pct),
+                    )
+                )
+
+    milestones.sort(key=lambda m: (m.due_on is None, m.due_on))
+
+    at_risk_by_repo: dict[str, AtRiskRepo] = {}
+    for m in milestones:
+        if m.state == "on_track":
+            continue
+        severity = "critical" if m.state == "overdue" else "warning"
+        reason = (
+            f"Milestone '{m.title}' overdue"
+            if m.state == "overdue"
+            else f"Milestone '{m.title}' due soon at {m.progress_pct:.0f}% complete"
+        )
+        existing = at_risk_by_repo.get(m.repo)
+        if existing is None:
+            at_risk_by_repo[m.repo] = AtRiskRepo(repo=m.repo, reasons=[reason], severity=severity)
+        else:
+            existing.reasons.append(reason)
+            if severity == "critical":
+                existing.severity = "critical"
+
+    at_risk_repos = sorted(at_risk_by_repo.values(), key=lambda r: r.severity != "critical")
+    return milestones[:10], at_risk_repos[:10]
+
+
+def _week_pr_cycle_time(client: GitHubClient, owner: str, start: date) -> PrCycleTimeWeek:
+    # closed_at approximates merge time for a merged PR (search API's issues endpoint
+    # doesn't expose merged_at directly) -- an approximation, same spirit as Phase 18's
+    # documented "last activity" sampling elsewhere in this codebase.
+    result = client.request(
+        "GET",
+        "/search/issues",
+        params={"q": f"org:{owner} type:pr merged:{start}..{start + timedelta(days=7)}", "per_page": 30},
+    )
+    items = result.get("items", []) if isinstance(result, dict) else []
+    days: list[float] = []
+    for item in items:
+        try:
+            created = datetime.fromisoformat(item["created_at"].replace("Z", "+00:00"))
+            closed = datetime.fromisoformat(item["closed_at"].replace("Z", "+00:00"))
+        except (KeyError, TypeError, ValueError):
+            continue
+        days.append((closed - created).total_seconds() / 86400)
+    avg_days = round(sum(days) / len(days), 1) if days else 0.0
+    return PrCycleTimeWeek(week=start.isoformat(), avg_days=avg_days)
+
+
+def _safe_pr_cycle_time_8w(owner: str, token: str) -> list[PrCycleTimeWeek]:
+    try:
+        client = GitHubClient(token)
+        week_starts = [_week_start(weeks_ago) for weeks_ago in range(7, -1, -1)]
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(_week_pr_cycle_time, client, owner, start) for start in week_starts]
+            return [f.result() for f in futures]
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return []
+
+
+def _safe_release_cadence_4w(owner: str, token: str, repo_names: list[str]) -> list[int]:
+    """Weekly release counts across the org's repos for the last 4 weeks -- a coarse
+    KPI signal for the CEO cockpit, distinct in shape/purpose from the full per-release
+    timeline docs/plan.md Phase 17 adds separately."""
+    week_starts = [_week_start(weeks_ago) for weeks_ago in range(3, -1, -1)]
+    totals = [0, 0, 0, 0]
+
+    def _fetch(repo: str) -> list[dict]:
+        try:
+            client = GitHubClient(token)
+            return client.request("GET", f"/repos/{owner}/{repo}/releases", params={"per_page": 20})
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return []
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = [pool.submit(_fetch, repo) for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]]
+        for future in futures:
+            releases = future.result()
+            if not isinstance(releases, list):
+                continue
+            for r in releases:
+                published_at = r.get("published_at")
+                if not published_at:
+                    continue
+                try:
+                    published = datetime.fromisoformat(published_at.replace("Z", "+00:00")).date()
+                except ValueError:
+                    continue
+                for i, start in enumerate(week_starts):
+                    if start <= published < start + timedelta(days=7):
+                        totals[i] += 1
+                        break
+    return totals
+
+
 def _cache_job_success_rate(db: Session) -> float:
     jobs = job_repo.list_recent_by_type(db, job_type=_CACHE_JOB_TYPE, limit=20)
     done = sum(1 for j in jobs if j["status"] == "done")
@@ -300,6 +448,9 @@ async def personal_analytics_cockpit(
         pr_merge_rate_4w,
         commit_activity_4w,
         total_cache_size_bytes,
+        (milestones, at_risk_repos),
+        pr_cycle_time_8w,
+        release_cadence_4w,
     ) = await asyncio.gather(
         anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
@@ -307,6 +458,9 @@ async def personal_analytics_cockpit(
         anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
+        anyio.to_thread.run_sync(lambda: _safe_milestones(owner, token, repo_names)),
+        anyio.to_thread.run_sync(lambda: _safe_pr_cycle_time_8w(owner, token)),
+        anyio.to_thread.run_sync(lambda: _safe_release_cadence_4w(owner, token, repo_names)),
     )
 
     return CockpitResponse(
@@ -320,4 +474,135 @@ async def personal_analytics_cockpit(
         commit_activity_4w=commit_activity_4w,
         total_cache_size_bytes=total_cache_size_bytes,
         cache_job_success_rate=cache_job_success_rate,
+        at_risk_repos=at_risk_repos,
+        milestones=milestones,
+        pr_cycle_time_8w=pr_cycle_time_8w,
+        release_cadence_4w=release_cadence_4w,
+    )
+
+
+# ---------------------------------------------------------------------------
+# My View (docs/plan.md Phase 14) -- a single GitHub-scoped account's own open PRs,
+# review queue, assigned issues, and recent workflow runs, resolved via the same
+# per-owner token as the cockpit. GitHub's search API works across every repo the
+# token can see (not just `owner`'s), so my_open_prs/review_requests/assigned_issues
+# aren't scoped to `owner` -- only the token-resolution step is.
+# ---------------------------------------------------------------------------
+
+_MAX_REPOS_FOR_RUN_LOOKUP = 15
+
+
+def _my_login(client: GitHubClient) -> str | None:
+    try:
+        data = client.request("GET", "/user")
+        return data.get("login") if isinstance(data, dict) else None
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        # Installation (App) tokens aren't user-to-server tokens and can't call /user --
+        # degrade to an empty MyViewResponse rather than 500 the whole page.
+        return None
+
+
+def _search_items(client: GitHubClient, query: str, per_page: int = 10) -> list[dict]:
+    try:
+        result = client.request("GET", "/search/issues", params={"q": query, "per_page": per_page})
+        return result.get("items", []) if isinstance(result, dict) else []
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return []
+
+
+def _pr_summaries(items: list[dict]) -> list[PRSummary]:
+    return [
+        PRSummary(
+            number=i["number"],
+            title=i.get("title", ""),
+            repository=i.get("repository_url", "").split("/repos/")[-1],
+            html_url=i.get("html_url", ""),
+            updated_at=i["updated_at"],
+        )
+        for i in items
+        if "number" in i and "updated_at" in i
+    ]
+
+
+def _issue_summaries(items: list[dict]) -> list[IssueSummary]:
+    return [
+        IssueSummary(
+            number=i["number"],
+            title=i.get("title", ""),
+            repository=i.get("repository_url", "").split("/repos/")[-1],
+            html_url=i.get("html_url", ""),
+            updated_at=i["updated_at"],
+        )
+        for i in items
+        if "number" in i and "updated_at" in i
+    ]
+
+
+def _safe_my_recent_runs(client: GitHubClient, owner: str, login: str, repo_names: list[str]) -> list[RunSummaryLite]:
+    def _fetch(repo: str) -> list[dict]:
+        try:
+            data = client.request(
+                "GET", f"/repos/{owner}/{repo}/actions/runs", params={"actor": login, "per_page": 5}
+            )
+            return data.get("workflow_runs", []) if isinstance(data, dict) else []
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return []
+
+    runs: list[RunSummaryLite] = []
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(_fetch, repo): repo for repo in repo_names[:_MAX_REPOS_FOR_RUN_LOOKUP]}
+        for future, repo in futures.items():
+            for r in future.result():
+                runs.append(
+                    RunSummaryLite(
+                        repository=f"{owner}/{repo}",
+                        id=r["id"],
+                        name=r.get("name"),
+                        status=r["status"],
+                        conclusion=r.get("conclusion"),
+                        html_url=r.get("html_url", ""),
+                        created_at=r["created_at"],
+                    )
+                )
+    runs.sort(key=lambda r: r.created_at, reverse=True)
+    return runs[:10]
+
+
+@router.get("/me/github/my-view", response_model=MyViewResponse)
+async def my_view(
+    owner: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = await anyio.to_thread.run_sync(
+            lambda: resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=x_github_token)
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    client = GitHubClient(token)
+    login = await anyio.to_thread.run_sync(lambda: _my_login(client))
+    if login is None:
+        return MyViewResponse()
+
+    try:
+        repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        repos = []
+    repo_names = [r["name"] for r in repos]
+
+    (my_open_prs_raw, review_requests_raw, assigned_issues_raw, my_recent_runs) = await asyncio.gather(
+        anyio.to_thread.run_sync(lambda: _search_items(client, f"is:pr is:open author:{login}")),
+        anyio.to_thread.run_sync(lambda: _search_items(client, f"is:pr is:open review-requested:{login}")),
+        anyio.to_thread.run_sync(lambda: _search_items(client, f"is:issue is:open assignee:{login}")),
+        anyio.to_thread.run_sync(lambda: _safe_my_recent_runs(client, owner, login, repo_names)),
+    )
+
+    return MyViewResponse(
+        my_open_prs=_pr_summaries(my_open_prs_raw),
+        review_requests=_pr_summaries(review_requests_raw),
+        assigned_issues=_issue_summaries(assigned_issues_raw),
+        my_recent_runs=my_recent_runs,
     )

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -343,10 +343,13 @@ def _week_pr_cycle_time(client: GitHubClient, owner: str, start: date) -> PrCycl
     # closed_at approximates merge time for a merged PR (search API's issues endpoint
     # doesn't expose merged_at directly) -- an approximation, same spirit as Phase 18's
     # documented "last activity" sampling elsewhere in this codebase.
+    # GitHub's search API date qualifiers are inclusive on both ends at day granularity,
+    # so the window end is `+6 days` (a 7-day span) not `+7` -- otherwise a PR merged
+    # exactly on a week-boundary day would double-count into both adjacent weeks.
     result = client.request(
         "GET",
         "/search/issues",
-        params={"q": f"org:{owner} type:pr merged:{start}..{start + timedelta(days=7)}", "per_page": 30},
+        params={"q": f"org:{owner} type:pr merged:{start}..{start + timedelta(days=6)}", "per_page": 30},
     )
     items = result.get("items", []) if isinstance(result, dict) else []
     days: list[float] = []

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, SecretStr
 
@@ -44,6 +45,27 @@ class PrWeekBucket(BaseModel):
     merged: int
 
 
+class AtRiskRepo(BaseModel):
+    repo: str
+    reasons: list[str]
+    severity: Literal["warning", "critical"]
+
+
+class MilestoneSummary(BaseModel):
+    repo: str
+    title: str
+    due_on: datetime | None
+    open_issues: int
+    closed_issues: int
+    progress_pct: float
+    state: Literal["on_track", "at_risk", "overdue"]
+
+
+class PrCycleTimeWeek(BaseModel):
+    week: str
+    avg_days: float
+
+
 class CockpitResponse(BaseModel):
     repo_count: int
     member_count: int
@@ -55,3 +77,40 @@ class CockpitResponse(BaseModel):
     commit_activity_4w: list[int]
     total_cache_size_bytes: int
     cache_job_success_rate: float
+    at_risk_repos: list[AtRiskRepo] = []
+    milestones: list[MilestoneSummary] = []
+    pr_cycle_time_8w: list[PrCycleTimeWeek] = []
+    release_cadence_4w: list[int] = []
+
+
+class PRSummary(BaseModel):
+    number: int
+    title: str
+    repository: str
+    html_url: str
+    updated_at: datetime
+
+
+class IssueSummary(BaseModel):
+    number: int
+    title: str
+    repository: str
+    html_url: str
+    updated_at: datetime
+
+
+class RunSummaryLite(BaseModel):
+    repository: str
+    id: int
+    name: str | None
+    status: str
+    conclusion: str | None
+    html_url: str
+    created_at: datetime
+
+
+class MyViewResponse(BaseModel):
+    my_open_prs: list[PRSummary] = []
+    review_requests: list[PRSummary] = []
+    assigned_issues: list[IssueSummary] = []
+    my_recent_runs: list[RunSummaryLite] = []

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -1,5 +1,6 @@
 """Tests for the Overview cockpit aggregate endpoint (docs/plan.md Phase 12)."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import httpx
@@ -371,6 +372,45 @@ def test_safe_milestones_one_bad_repo_does_not_blank_others():
     assert milestones[0].repo == "repo-good"
 
 
+def test_milestone_state_unparsable_due_on_treated_as_on_track():
+    from src.routers.analytics import _milestone_state
+
+    assert _milestone_state("not-a-real-date", 0.0) == "on_track"
+
+
+def test_milestone_state_at_risk_when_due_soon_and_below_threshold():
+    from src.routers.analytics import _milestone_state
+
+    soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+    assert _milestone_state(soon, 40.0) == "at_risk"
+
+
+def test_milestone_state_on_track_when_due_soon_but_above_threshold():
+    from src.routers.analytics import _milestone_state
+
+    soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+    assert _milestone_state(soon, 90.0) == "on_track"
+
+
+def test_safe_milestones_multiple_overdue_milestones_same_repo_collect_both_reasons():
+    """Two overdue milestones in the same repo: the repo's aggregated at_risk entry
+    should collect both reasons (not just the first one it saw)."""
+    from src.routers.analytics import _safe_milestones
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [
+            {"title": "v1-overdue", "due_on": "2020-01-01T00:00:00Z", "open_issues": 3, "closed_issues": 1},
+            {"title": "v2-overdue", "due_on": "2020-02-01T00:00:00Z", "open_issues": 5, "closed_issues": 0},
+        ]
+        milestones, at_risk = _safe_milestones("acme", "ghp_test", ["repo-a"])
+
+    assert len(milestones) == 2
+    assert len(at_risk) == 1
+    assert at_risk[0].repo == "repo-a"
+    assert at_risk[0].severity == "critical"
+    assert len(at_risk[0].reasons) == 2
+
+
 # ---------------------------------------------------------------------------
 # PR cycle time / release cadence (docs/plan.md Phase 14)
 # ---------------------------------------------------------------------------
@@ -408,6 +448,22 @@ def test_safe_pr_cycle_time_8w_zero_when_no_merges():
     assert all(b.avg_days == 0.0 for b in buckets)
 
 
+def test_safe_pr_cycle_time_8w_skips_malformed_search_items():
+    """An item missing closed_at (or with a garbage timestamp) shouldn't blow up the
+    week's average -- it's just excluded from that week's day-count."""
+    from src.routers.analytics import _safe_pr_cycle_time_8w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {
+            "items": [
+                {"created_at": "2026-01-01T00:00:00Z"},  # missing closed_at -> KeyError
+                {"created_at": "2026-01-01T00:00:00Z", "closed_at": "not-a-date"},  # ValueError
+            ]
+        }
+        buckets = _safe_pr_cycle_time_8w("acme", "ghp_test")
+    assert all(b.avg_days == 0.0 for b in buckets)
+
+
 def test_safe_release_cadence_4w_returns_zeros_on_error():
     from src.routers.analytics import _safe_release_cadence_4w
 
@@ -417,8 +473,6 @@ def test_safe_release_cadence_4w_returns_zeros_on_error():
 
 
 def test_safe_release_cadence_4w_buckets_by_week():
-    from datetime import timedelta
-
     from src.routers.analytics import _safe_release_cadence_4w, _week_start
 
     this_week_release = {"published_at": (_week_start(0) + timedelta(days=1)).isoformat() + "T00:00:00Z"}
@@ -427,3 +481,21 @@ def test_safe_release_cadence_4w_buckets_by_week():
         totals = _safe_release_cadence_4w("acme", "ghp_test", ["repo-a"])
     assert totals[3] == 1
     assert sum(totals) == 1
+
+
+def test_safe_release_cadence_4w_skips_non_list_response_and_missing_or_bad_dates():
+    from src.routers.analytics import _safe_release_cadence_4w
+
+    def _side_effect(method, path, params=None):
+        if "repo-not-a-list" in path:
+            return {"message": "not found"}  # not a list -> skipped entirely
+        return [
+            {"published_at": None},  # missing published_at -> skipped
+            {"published_at": "not-a-real-timestamp"},  # unparsable -> skipped
+        ]
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        totals = _safe_release_cadence_4w("acme", "ghp_test", ["repo-not-a-list", "repo-b"])
+
+    assert totals == [0, 0, 0, 0]

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -54,6 +54,9 @@ _DEFAULT_SAFE_MOCKS = {
     "src.routers.analytics._safe_pr_merge_rate_4w": {"return_value": []},
     "src.routers.analytics._safe_commit_activity_4w": {"return_value": [1, 2, 3, 4]},
     "src.routers.analytics._safe_total_cache_bytes": {"return_value": 123456},
+    "src.routers.analytics._safe_milestones": {"return_value": ([], [])},
+    "src.routers.analytics._safe_pr_cycle_time_8w": {"return_value": []},
+    "src.routers.analytics._safe_release_cadence_4w": {"return_value": [0, 0, 0, 0]},
 }
 
 
@@ -306,3 +309,121 @@ def test_cache_job_success_rate_ignores_other_job_types(db):
     db.add(job)
     db.commit()
     assert _cache_job_success_rate(db) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Milestones / at-risk repos (docs/plan.md Phase 14)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_milestones_returns_empty_on_error():
+    from src.routers.analytics import _safe_milestones
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        milestones, at_risk = _safe_milestones("acme", "ghp_test", ["repo-a"])
+    assert milestones == []
+    assert at_risk == []
+
+
+def test_safe_milestones_flags_overdue_as_critical():
+    from src.routers.analytics import _safe_milestones
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [
+            {"title": "v1", "due_on": "2020-01-01T00:00:00Z", "open_issues": 3, "closed_issues": 1}
+        ]
+        milestones, at_risk = _safe_milestones("acme", "ghp_test", ["repo-a"])
+
+    assert milestones[0].state == "overdue"
+    assert milestones[0].progress_pct == 25.0
+    assert len(at_risk) == 1
+    assert at_risk[0].repo == "repo-a"
+    assert at_risk[0].severity == "critical"
+
+
+def test_safe_milestones_on_track_when_no_due_date():
+    from src.routers.analytics import _safe_milestones
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [
+            {"title": "backlog", "due_on": None, "open_issues": 0, "closed_issues": 0}
+        ]
+        milestones, at_risk = _safe_milestones("acme", "ghp_test", ["repo-a"])
+
+    assert milestones[0].state == "on_track"
+    assert at_risk == []
+
+
+def test_safe_milestones_one_bad_repo_does_not_blank_others():
+    from src.routers.analytics import _safe_milestones
+
+    def _side_effect(method, path, params=None):
+        if "repo-bad" in path:
+            raise httpx.RequestError("boom")
+        return [{"title": "v1", "due_on": None, "open_issues": 0, "closed_issues": 0}]
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        milestones, _ = _safe_milestones("acme", "ghp_test", ["repo-bad", "repo-good"])
+
+    assert len(milestones) == 1
+    assert milestones[0].repo == "repo-good"
+
+
+# ---------------------------------------------------------------------------
+# PR cycle time / release cadence (docs/plan.md Phase 14)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_pr_cycle_time_8w_returns_empty_on_error():
+    from src.routers.analytics import _safe_pr_cycle_time_8w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_pr_cycle_time_8w("acme", "ghp_test") == []
+
+
+def test_safe_pr_cycle_time_8w_computes_average_days():
+    from src.routers.analytics import _safe_pr_cycle_time_8w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {
+            "items": [
+                {"created_at": "2026-01-01T00:00:00Z", "closed_at": "2026-01-03T00:00:00Z"},
+                {"created_at": "2026-01-01T00:00:00Z", "closed_at": "2026-01-05T00:00:00Z"},
+            ]
+        }
+        buckets = _safe_pr_cycle_time_8w("acme", "ghp_test")
+    assert len(buckets) == 8
+    assert all(b.avg_days == 3.0 for b in buckets)
+
+
+def test_safe_pr_cycle_time_8w_zero_when_no_merges():
+    from src.routers.analytics import _safe_pr_cycle_time_8w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {"items": []}
+        buckets = _safe_pr_cycle_time_8w("acme", "ghp_test")
+    assert all(b.avg_days == 0.0 for b in buckets)
+
+
+def test_safe_release_cadence_4w_returns_zeros_on_error():
+    from src.routers.analytics import _safe_release_cadence_4w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_release_cadence_4w("acme", "ghp_test", ["repo-a"]) == [0, 0, 0, 0]
+
+
+def test_safe_release_cadence_4w_buckets_by_week():
+    from datetime import timedelta
+
+    from src.routers.analytics import _safe_release_cadence_4w, _week_start
+
+    this_week_release = {"published_at": (_week_start(0) + timedelta(days=1)).isoformat() + "T00:00:00Z"}
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [this_week_release]
+        totals = _safe_release_cadence_4w("acme", "ghp_test", ["repo-a"])
+    assert totals[3] == 1
+    assert sum(totals) == 1

--- a/apps/api/tests/test_analytics_my_view.py
+++ b/apps/api/tests/test_analytics_my_view.py
@@ -127,3 +127,75 @@ def test_my_view_falls_back_to_client_supplied_token_header(http):
 
     assert resp.status_code == 200
     assert resp.json()["my_open_prs"] == []
+
+
+def test_my_view_repos_fetch_failure_degrades_to_empty_recent_runs(http):
+    """If the repo-list call itself fails, my-view should still return 200 with an
+    empty my_recent_runs rather than propagating the error (repos are only used for
+    the recent-runs fan-out here, not required for the search-based PR/issue lists)."""
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            return {"items": []}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        mock_client.return_value.request_paginated.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/orgs/acme/repos"),
+            response=httpx.Response(500, request=httpx.Request("GET", "https://api.github.com/orgs/acme/repos")),
+        )
+        resp = http.get("/me/github/my-view?owner=acme")
+
+    assert resp.status_code == 200
+    assert resp.json()["my_recent_runs"] == []
+
+
+def test_my_view_search_failure_degrades_each_list_to_empty_but_still_returns_recent_runs(http):
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            raise httpx.HTTPStatusError(
+                "boom",
+                request=httpx.Request("GET", "https://api.github.com/search/issues"),
+                response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/search/issues")),
+            )
+        if path == "/repos/acme/demo/actions/runs":
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 1,
+                        "name": "CI",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "html_url": "https://github.com/acme/demo/actions/runs/1",
+                        "created_at": "2026-07-20T00:00:00Z",
+                    }
+                ]
+            }
+        if path == "/repos/acme/bad/actions/runs":
+            raise httpx.RequestError("boom")
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        mock_client.return_value.request_paginated.return_value = [{"name": "demo"}, {"name": "bad"}]
+        resp = http.get("/me/github/my-view?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["my_open_prs"] == []
+    assert body["review_requests"] == []
+    assert body["assigned_issues"] == []
+    assert len(body["my_recent_runs"]) == 1
+    assert body["my_recent_runs"][0]["repository"] == "acme/demo"

--- a/apps/api/tests/test_analytics_my_view.py
+++ b/apps/api/tests/test_analytics_my_view.py
@@ -1,0 +1,129 @@
+"""Tests for the My View endpoint (docs/plan.md Phase 14)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.routers.analytics import router
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "myview@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
+    a = FastAPI()
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture()
+def http(app):
+    return TestClient(app)
+
+
+def test_my_view_requires_auth(db):
+    a = FastAPI()
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    resp = TestClient(a).get("/me/github/my-view?owner=acme")
+    assert resp.status_code == 401
+
+
+def test_my_view_no_token_available_returns_400(http):
+    resp = http.get("/me/github/my-view?owner=acme")
+    assert resp.status_code == 400
+
+
+def test_my_view_degrades_to_empty_when_login_unresolvable(http):
+    """An installation (App) token can't call GET /user -- this should degrade to an
+    empty MyViewResponse, not 500 the page."""
+    with (
+        patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
+        resp = http.get("/me/github/my-view?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"my_open_prs": [], "review_requests": [], "assigned_issues": [], "my_recent_runs": []}
+
+
+def test_my_view_success(http):
+    pr_item = {
+        "number": 12,
+        "title": "Fix bug",
+        "repository_url": "https://api.github.com/repos/acme/api",
+        "html_url": "https://github.com/acme/api/pull/12",
+        "updated_at": "2026-07-20T00:00:00Z",
+    }
+    issue_item = {
+        "number": 3,
+        "title": "Investigate flake",
+        "repository_url": "https://api.github.com/repos/acme/worker",
+        "html_url": "https://github.com/acme/worker/issues/3",
+        "updated_at": "2026-07-19T00:00:00Z",
+    }
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/orgs/acme/repos":
+            return {"total_count": 0}
+        if path == "/search/issues":
+            q = params["q"]
+            if "author:octocat" in q:
+                return {"items": [pr_item]}
+            if "review-requested:octocat" in q:
+                return {"items": []}
+            if "assignee:octocat" in q:
+                return {"items": [issue_item]}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_personal_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        mock_client.return_value.request_paginated.return_value = []
+        resp = http.get("/me/github/my-view?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["my_open_prs"]) == 1
+    assert body["my_open_prs"][0]["repository"] == "acme/api"
+    assert body["review_requests"] == []
+    assert len(body["assigned_issues"]) == 1
+    assert body["assigned_issues"][0]["repository"] == "acme/worker"
+    assert body["my_recent_runs"] == []
+
+
+def test_my_view_falls_back_to_client_supplied_token_header(http):
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        resp = http.get("/me/github/my-view?owner=acme", headers={"X-GitHub-Token": "ghp_client"})
+
+    assert resp.status_code == 200
+    assert resp.json()["my_open_prs"] == []

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -8,9 +8,40 @@ import { StatCard } from "@/components/stat-card"
 import { EventActivityList } from "@/components/event-activity-list"
 import { AreaTimeChart } from "@/components/charts/area-time-chart"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
-import { ArrowRight } from "@phosphor-icons/react"
+import { ArrowRight, Warning } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { CHART_COLORS } from "@/lib/charts/theme"
+import { relativeTime } from "@/lib/format"
+import type { MyViewIssueSummary, MyViewPRSummary } from "@/lib/api/types"
+
+const MY_VIEW_TABS = [
+  { id: "prs", label: "My PRs" },
+  { id: "reviews", label: "Review Queue" },
+  { id: "issues", label: "Assigned Issues" },
+] as const
+
+type MyViewTabId = (typeof MY_VIEW_TABS)[number]["id"]
+
+function MyViewRow({ item }: { item: MyViewPRSummary | MyViewIssueSummary }) {
+  return (
+    <a
+      href={item.html_url}
+      target="_blank"
+      rel="noreferrer"
+      className="flex items-center justify-between px-3 py-2 text-sm hover:bg-elevated transition-colors"
+    >
+      <span className="flex flex-col min-w-0">
+        <span className="text-foreground/90 truncate">{item.title}</span>
+        <span className="text-[0.6875rem] text-muted-foreground font-mono">
+          {item.repository} #{item.number}
+        </span>
+      </span>
+      <span className="text-[0.6875rem] text-muted-foreground whitespace-nowrap shrink-0 ml-3">
+        {relativeTime(item.updated_at)}
+      </span>
+    </a>
+  )
+}
 
 const quickActions = [
   { label: "Run Security Scan",  href: "/security" },
@@ -72,6 +103,15 @@ export default function OverviewPage() {
   })
   const cockpit = cockpitQuery.data
 
+  const [myViewTab, setMyViewTab] = useState<MyViewTabId>("prs")
+  const myViewQuery = useQuery({
+    queryKey: ["analytics.my-view", org],
+    queryFn: () => api.analytics.myView(org, resolveQuery.data?.token),
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    retry: false,
+  })
+  const myView = myViewQuery.data
+
   const commitActivityData = (cockpit?.commit_activity_4w ?? []).map((value, i) => ({
     week: `W${i + 1}`,
     value,
@@ -85,6 +125,18 @@ export default function OverviewPage() {
     opened: b.opened,
     merged: b.merged,
   }))
+  const cycleTimeData = (cockpit?.pr_cycle_time_8w ?? []).map((b, i) => ({
+    week: `W${i + 1}`,
+    value: b.avg_days,
+  }))
+  const releaseCadenceData = (cockpit?.release_cadence_4w ?? []).map((count, i) => ({
+    name: `W${i + 1}`,
+    releases: count,
+  }))
+  const atRiskRepos = cockpit?.at_risk_repos ?? []
+  const milestones = cockpit?.milestones ?? []
+  const myViewItems: (MyViewPRSummary | MyViewIssueSummary)[] =
+    myViewTab === "prs" ? myView?.my_open_prs ?? [] : myViewTab === "reviews" ? myView?.review_requests ?? [] : myView?.assigned_issues ?? []
 
   return (
     <>
@@ -174,6 +226,134 @@ export default function OverviewPage() {
             isLoading={cockpitQuery.isLoading}
             limit={5}
           />
+        </div>
+      </div>
+
+      {atRiskRepos.length > 0 && (
+        <div className="card mb-6">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">Needs Attention</span>
+          </div>
+          <div className="divide-y divide-border">
+            {atRiskRepos.map((r) => (
+              <div
+                key={r.repo}
+                className={`px-4 py-3 border-l-2 ${r.severity === "critical" ? "border-red-500" : "border-yellow-500"}`}
+              >
+                <div className="flex items-center gap-2">
+                  <Warning className={`size-3.5 shrink-0 ${r.severity === "critical" ? "text-red-400" : "text-yellow-400"}`} />
+                  <span className="text-sm font-mono text-foreground/90">{r.repo}</span>
+                </div>
+                <ul className="mt-1 ml-5 text-xs text-muted-foreground list-disc">
+                  {r.reasons.map((reason) => <li key={reason}>{reason}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2 mb-6">
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">Milestone Burndown</span>
+          </div>
+          {milestones.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">No open milestones</p>
+          ) : (
+            <div className="divide-y divide-border">
+              {milestones.map((m) => (
+                <div key={`${m.repo}-${m.title}`} className="px-4 py-3">
+                  <div className="flex items-center justify-between gap-2 mb-1.5">
+                    <span className="text-sm text-foreground/90 truncate">
+                      <span className="font-mono text-muted-foreground">{m.repo}</span> · {m.title}
+                    </span>
+                    <span
+                      className={`stat-chip shrink-0 ${
+                        m.state === "overdue"
+                          ? "text-red-400 border-red-500/30"
+                          : m.state === "at_risk"
+                            ? "text-yellow-400 border-yellow-500/30"
+                            : ""
+                      }`}
+                    >
+                      {m.state.replace("_", " ")}
+                    </span>
+                  </div>
+                  <div className="h-1.5 rounded-full bg-elevated overflow-hidden">
+                    <div
+                      className="h-full bg-primary"
+                      style={{ width: `${Math.min(100, m.progress_pct)}%` }}
+                    />
+                  </div>
+                  <p className="text-[0.6875rem] text-muted-foreground mt-1">
+                    {m.closed_issues}/{m.open_issues + m.closed_issues} closed
+                    {m.due_on && <> · due {relativeTime(m.due_on)}</>}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-1.5">
+            {MY_VIEW_TABS.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setMyViewTab(t.id)}
+                aria-pressed={myViewTab === t.id}
+                className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
+                  myViewTab === t.id
+                    ? "border-border bg-elevated text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-elevated"
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+          {myViewQuery.isLoading ? (
+            <p className="p-4 text-sm text-muted-foreground">Loading…</p>
+          ) : myViewItems.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">Nothing here right now</p>
+          ) : (
+            <div className="divide-y divide-border">
+              {myViewItems.map((item) => <MyViewRow key={`${item.repository}-${item.number}`} item={item} />)}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2 mb-6">
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">Release Cadence (4w)</span>
+          </div>
+          <div className="p-4">
+            {releaseCadenceData.some((d) => d.releases > 0) ? (
+              <BarGroupChart
+                data={releaseCadenceData}
+                bars={[{ key: "releases", color: CHART_COLORS.series[1] }]}
+                height={160}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">No releases in the last 4 weeks</p>
+            )}
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-label">PR Cycle Time (8w, avg days)</span>
+          </div>
+          <div className="p-4">
+            {cycleTimeData.some((d) => d.value > 0) ? (
+              <AreaTimeChart data={cycleTimeData} label="days" color={CHART_COLORS.series[2]} height={160} />
+            ) : (
+              <p className="text-sm text-muted-foreground">No merged pull requests yet</p>
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -17,6 +17,7 @@ import type {
   InvitationPreview,
   JobOut,
   MyOrgMembership,
+  MyViewResponse,
   OrgEventsResponse,
   PendingInvitationSummary,
   RepoListResponse,
@@ -185,6 +186,8 @@ export const api = {
     // carried via header since this is a GET (see githubTokenHeader).
     cockpit: (owner: string, token?: string) =>
       get<CockpitResponse>(`/me/analytics/cockpit/${encodeURIComponent(owner)}`, githubTokenHeader(token)),
+    myView: (owner: string, token?: string) =>
+      get<MyViewResponse>(`/me/github/my-view?owner=${encodeURIComponent(owner)}`, githubTokenHeader(token)),
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -276,6 +276,27 @@ export interface PrWeekBucket {
   merged: number
 }
 
+export interface AtRiskRepo {
+  repo: string
+  reasons: string[]
+  severity: "warning" | "critical"
+}
+
+export interface MilestoneSummary {
+  repo: string
+  title: string
+  due_on: string | null
+  open_issues: number
+  closed_issues: number
+  progress_pct: number
+  state: "on_track" | "at_risk" | "overdue"
+}
+
+export interface PrCycleTimeWeek {
+  week: string
+  avg_days: number
+}
+
 export interface CockpitResponse {
   repo_count: number
   member_count: number
@@ -287,4 +308,41 @@ export interface CockpitResponse {
   commit_activity_4w: number[]
   total_cache_size_bytes: number
   cache_job_success_rate: number
+  at_risk_repos: AtRiskRepo[]
+  milestones: MilestoneSummary[]
+  pr_cycle_time_8w: PrCycleTimeWeek[]
+  release_cadence_4w: number[]
+}
+
+export interface MyViewPRSummary {
+  number: number
+  title: string
+  repository: string
+  html_url: string
+  updated_at: string
+}
+
+export interface MyViewIssueSummary {
+  number: number
+  title: string
+  repository: string
+  html_url: string
+  updated_at: string
+}
+
+export interface MyViewRunSummary {
+  repository: string
+  id: number
+  name: string | null
+  status: string
+  conclusion: string | null
+  html_url: string
+  created_at: string
+}
+
+export interface MyViewResponse {
+  my_open_prs: MyViewPRSummary[]
+  review_requests: MyViewPRSummary[]
+  assigned_issues: MyViewIssueSummary[]
+  my_recent_runs: MyViewRunSummary[]
 }

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -188,6 +188,22 @@ describe("OverviewPage cockpit", () => {
     expect(screen.getByText("Milestone 'v2' overdue")).toBeInTheDocument();
   });
 
+  it("renders at-risk repos with warning severity styling (not just critical)", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      at_risk_repos: [{ repo: "acme/worker", reasons: ["Milestone 'v3' due soon at 40% complete"], severity: "warning" }],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/worker")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Milestone 'v3' due soon at 40% complete")).toBeInTheDocument();
+  });
+
   it("renders milestone burndown rows", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
@@ -212,6 +228,41 @@ describe("OverviewPage cockpit", () => {
       expect(screen.getByText(/v2/)).toBeInTheDocument();
     });
     expect(screen.getByText((_, el) => el?.textContent === "8/10 closed · due just now")).toBeInTheDocument();
+  });
+
+  it("renders overdue and at-risk milestone chips with their own styling", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      milestones: [
+        {
+          repo: "acme/api",
+          title: "v1",
+          due_on: "2020-01-01T00:00:00Z",
+          open_issues: 3,
+          closed_issues: 1,
+          progress_pct: 25,
+          state: "overdue",
+        },
+        {
+          repo: "acme/worker",
+          title: "v3",
+          due_on: "2026-08-01T00:00:00Z",
+          open_issues: 6,
+          closed_issues: 4,
+          progress_pct: 40,
+          state: "at_risk",
+        },
+      ],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("overdue")).toBeInTheDocument();
+    });
+    expect(screen.getByText("at risk")).toBeInTheDocument();
   });
 
   it("fetches My View data and switches tabs", async () => {

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const tokensResolveMock = vi.fn();
 const cockpitMock = vi.fn();
+const myViewMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
@@ -12,6 +13,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     analytics: {
       cockpit: (...args: unknown[]) => cockpitMock(...args),
+      myView: (...args: unknown[]) => myViewMock(...args),
     },
   },
 }));
@@ -40,12 +42,25 @@ const EMPTY_COCKPIT = {
   commit_activity_4w: [],
   total_cache_size_bytes: 0,
   cache_job_success_rate: 0,
+  at_risk_repos: [],
+  milestones: [],
+  pr_cycle_time_8w: [],
+  release_cadence_4w: [],
+};
+
+const EMPTY_MY_VIEW = {
+  my_open_prs: [],
+  review_requests: [],
+  assigned_issues: [],
+  my_recent_runs: [],
 };
 
 describe("OverviewPage cockpit", () => {
   beforeEach(() => {
     tokensResolveMock.mockReset();
     cockpitMock.mockReset();
+    myViewMock.mockReset();
+    myViewMock.mockResolvedValue(EMPTY_MY_VIEW);
     localStorage.clear();
   });
 
@@ -143,5 +158,100 @@ describe("OverviewPage cockpit", () => {
       expect(screen.getByText("alice")).toBeInTheDocument();
     });
     expect(screen.getByText("pushed 3 commits to main")).toBeInTheDocument();
+  });
+
+  it("hides the Needs Attention card when there are no at-risk repos", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+
+    renderPage();
+
+    await waitFor(() => expect(cockpitMock).toHaveBeenCalled());
+    expect(screen.queryByText("Needs Attention")).not.toBeInTheDocument();
+  });
+
+  it("renders at-risk repos with their reasons and severity", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      at_risk_repos: [{ repo: "acme/api", reasons: ["Milestone 'v2' overdue"], severity: "critical" }],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Needs Attention")).toBeInTheDocument();
+    });
+    expect(screen.getByText("acme/api")).toBeInTheDocument();
+    expect(screen.getByText("Milestone 'v2' overdue")).toBeInTheDocument();
+  });
+
+  it("renders milestone burndown rows", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      milestones: [
+        {
+          repo: "acme/api",
+          title: "v2",
+          due_on: "2026-08-01T00:00:00Z",
+          open_issues: 2,
+          closed_issues: 8,
+          progress_pct: 80,
+          state: "on_track",
+        },
+      ],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/v2/)).toBeInTheDocument();
+    });
+    expect(screen.getByText((_, el) => el?.textContent === "8/10 closed · due just now")).toBeInTheDocument();
+  });
+
+  it("fetches My View data and switches tabs", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+    myViewMock.mockResolvedValue({
+      my_open_prs: [
+        { number: 1, title: "Fix bug", repository: "acme/api", html_url: "https://github.com/acme/api/pull/1", updated_at: "2026-07-20T00:00:00Z" },
+      ],
+      review_requests: [],
+      assigned_issues: [
+        { number: 2, title: "Investigate flake", repository: "acme/worker", html_url: "https://github.com/acme/worker/issues/2", updated_at: "2026-07-19T00:00:00Z" },
+      ],
+      my_recent_runs: [],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(myViewMock).toHaveBeenCalledWith("acme", "ghp_test");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Fix bug")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Assigned Issues"));
+    expect(screen.getByText("Investigate flake")).toBeInTheDocument();
+    expect(screen.queryByText("Fix bug")).not.toBeInTheDocument();
+  });
+
+  it("shows empty states for release cadence and PR cycle time when all values are zero", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+
+    renderPage();
+
+    await waitFor(() => expect(cockpitMock).toHaveBeenCalled());
+    expect(screen.getByText("No releases in the last 4 weeks")).toBeInTheDocument();
+    expect(screen.getByText("No merged pull requests yet")).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -182,6 +182,15 @@ describe("api.analytics value normalization", () => {
     expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
   });
 
+  it("GETs /me/github/my-view?owner=... with an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({ my_open_prs: [], review_requests: [], assigned_issues: [], my_recent_runs: [] });
+    const result = await api.analytics.myView("acme", "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/github/my-view?owner=acme");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual({ my_open_prs: [], review_requests: [], assigned_issues: [], my_recent_runs: [] });
+  });
+
   it("GETs /me/analytics/history?owner=... and returns the raw scan history", async () => {
     stubOkJson([{ id: 1, owner: "acme", score: 80, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" }]);
     const result = await api.analytics.history("acme");


### PR DESCRIPTION
## Summary

Closes #181. Implements docs/plan.md Phase 14 ("Overview Cockpit: CEO & Dev Cards") end-to-end: extends the cockpit aggregate endpoint and adds a new personal "My View" endpoint, plus five new Overview page cards/panels.

## What changed and why

**Backend** — `apps/api/src/routers/analytics.py` / `apps/api/src/schemas/analytics.py`:

- `CockpitResponse` gains four fields, each computed by a new best-effort `_safe_*` helper following this file's existing fan-out pattern (`asyncio.gather` + `ThreadPoolExecutor`, degrade to an empty/zeroed default on failure rather than 500 the whole cockpit):
  - `milestones` / `at_risk_repos` — fetches each repo's open milestones (capped, same `_MAX_REPOS_FOR_AGGREGATES` bound the commit-activity/cache helpers already use). A milestone is `overdue` if its due date has passed, `at_risk` if due within 7 days at <70% issue-completion, else `on_track`. `at_risk_repos` groups the non-on_track milestones per repo with a severity (critical for overdue, warning otherwise) and human-readable reasons — this is what drives the "Needs Attention" card.
  - `pr_cycle_time_8w` — average days-to-close for merged PRs per week over 8 weeks, via the search API's `closed_at - created_at` (an approximation, since the issues-search endpoint doesn't expose `merged_at` directly — documented inline).
  - `release_cadence_4w` — weekly release counts across the org's repos for 4 weeks. Deliberately a coarse per-week count, not the full per-release timeline docs/plan.md Phase 17 will add separately (`GET /github/orgs/{org}/release-timeline`) — different shape/purpose, so this doesn't preempt or duplicate that future endpoint.
- New `GET /me/github/my-view?owner={org}` endpoint — resolves the caller's own GitHub login via `GET /user` on the resolved token, then returns their open PRs, PRs where they're a requested reviewer, assigned issues (all via the search API, so not restricted to `owner`'s repos), and recent workflow runs (fanned out across `owner`'s repos, capped). If the token can't resolve a login (e.g. a GitHub App installation token, which isn't a user-to-server token), the endpoint degrades to an empty `MyViewResponse` rather than a 500 — same graceful-degradation philosophy as the rest of this file.
- 30 new/updated backend tests (`test_analytics_cockpit.py`, new `test_analytics_my_view.py`) covering the milestone-state logic, at-risk grouping, cycle-time/release-cadence math, and my-view's auth/token/degradation paths.

**Frontend** — `apps/ui/app/page.tsx`:
- "Needs Attention" card (hidden entirely when `at_risk_repos` is empty), left-border colored by severity.
- "Milestone Burndown" card — per-milestone progress bar + state chip.
- "My View" panel — tabbed (My PRs / Review Queue / Assigned Issues), a second query alongside the existing cockpit query (same non-waterfalled pattern: fires once `resolveQuery` settles).
- "Release Cadence" and "PR Cycle Time" cards, reusing the existing `BarGroupChart`/`AreaTimeChart` components and `CHART_COLORS` theme — no new chart primitives.
- New `api.analytics.myView` client method, new types in `lib/api/types.ts`.
- Extended `overview-page.test.tsx` with 5 new tests for the added cards/panel.

No schema migration — this is entirely live GitHub reads, no new persisted state. No RBAC changes (all endpoints stay `require_auth`-only, personal-scoped, matching the existing cockpit convention). No `.env`/secrets changes.

## Test plan

- [x] `pytest -q` (full backend suite) — 408/408 pass
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` (full UI suite) — 216/216 pass