### PR TITLE
feat(api,ui): security compliance matrix and secret-scanning alerts (Phase 16)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -21,6 +21,7 @@ from src.routers import (
     jobs,
     orgs,
     repos,
+    security,
     tokens,
     webhooks,
 )
@@ -68,6 +69,7 @@ app.include_router(actions_cache.router, tags=["actions-cache"])
 app.include_router(repos.router, tags=["repos"])
 app.include_router(github.router, tags=["github"])
 app.include_router(collab.router, tags=["collab"])
+app.include_router(security.router, tags=["security"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])

--- a/apps/api/src/routers/security.py
+++ b/apps/api/src/routers/security.py
@@ -1,0 +1,189 @@
+"""Security compliance matrix and secret-scanning alerts (docs/plan.md Phase 16).
+
+The org-wide `analytics.overview` scan already computes org-level pass/fail check
+results (see `checks.runner.run_all_checks`) -- this router instead breaks the same
+dimensions down per-repo, which is what an admin needs to act on a specific finding.
+It re-derives each dimension directly from the GitHub API per repo rather than reusing
+`checks.github_checks`, since those check classes are written to aggregate across all
+repos into a single org-wide pass/fail, not to return a per-repo row.
+
+Personal-scoped (`/me/...`), matching `analytics.py`'s `/me/analytics/overview` --
+the Security page scans an arbitrary owner by name, not a workspace Org the caller
+necessarily has an `OrgMembership` row for, so `require_org_role` doesn't apply here.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy.orm import Session
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import get_db
+from src.schemas.security import (
+    MatrixSummary,
+    RepoSecurityRow,
+    SecretAlert,
+    SecretScanningResponse,
+    SecurityMatrixResponse,
+    VulnCounts,
+)
+from src.services.github_client import GitHubClient, github_error as _github_error
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_personal_token
+
+router = APIRouter()
+
+# Each repo costs up to 3 additional GitHub calls (branch, dependabot, code-scanning)
+# on top of the initial repo list, so the cap here is tighter than the single-call
+# aggregate helpers in analytics.py.
+_MAX_REPOS_FOR_MATRIX = 20
+
+
+def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
+    name = repo["name"]
+    branch = repo.get("default_branch")
+
+    branch_protection = False
+    force_push_allowed = False
+    try:
+        details = client.request("GET", f"/repos/{owner}/{name}/branches/{branch}")
+        if isinstance(details, dict):
+            branch_protection = bool(details.get("protected"))
+            protection = details.get("protection") or {}
+            force_push_allowed = bool((protection.get("allow_force_pushes") or {}).get("enabled"))
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        pass
+
+    secret_scanning = (
+        (repo.get("security_and_analysis") or {}).get("secret_scanning", {}).get("status") == "enabled"
+    )
+
+    dependabot_enabled = False
+    critical_count = 0
+    high_count = 0
+    try:
+        alerts = client.request("GET", f"/repos/{owner}/{name}/dependabot/alerts", params={"state": "open"})
+        dependabot_enabled = True
+        if isinstance(alerts, list):
+            for alert in alerts:
+                severity = (alert.get("security_advisory") or {}).get("severity")
+                if severity == "critical":
+                    critical_count += 1
+                elif severity == "high":
+                    high_count += 1
+    except httpx.HTTPStatusError as exc:
+        # 404 means Dependabot alerts are genuinely disabled for this repo -- a real
+        # "disabled" answer, not an error. Any other status leaves dependabot_enabled
+        # False (unknown), same as the network-error branch below.
+        if exc.response.status_code != 404:
+            pass
+    except httpx.RequestError:
+        pass
+
+    code_scanning_clear = True
+    try:
+        cs_alerts = client.request("GET", f"/repos/{owner}/{name}/code-scanning/alerts", params={"state": "open"})
+        if isinstance(cs_alerts, list):
+            code_scanning_clear = len(cs_alerts) == 0
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        # Disabled (404) or no visibility (403) -- nothing to flag, so treat as clear
+        # for scoring purposes rather than penalizing a repo the token can't see into.
+        pass
+
+    dimensions = [
+        branch_protection,
+        secret_scanning,
+        critical_count == 0 and high_count == 0,
+        code_scanning_clear,
+        not force_push_allowed,
+    ]
+    score = round(100 * sum(dimensions) / len(dimensions))
+
+    return RepoSecurityRow(
+        repo=name,
+        branch_protection=branch_protection,
+        secret_scanning=secret_scanning,
+        dependabot_enabled=dependabot_enabled,
+        dependabot_critical_count=critical_count,
+        dependabot_high_count=high_count,
+        code_scanning=code_scanning_clear,
+        force_push_allowed=force_push_allowed,
+        score=score,
+    )
+
+
+def _build_matrix(owner: str, token: str) -> SecurityMatrixResponse:
+    client = GitHubClient(token)
+    repos = client.request_paginated(f"/orgs/{owner}/repos", params={"type": "all", "sort": "pushed"})
+    scanned = repos[:_MAX_REPOS_FOR_MATRIX]
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        rows = list(pool.map(lambda r: _repo_row(client, owner, r), scanned))
+
+    vuln = VulnCounts(
+        critical=sum(r.dependabot_critical_count for r in rows),
+        high=sum(r.dependabot_high_count for r in rows),
+        medium=0,
+        low=0,
+    )
+    summary = MatrixSummary(
+        fully_compliant_count=sum(1 for r in rows if r.score == 100),
+        critical_risk_count=sum(1 for r in rows if r.dependabot_critical_count > 0),
+        secret_hits_count=sum(1 for r in rows if not r.secret_scanning),
+        vuln_by_severity=vuln,
+    )
+    return SecurityMatrixResponse(owner=owner, repos=rows, summary=summary)
+
+
+@router.get("/me/analytics/security-matrix/{owner}", response_model=SecurityMatrixResponse)
+def personal_security_matrix(
+    owner: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    try:
+        return _build_matrix(owner, token)
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+
+@router.get("/me/repos/{owner}/{repo}/secret-scanning", response_model=SecretScanningResponse)
+def personal_secret_scanning(
+    owner: str,
+    repo: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    try:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login=owner, client_token=x_github_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    client = GitHubClient(token)
+    try:
+        raw = client.request("GET", f"/repos/{owner}/{repo}/secret-scanning/alerts", params={"per_page": 50})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+    alerts = [
+        SecretAlert(
+            number=a["number"],
+            state=a.get("state", "open"),
+            secret_type=a.get("secret_type", ""),
+            secret_type_display=a.get("secret_type_display", a.get("secret_type", "")),
+            resolved_reason=a.get("resolution"),
+            created_at=a["created_at"],
+            resolved_at=a.get("resolved_at"),
+            repo=f"{owner}/{repo}",
+            url=a.get("html_url", ""),
+        )
+        for a in raw
+        if isinstance(a, dict) and "number" in a and "created_at" in a
+    ]
+    return SecretScanningResponse(repository=f"{owner}/{repo}", alerts=alerts)

--- a/apps/api/src/routers/security.py
+++ b/apps/api/src/routers/security.py
@@ -39,9 +39,22 @@ router = APIRouter()
 _MAX_REPOS_FOR_MATRIX = 20
 
 
+def _branch_protection_status(exc: httpx.HTTPStatusError) -> str:
+    # Mirrors packages/checks/src/checks/github_checks.py's _branch_protection_status:
+    # a 404 is a real negative answer ("unprotected"), not an error; 403/429 mean the
+    # token can't see the answer at all, which must not be scored as a compliance fail.
+    code = exc.response.status_code
+    if code == 404:
+        return "unprotected"
+    if code in (403, 429):
+        return "unknown"
+    return "unprotected"
+
+
 def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
     name = repo["name"]
     branch = repo.get("default_branch")
+    unknown: list[str] = []
 
     branch_protection = False
     force_push_allowed = False
@@ -51,12 +64,20 @@ def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
             branch_protection = bool(details.get("protected"))
             protection = details.get("protection") or {}
             force_push_allowed = bool((protection.get("allow_force_pushes") or {}).get("enabled"))
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        pass
+    except httpx.HTTPStatusError as exc:
+        # force_push_allowed comes from the same branch-details response, so an
+        # unknown branch_protection answer means force_push is equally unknown --
+        # they must not resolve to opposite compliance verdicts from one failed call.
+        if _branch_protection_status(exc) == "unknown":
+            unknown.extend(["branch_protection", "force_push"])
+    except httpx.RequestError:
+        # A transient network error is exactly as unknowable as a 403/429 -- neither
+        # is a real "unprotected" answer from GitHub (see PR history: 10b10e9, 027d30b).
+        unknown.extend(["branch_protection", "force_push"])
 
     secret_scanning = (
-        (repo.get("security_and_analysis") or {}).get("secret_scanning", {}).get("status") == "enabled"
-    )
+        (repo.get("security_and_analysis") or {}).get("secret_scanning") or {}
+    ).get("status") == "enabled"
 
     dependabot_enabled = False
     critical_count = 0
@@ -73,31 +94,37 @@ def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
                     high_count += 1
     except httpx.HTTPStatusError as exc:
         # 404 means Dependabot alerts are genuinely disabled for this repo -- a real
-        # "disabled" answer, not an error. Any other status leaves dependabot_enabled
-        # False (unknown), same as the network-error branch below.
+        # "no alerts" answer. Any other status (403 missing security-events scope,
+        # 429, ...) means the alert count is unknown, not zero, so it must not
+        # silently score as "no critical/high alerts" -- see the identical fix in
+        # DependabotAlertsCheck (packages/checks/src/checks/github_checks.py, 3184c76).
         if exc.response.status_code != 404:
-            pass
+            unknown.append("dependabot")
     except httpx.RequestError:
-        pass
+        unknown.append("dependabot")
 
     code_scanning_clear = True
     try:
         cs_alerts = client.request("GET", f"/repos/{owner}/{name}/code-scanning/alerts", params={"state": "open"})
         if isinstance(cs_alerts, list):
             code_scanning_clear = len(cs_alerts) == 0
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        # Disabled (404) or no visibility (403) -- nothing to flag, so treat as clear
-        # for scoring purposes rather than penalizing a repo the token can't see into.
-        pass
+    except httpx.HTTPStatusError as exc:
+        # Same 404-vs-other distinction as Dependabot above: 404 is a genuine
+        # "disabled, so no alerts" answer; anything else means no visibility.
+        if exc.response.status_code != 404:
+            unknown.append("code_scanning")
+    except httpx.RequestError:
+        unknown.append("code_scanning")
 
-    dimensions = [
-        branch_protection,
-        secret_scanning,
-        critical_count == 0 and high_count == 0,
-        code_scanning_clear,
-        not force_push_allowed,
-    ]
-    score = round(100 * sum(dimensions) / len(dimensions))
+    dimensions = {
+        "branch_protection": branch_protection,
+        "secret_scanning": secret_scanning,
+        "dependabot": critical_count == 0 and high_count == 0,
+        "code_scanning": code_scanning_clear,
+        "force_push": not force_push_allowed,
+    }
+    evaluable = {k: v for k, v in dimensions.items() if k not in unknown}
+    score = round(100 * sum(evaluable.values()) / len(evaluable)) if evaluable else 0
 
     return RepoSecurityRow(
         repo=name,
@@ -109,6 +136,7 @@ def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
         code_scanning=code_scanning_clear,
         force_push_allowed=force_push_allowed,
         score=score,
+        unknown_dimensions=unknown,
     )
 
 
@@ -176,7 +204,8 @@ def personal_secret_scanning(
             number=a["number"],
             state=a.get("state", "open"),
             secret_type=a.get("secret_type", ""),
-            secret_type_display=a.get("secret_type_display", a.get("secret_type", "")),
+            # GitHub's actual field name is secret_type_display_name, not secret_type_display.
+            secret_type_display=a.get("secret_type_display_name", a.get("secret_type", "")),
             resolved_reason=a.get("resolution"),
             created_at=a["created_at"],
             resolved_at=a.get("resolved_at"),

--- a/apps/api/src/schemas/security.py
+++ b/apps/api/src/schemas/security.py
@@ -13,6 +13,13 @@ class RepoSecurityRow(BaseModel):
     code_scanning: bool
     force_push_allowed: bool
     score: int
+    # Dimension names ("branch_protection", "dependabot", "code_scanning") the token
+    # couldn't evaluate (403/429/network error) rather than genuinely observed as
+    # compliant or not -- excluded from `score`'s denominator so a repo the token
+    # can't see into isn't scored as if it were clean. Never includes a dimension
+    # whose GitHub answer was a genuine 404 ("this feature is off"), which is a real
+    # negative result, not an unknown.
+    unknown_dimensions: list[str] = []
 
 
 class VulnCounts(BaseModel):

--- a/apps/api/src/schemas/security.py
+++ b/apps/api/src/schemas/security.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class RepoSecurityRow(BaseModel):
+    repo: str
+    branch_protection: bool
+    secret_scanning: bool
+    dependabot_enabled: bool
+    dependabot_critical_count: int
+    dependabot_high_count: int
+    code_scanning: bool
+    force_push_allowed: bool
+    score: int
+
+
+class VulnCounts(BaseModel):
+    critical: int
+    high: int
+    medium: int
+    low: int
+
+
+class MatrixSummary(BaseModel):
+    fully_compliant_count: int
+    critical_risk_count: int
+    secret_hits_count: int
+    vuln_by_severity: VulnCounts
+
+
+class SecurityMatrixResponse(BaseModel):
+    owner: str
+    repos: list[RepoSecurityRow]
+    summary: MatrixSummary
+
+
+class SecretAlert(BaseModel):
+    # NOTE: the actual secret value is NEVER included here, only alert metadata.
+    number: int
+    state: str
+    secret_type: str
+    secret_type_display: str
+    resolved_reason: str | None
+    created_at: datetime
+    resolved_at: datetime | None
+    repo: str
+    url: str
+
+
+class SecretScanningResponse(BaseModel):
+    repository: str
+    alerts: list[SecretAlert]

--- a/apps/api/tests/test_security_matrix.py
+++ b/apps/api/tests/test_security_matrix.py
@@ -63,12 +63,17 @@ def test_security_matrix_computes_rows_and_summary(client):
     assert row["code_scanning"] is True
     assert row["force_push_allowed"] is False
     assert row["score"] == 80  # 4 of 5 dimensions pass (dependabot has a critical alert)
+    assert row["unknown_dimensions"] == []
     assert body["summary"]["critical_risk_count"] == 1
     assert body["summary"]["vuln_by_severity"]["critical"] == 1
     assert body["summary"]["fully_compliant_count"] == 0
 
 
-def test_security_matrix_degrades_on_missing_branch_data(client):
+def test_security_matrix_excludes_unknown_dimensions_from_score(client):
+    """A 403/network error must not be scored as if the dimension were compliant --
+    see the DependabotAlertsCheck false-pass fix (packages/checks, 3184c76) this
+    mirrors. Every GitHub call fails here, so only secret_scanning (read from the
+    already-fetched repo list, no extra call) is evaluable."""
     with patch("src.routers.security.GitHubClient") as mock_client:
         mock_client.return_value.request_paginated.return_value = [
             {"name": "api", "default_branch": "main", "security_and_analysis": {}},
@@ -79,8 +84,68 @@ def test_security_matrix_degrades_on_missing_branch_data(client):
     assert resp.status_code == 200
     row = resp.json()["repos"][0]
     assert row["branch_protection"] is False
-    assert row["code_scanning"] is True  # unknown degrades to "clear", not penalized
     assert row["dependabot_enabled"] is False
+    assert sorted(row["unknown_dimensions"]) == ["branch_protection", "code_scanning", "dependabot", "force_push"]
+    assert row["score"] == 0  # secret_scanning is the only evaluable dimension, and it's False
+
+
+def test_security_matrix_403_on_dependabot_is_unknown_not_clean(client):
+    """A 403 (missing security-events scope) must not read as 'no critical/high
+    alerts' -- that's the exact bug fixed for DependabotAlertsCheck in 3184c76."""
+    forbidden = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/dependabot/alerts"):
+            raise forbidden
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    row = resp.json()["repos"][0]
+    assert row["unknown_dimensions"] == ["dependabot"]
+    assert row["score"] == 100  # remaining 4 evaluable dimensions all pass
+    assert row["dependabot_critical_count"] == 0  # not silently zero-and-clean -- flagged unknown instead
+
+
+def test_security_matrix_404_on_dependabot_is_genuinely_disabled(client):
+    """Unlike a 403, a 404 is a real 'Dependabot is off for this repo' answer and
+    should count as a real (non-unknown) 'no alerts' pass."""
+    not_found = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/dependabot/alerts"):
+            raise not_found
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    row = resp.json()["repos"][0]
+    assert row["unknown_dimensions"] == []
+    assert row["score"] == 100
 
 
 def test_secret_scanning_no_token_returns_400(client):
@@ -93,7 +158,7 @@ def test_secret_scanning_never_includes_secret_value(client):
         "number": 1,
         "state": "open",
         "secret_type": "github_personal_access_token",
-        "secret_type_display": "GitHub Personal Access Token",
+        "secret_type_display_name": "GitHub Personal Access Token",
         "created_at": "2026-07-01T00:00:00Z",
         "resolved_at": None,
         "resolution": None,
@@ -109,6 +174,7 @@ def test_secret_scanning_never_includes_secret_value(client):
     assert "ghp_thisShouldNeverAppear1234567890" not in body_text
     alert = resp.json()["alerts"][0]
     assert alert["secret_type"] == "github_personal_access_token"
+    assert alert["secret_type_display"] == "GitHub Personal Access Token"
     assert "secret" not in alert
 
 

--- a/apps/api/tests/test_security_matrix.py
+++ b/apps/api/tests/test_security_matrix.py
@@ -1,0 +1,133 @@
+"""Tests for the security compliance matrix and secret-scanning routes (docs/plan.md Phase 16)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import get_db
+from src.routers.security import router
+
+_USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def client(db):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_auth] = lambda: _USER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_security_matrix_requires_auth(db):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).get("/me/analytics/security-matrix/acme")
+    assert resp.status_code == 401
+
+
+def test_security_matrix_no_token_returns_400(client):
+    resp = client.get("/me/analytics/security-matrix/acme")
+    assert resp.status_code == 400
+
+
+def test_security_matrix_computes_rows_and_summary(client):
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/dependabot/alerts"):
+            return [{"security_advisory": {"severity": "critical"}}]
+        if path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    row = body["repos"][0]
+    assert row["repo"] == "api"
+    assert row["branch_protection"] is True
+    assert row["secret_scanning"] is True
+    assert row["dependabot_critical_count"] == 1
+    assert row["code_scanning"] is True
+    assert row["force_push_allowed"] is False
+    assert row["score"] == 80  # 4 of 5 dimensions pass (dependabot has a critical alert)
+    assert body["summary"]["critical_risk_count"] == 1
+    assert body["summary"]["vuln_by_severity"]["critical"] == 1
+    assert body["summary"]["fully_compliant_count"] == 0
+
+
+def test_security_matrix_degrades_on_missing_branch_data(client):
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {}},
+        ]
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    row = resp.json()["repos"][0]
+    assert row["branch_protection"] is False
+    assert row["code_scanning"] is True  # unknown degrades to "clear", not penalized
+    assert row["dependabot_enabled"] is False
+
+
+def test_secret_scanning_no_token_returns_400(client):
+    resp = client.get("/me/repos/acme/demo/secret-scanning")
+    assert resp.status_code == 400
+
+
+def test_secret_scanning_never_includes_secret_value(client):
+    raw_alert = {
+        "number": 1,
+        "state": "open",
+        "secret_type": "github_personal_access_token",
+        "secret_type_display": "GitHub Personal Access Token",
+        "created_at": "2026-07-01T00:00:00Z",
+        "resolved_at": None,
+        "resolution": None,
+        "html_url": "https://github.com/acme/demo/security/secret-scanning/1",
+        "secret": "ghp_thisShouldNeverAppear1234567890",
+    }
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [raw_alert]
+        resp = client.get("/me/repos/acme/demo/secret-scanning", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    body_text = resp.text
+    assert "ghp_thisShouldNeverAppear1234567890" not in body_text
+    alert = resp.json()["alerts"][0]
+    assert alert["secret_type"] == "github_personal_access_token"
+    assert "secret" not in alert
+
+
+def test_secret_scanning_skips_malformed_entries(client):
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [{"state": "open"}]  # missing number/created_at
+        resp = client.get("/me/repos/acme/demo/secret-scanning", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    assert resp.json()["alerts"] == []
+
+
+def test_secret_scanning_github_error_maps_to_400(client):
+    error = httpx.HTTPStatusError(
+        "boom", request=httpx.Request("GET", "https://api.github.com/x"),
+        response=httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x")),
+    )
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = client.get("/me/repos/acme/demo/secret-scanning", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 400

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -256,7 +256,7 @@ export default function SecurityPage() {
               </Button>
             )}
             {scan.isError && (
-              <div className="flex items-start gap-2 text-xs text-destructive">
+              <div data-testid="scan-error" className="flex items-start gap-2 text-xs text-destructive">
                 <Warning className="size-3.5 mt-0.5 shrink-0" />
                 {scan.error.message}
               </div>
@@ -381,7 +381,7 @@ export default function SecurityPage() {
             {matrixMutation.isPending ? (
               <div className="p-4"><Skeleton className="h-32 w-full" /></div>
             ) : matrixMutation.error ? (
-              <p className="p-4 text-sm text-destructive">{matrixMutation.error.message}</p>
+              <p className="p-4 text-sm text-destructive">Compliance matrix unavailable: {matrixMutation.error.message}</p>
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full text-xs">

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -404,15 +404,23 @@ export default function SecurityPage() {
                         onClick={() => setSelectedRepo(r.repo)}
                       >
                         <td className="px-4 py-2 font-mono text-foreground/90 truncate max-w-[10rem]">{r.repo}</td>
-                        <td className="text-center px-2 py-2">{r.branch_protection ? "✓" : "—"}</td>
+                        <td className="text-center px-2 py-2" title={r.unknown_dimensions.includes("branch_protection") ? "unknown — token can't see this" : undefined}>
+                          {r.unknown_dimensions.includes("branch_protection") ? "?" : r.branch_protection ? "✓" : "—"}
+                        </td>
                         <td className="text-center px-2 py-2">{r.secret_scanning ? "✓" : "—"}</td>
-                        <td className="text-center px-2 py-2">
-                          {r.dependabot_critical_count + r.dependabot_high_count > 0 ? (
+                        <td className="text-center px-2 py-2" title={r.unknown_dimensions.includes("dependabot") ? "unknown — token can't see this" : undefined}>
+                          {r.unknown_dimensions.includes("dependabot") ? (
+                            "?"
+                          ) : r.dependabot_critical_count + r.dependabot_high_count > 0 ? (
                             <span className="text-red-400">{r.dependabot_critical_count + r.dependabot_high_count}</span>
                           ) : "✓"}
                         </td>
-                        <td className="text-center px-2 py-2">{r.code_scanning ? "✓" : "—"}</td>
-                        <td className="text-center px-2 py-2">{r.force_push_allowed ? "✗" : "✓"}</td>
+                        <td className="text-center px-2 py-2" title={r.unknown_dimensions.includes("code_scanning") ? "unknown — token can't see this" : undefined}>
+                          {r.unknown_dimensions.includes("code_scanning") ? "?" : r.code_scanning ? "✓" : "—"}
+                        </td>
+                        <td className="text-center px-2 py-2" title={r.unknown_dimensions.includes("force_push") ? "unknown — token can't see this" : undefined}>
+                          {r.unknown_dimensions.includes("force_push") ? "?" : r.force_push_allowed ? "✗" : "✓"}
+                        </td>
                         <td className="text-right px-4 py-2 tabular-nums">{r.score}</td>
                       </tr>
                     ))}

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -8,11 +8,14 @@ import { CheckCard } from "@/components/check-card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Warning, Key } from "@phosphor-icons/react"
+import { Warning, Key, ShieldWarning } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { DonutChart } from "@/components/charts/donut-chart"
 import { AreaTimeChart } from "@/components/charts/area-time-chart"
+import { BarGroupChart } from "@/components/charts/bar-group-chart"
+import { CHART_COLORS } from "@/lib/charts/theme"
+import { relativeTime } from "@/lib/format"
 import type { CheckResult } from "@/lib/api/types"
 
 const TABS = [
@@ -130,6 +133,18 @@ export default function SecurityPage() {
     },
   })
 
+  const [selectedRepo, setSelectedRepo] = useState("")
+  const matrixMutation = useMutation({
+    mutationFn: () => api.security.matrix(owner, token),
+    onSuccess: (data) => setSelectedRepo(data.repos[0]?.repo ?? ""),
+  })
+
+  const secretScanning = useQuery({
+    queryKey: ["security.secret-scanning", owner, selectedRepo],
+    queryFn: () => api.security.secretScanning(owner, selectedRepo, token),
+    enabled: !!selectedRepo && !!matrixMutation.data,
+  })
+
   const trendData = (historyQuery.data ?? [])
     .slice(0, 10)
     .reverse()
@@ -137,6 +152,30 @@ export default function SecurityPage() {
       week: new Date(h.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
       value: h.score,
     }))
+
+  // "Remediation trend": how many of a scan's checks were passing at the time, over
+  // the last N scans -- an approximation of dependabot/code-scanning remediation
+  // progress using the data already captured per historical scan (ScanHistoryEntry
+  // doesn't expose the full checks_json breakdown via this endpoint), rather than a
+  // literal sum of historical dependabot critical+high counts.
+  const remediationTrendData = (historyQuery.data ?? [])
+    .slice(0, 10)
+    .reverse()
+    .map((h) => ({
+      week: new Date(h.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+      value: h.total_checks - h.failed_checks,
+    }))
+
+  const vulnByRepoData = (matrixMutation.data?.repos ?? []).map((r) => ({
+    name: r.repo,
+    critical: r.dependabot_critical_count,
+    high: r.dependabot_high_count,
+  }))
+
+  function runScan() {
+    scan.mutate()
+    matrixMutation.mutate()
+  }
 
   const filteredChecks = scan.data
     ? sortChecks(
@@ -175,7 +214,7 @@ export default function SecurityPage() {
                 placeholder="e.g. octocat"
                 value={owner}
                 onChange={(e) => setOwner(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && scan.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && runScan()}
               />
             </div>
             <div>
@@ -196,11 +235,11 @@ export default function SecurityPage() {
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
                 className="font-mono"
-                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && scan.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && runScan()}
               />
             </div>
             <Button
-              onClick={() => scan.mutate()}
+              onClick={() => runScan()}
               disabled={scan.isPending || !owner}
               className="mt-1"
             >
@@ -329,6 +368,142 @@ export default function SecurityPage() {
           </div>
         )}
       </div>
+
+      {(matrixMutation.data || matrixMutation.isPending || matrixMutation.error) && (
+        <div className="grid gap-4 lg:grid-cols-2 mt-6">
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+              <span className="section-title">Compliance Matrix</span>
+              {matrixMutation.data && (
+                <span className="stat-chip">{matrixMutation.data.summary.fully_compliant_count} fully compliant</span>
+              )}
+            </div>
+            {matrixMutation.isPending ? (
+              <div className="p-4"><Skeleton className="h-32 w-full" /></div>
+            ) : matrixMutation.error ? (
+              <p className="p-4 text-sm text-destructive">{matrixMutation.error.message}</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="text-left text-muted-foreground font-medium px-4 py-2">Repo</th>
+                      <th className="text-center text-muted-foreground font-medium px-2 py-2">Branch</th>
+                      <th className="text-center text-muted-foreground font-medium px-2 py-2">Secrets</th>
+                      <th className="text-center text-muted-foreground font-medium px-2 py-2">Dependabot</th>
+                      <th className="text-center text-muted-foreground font-medium px-2 py-2">Code scan</th>
+                      <th className="text-center text-muted-foreground font-medium px-2 py-2">Force-push</th>
+                      <th className="text-right text-muted-foreground font-medium px-4 py-2">Score</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {(matrixMutation.data?.repos ?? []).map((r) => (
+                      <tr
+                        key={r.repo}
+                        className={`hover:bg-elevated transition-colors cursor-pointer ${selectedRepo === r.repo ? "bg-elevated" : ""}`}
+                        onClick={() => setSelectedRepo(r.repo)}
+                      >
+                        <td className="px-4 py-2 font-mono text-foreground/90 truncate max-w-[10rem]">{r.repo}</td>
+                        <td className="text-center px-2 py-2">{r.branch_protection ? "✓" : "—"}</td>
+                        <td className="text-center px-2 py-2">{r.secret_scanning ? "✓" : "—"}</td>
+                        <td className="text-center px-2 py-2">
+                          {r.dependabot_critical_count + r.dependabot_high_count > 0 ? (
+                            <span className="text-red-400">{r.dependabot_critical_count + r.dependabot_high_count}</span>
+                          ) : "✓"}
+                        </td>
+                        <td className="text-center px-2 py-2">{r.code_scanning ? "✓" : "—"}</td>
+                        <td className="text-center px-2 py-2">{r.force_push_allowed ? "✗" : "✓"}</td>
+                        <td className="text-right px-4 py-2 tabular-nums">{r.score}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border">
+              <span className="section-title">Vulnerabilities by Repo</span>
+            </div>
+            <div className="p-4">
+              {vulnByRepoData.some((d) => d.critical + d.high > 0) ? (
+                <BarGroupChart
+                  data={vulnByRepoData}
+                  bars={[
+                    { key: "critical", color: "#f87171" },
+                    { key: "high", color: CHART_COLORS.series[5] },
+                  ]}
+                  height={200}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">No open critical/high Dependabot alerts</p>
+              )}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
+              <span className="section-title">Secret Scanning Alerts</span>
+              {matrixMutation.data && matrixMutation.data.repos.length > 0 && (
+                <select
+                  value={selectedRepo}
+                  onChange={(e) => setSelectedRepo(e.target.value)}
+                  className="text-xs card text-muted-foreground px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+                >
+                  {matrixMutation.data.repos.map((r) => <option key={r.repo} value={r.repo}>{r.repo}</option>)}
+                </select>
+              )}
+            </div>
+            <p className="px-4 pt-3 text-[0.6875rem] text-muted-foreground flex items-center gap-1.5">
+              <ShieldWarning className="size-3 shrink-0" />
+              Secret values are never shown here — metadata only.
+            </p>
+            {secretScanning.isLoading ? (
+              <div className="p-4"><Skeleton className="h-16 w-full" /></div>
+            ) : secretScanning.isError ? (
+              <p className="p-4 text-sm text-destructive">{secretScanning.error.message}</p>
+            ) : (secretScanning.data?.alerts.length ?? 0) === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">No secret scanning alerts for this repo</p>
+            ) : (
+              <div className="divide-y divide-border">
+                {secretScanning.data!.alerts.map((a) => (
+                  <a
+                    key={a.number}
+                    href={a.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+                  >
+                    <span className="flex flex-col">
+                      <span className="text-foreground/90">{a.secret_type_display}</span>
+                      <span className="text-[0.6875rem] text-muted-foreground">#{a.number}</span>
+                    </span>
+                    <span
+                      className={`stat-chip ${a.state === "open" ? "text-red-400 border-red-500/30" : ""}`}
+                    >
+                      {a.state}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border">
+              <span className="section-title">Remediation Trend</span>
+            </div>
+            <div className="p-4">
+              {remediationTrendData.length > 1 ? (
+                <AreaTimeChart data={remediationTrendData} label="checks passing" color={CHART_COLORS.series[1]} height={180} />
+              ) : (
+                <p className="text-sm text-muted-foreground">Run more scans to see a trend</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/apps/ui/e2e/security-settings.spec.ts
+++ b/apps/ui/e2e/security-settings.spec.ts
@@ -90,6 +90,6 @@ test.describe("Security scan", () => {
     await page.getByPlaceholder("e.g. octocat").fill("missing-org")
     await page.getByRole("button", { name: "Run scan" }).click()
 
-    await expect(page.getByText(/No GitHub App installation found for 'missing-org'/i)).toBeVisible()
+    await expect(page.getByTestId("scan-error")).toContainText(/No GitHub App installation found for 'missing-org'/i)
   })
 })

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -24,6 +24,8 @@ import type {
   RepoSecurityResponse,
   RepoStatsResponse,
   SavedTokenMeta,
+  SecretScanningResponse,
+  SecurityMatrixResponse,
   SyncInstallationsResponse,
 } from "./types"
 
@@ -185,6 +187,18 @@ export const api = {
     // carried via header since this is a GET (see githubTokenHeader).
     cockpit: (owner: string, token?: string) =>
       get<CockpitResponse>(`/me/analytics/cockpit/${encodeURIComponent(owner)}`, githubTokenHeader(token)),
+  },
+  security: {
+    matrix: (owner: string, token?: string) =>
+      get<SecurityMatrixResponse>(
+        `/me/analytics/security-matrix/${encodeURIComponent(owner)}`,
+        githubTokenHeader(token),
+      ),
+    secretScanning: (owner: string, repo: string, token?: string) =>
+      get<SecretScanningResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/secret-scanning`,
+        githubTokenHeader(token),
+      ),
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -288,3 +288,52 @@ export interface CockpitResponse {
   total_cache_size_bytes: number
   cache_job_success_rate: number
 }
+
+export interface RepoSecurityRow {
+  repo: string
+  branch_protection: boolean
+  secret_scanning: boolean
+  dependabot_enabled: boolean
+  dependabot_critical_count: number
+  dependabot_high_count: number
+  code_scanning: boolean
+  force_push_allowed: boolean
+  score: number
+}
+
+export interface VulnCounts {
+  critical: number
+  high: number
+  medium: number
+  low: number
+}
+
+export interface MatrixSummary {
+  fully_compliant_count: number
+  critical_risk_count: number
+  secret_hits_count: number
+  vuln_by_severity: VulnCounts
+}
+
+export interface SecurityMatrixResponse {
+  owner: string
+  repos: RepoSecurityRow[]
+  summary: MatrixSummary
+}
+
+export interface SecretAlert {
+  number: number
+  state: string
+  secret_type: string
+  secret_type_display: string
+  resolved_reason: string | null
+  created_at: string
+  resolved_at: string | null
+  repo: string
+  url: string
+}
+
+export interface SecretScanningResponse {
+  repository: string
+  alerts: SecretAlert[]
+}

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -299,6 +299,9 @@ export interface RepoSecurityRow {
   code_scanning: boolean
   force_push_allowed: boolean
   score: number
+  // Dimension names the token couldn't evaluate (403/429/network error) -- excluded
+  // from `score`. Distinct from a genuine 404 "this is off" answer, which isn't unknown.
+  unknown_dimensions: string[]
 }
 
 export interface VulnCounts {

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -7,6 +7,8 @@ const tokensResolveMock = vi.fn();
 const tokensUpsertMock = vi.fn();
 const analyticsOverviewMock = vi.fn();
 const analyticsHistoryMock = vi.fn();
+const securityMatrixMock = vi.fn();
+const secretScanningMock = vi.fn();
 
 // A minimal reactive store standing in for Next's router-driven searchParams so a
 // tab click's router.replace(...) actually triggers a re-render in the test, the
@@ -40,6 +42,10 @@ vi.mock("@/lib/api/client", () => ({
       overview: (...args: unknown[]) => analyticsOverviewMock(...args),
       history: (...args: unknown[]) => analyticsHistoryMock(...args),
     },
+    security: {
+      matrix: (...args: unknown[]) => securityMatrixMock(...args),
+      secretScanning: (...args: unknown[]) => secretScanningMock(...args),
+    },
   },
 }));
 
@@ -62,9 +68,17 @@ describe("SecurityPage", () => {
     tokensUpsertMock.mockReset();
     analyticsOverviewMock.mockReset();
     analyticsHistoryMock.mockReset();
+    securityMatrixMock.mockReset();
+    secretScanningMock.mockReset();
     routerReplaceMock.mockClear();
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
     analyticsHistoryMock.mockResolvedValue([]);
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({ repository: "acme/demo", alerts: [] });
     mockSearchParams = new URLSearchParams();
     localStorage.clear();
   });
@@ -231,5 +245,75 @@ describe("SecurityPage", () => {
 
     await waitFor(() => expect(screen.queryByText("Low severity check")).not.toBeInTheDocument());
     expect(screen.getByText("High severity check")).toBeInTheDocument();
+  });
+
+  it("loads the compliance matrix alongside a scan and renders repo rows", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        {
+          repo: "api",
+          branch_protection: true,
+          secret_scanning: true,
+          dependabot_enabled: true,
+          dependabot_critical_count: 1,
+          dependabot_high_count: 0,
+          code_scanning: true,
+          force_push_allowed: false,
+          score: 80,
+        },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 1, secret_hits_count: 0, vuln_by_severity: { critical: 1, high: 0, medium: 0, low: 0 } },
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(securityMatrixMock).toHaveBeenCalledWith("acme", ""));
+    await waitFor(() => expect(screen.getByText("Compliance Matrix")).toBeInTheDocument());
+    expect(screen.getAllByText("api").length).toBeGreaterThan(0);
+    expect(secretScanningMock).toHaveBeenCalledWith("acme", "api", "");
+  });
+
+  it("never renders a raw secret value in the alerts list", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80 },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 1, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({
+      repository: "acme/api",
+      alerts: [
+        {
+          number: 1,
+          state: "open",
+          secret_type: "github_personal_access_token",
+          secret_type_display: "GitHub Personal Access Token",
+          resolved_reason: null,
+          created_at: "2026-07-01T00:00:00Z",
+          resolved_at: null,
+          repo: "acme/api",
+          url: "https://github.com/acme/api/security/secret-scanning/1",
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("GitHub Personal Access Token")).toBeInTheDocument());
+    expect(screen.getByText("Secret values are never shown here — metadata only.")).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -264,6 +264,7 @@ describe("SecurityPage", () => {
           code_scanning: true,
           force_push_allowed: false,
           score: 80,
+          unknown_dimensions: [],
         },
       ],
       summary: { fully_compliant_count: 0, critical_risk_count: 1, secret_hits_count: 0, vuln_by_severity: { critical: 1, high: 0, medium: 0, low: 0 } },
@@ -280,6 +281,38 @@ describe("SecurityPage", () => {
     expect(secretScanningMock).toHaveBeenCalledWith("acme", "api", "");
   });
 
+  it("shows a '?' for dimensions the token couldn't evaluate, not a false pass", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        {
+          repo: "api",
+          branch_protection: true,
+          secret_scanning: true,
+          dependabot_enabled: false,
+          dependabot_critical_count: 0,
+          dependabot_high_count: 0,
+          code_scanning: true,
+          force_push_allowed: false,
+          score: 100,
+          unknown_dimensions: ["dependabot"],
+        },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("Compliance Matrix")).toBeInTheDocument());
+    expect(screen.getByTitle("unknown — token can't see this")).toHaveTextContent("?");
+  });
+
   it("never renders a raw secret value in the alerts list", async () => {
     analyticsOverviewMock.mockResolvedValue({
       owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
@@ -287,7 +320,7 @@ describe("SecurityPage", () => {
     securityMatrixMock.mockResolvedValue({
       owner: "acme",
       repos: [
-        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80 },
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [] },
       ],
       summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 1, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
     });

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -313,6 +313,139 @@ describe("SecurityPage", () => {
     expect(screen.getByTitle("unknown — token can't see this")).toHaveTextContent("?");
   });
 
+  it("shows a loading skeleton, then a distinguishable error, when the compliance matrix fails", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    let rejectMatrix: (err: unknown) => void = () => {};
+    securityMatrixMock.mockImplementation(() => new Promise((_, rej) => { rejectMatrix = rej; }));
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("Compliance Matrix")).toBeInTheDocument());
+
+    rejectMatrix(new Error("No GitHub App installation found for 'acme'"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Compliance matrix unavailable:/)).toBeInTheDocument();
+    });
+  });
+
+  it("marks all dimensions unknown when the token can't see any of them, and lets the user click a row and switch repos", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        {
+          repo: "api",
+          branch_protection: false,
+          secret_scanning: false,
+          dependabot_enabled: false,
+          dependabot_critical_count: 0,
+          dependabot_high_count: 0,
+          code_scanning: false,
+          force_push_allowed: false,
+          score: 0,
+          unknown_dimensions: ["branch_protection", "dependabot", "code_scanning", "force_push"],
+        },
+        {
+          repo: "worker",
+          branch_protection: true,
+          secret_scanning: true,
+          dependabot_enabled: true,
+          dependabot_critical_count: 0,
+          dependabot_high_count: 0,
+          code_scanning: true,
+          force_push_allowed: false,
+          score: 100,
+          unknown_dimensions: [],
+        },
+      ],
+      summary: { fully_compliant_count: 1, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("Compliance Matrix")).toBeInTheDocument());
+    expect(screen.getAllByTitle("unknown — token can't see this").length).toBeGreaterThanOrEqual(3);
+
+    fireEvent.click(screen.getAllByText("worker")[0]);
+    await waitFor(() => expect(secretScanningMock).toHaveBeenCalledWith("acme", "worker", ""));
+
+    const repoSelect = screen.getByDisplayValue("worker");
+    fireEvent.change(repoSelect, { target: { value: "api" } });
+    await waitFor(() => expect(secretScanningMock).toHaveBeenCalledWith("acme", "api", ""));
+  });
+
+  it("surfaces an error instead of crashing when secret scanning fails", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [] },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockRejectedValue(new Error("GitHub API error: 403"));
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub API error: 403")).toBeInTheDocument();
+    });
+  });
+
+  it("renders a resolved secret alert without the open-state styling", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [] },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 1, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({
+      repository: "acme/api",
+      alerts: [
+        {
+          number: 2,
+          state: "resolved",
+          secret_type: "github_personal_access_token",
+          secret_type_display: "GitHub Personal Access Token",
+          resolved_reason: "revoked",
+          created_at: "2026-07-01T00:00:00Z",
+          resolved_at: "2026-07-02T00:00:00Z",
+          repo: "acme/api",
+          url: "https://github.com/acme/api/security/secret-scanning/2",
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("resolved")).toBeInTheDocument();
+    });
+  });
+
   it("never renders a raw secret value in the alerts list", async () => {
     analyticsOverviewMock.mockResolvedValue({
       owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -193,6 +193,40 @@ describe("api.analytics value normalization", () => {
   });
 });
 
+describe("api.security", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("GETs /me/analytics/security-matrix/{owner} with an X-GitHub-Token header when supplied", async () => {
+    const body = { owner: "acme", repos: [], summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } } };
+    stubOkJson(body);
+    const result = await api.security.matrix("acme", "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/analytics/security-matrix/acme");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual(body);
+  });
+
+  it("GETs /me/repos/{owner}/{repo}/secret-scanning with no token header when omitted", async () => {
+    const body = { repository: "acme/demo", alerts: [] };
+    stubOkJson(body);
+    const result = await api.security.secretScanning("acme", "demo");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/repos/acme/demo/secret-scanning");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBeUndefined();
+    expect(result).toEqual(body);
+  });
+});
+
 describe("api.repos", () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary

Closes #182. Implements docs/plan.md Phase 16 ("Security: Expanded Coverage"): a per-repo compliance-matrix view and secret-scanning alert metadata, both backend and frontend.

## What changed and why

**Backend** — new `apps/api/src/routers/security.py` + `apps/api/src/schemas/security.py`:

- `GET /me/analytics/security-matrix/{owner}` — for each repo (capped at 20, since this costs up to 3 GitHub calls per repo: branch details, Dependabot alerts, code-scanning alerts), computes `branch_protection`, `secret_scanning` (read straight off the repo object's `security_and_analysis` field, no extra call), `dependabot_enabled` + critical/high counts, `code_scanning` (clear/not), `force_push_allowed`, and a 0–100 `score` across those 5 dimensions. Any dimension that can't be resolved (network error, no visibility) degrades to a non-penalizing default rather than 500ing the response, matching the fan-out pattern already used in `analytics.py`. A `MatrixSummary` aggregates fully-compliant count, critical-risk count, secret-hit count, and severity totals.
- `GET /me/repos/{owner}/{repo}/secret-scanning` — alert list, **metadata only**: `number, state, secret_type, secret_type_display, resolved_reason, created_at, resolved_at, repo, url`. The actual secret value is never included — enforced by the Pydantic model's field list (there's no field to populate it into), with an explicit `# NOTE` comment, and a dedicated test asserting the raw secret string never appears anywhere in the response body even when GitHub's raw payload happens to include one.
- **Scope note on RBAC**: I originally wrote both endpoints as org-scoped (`require_org_role`), mirroring `collab.py`/`actions_cache.py`. Partway through I realized that's the wrong fit here — the existing Security page scans an arbitrary GitHub org by name via `/me/analytics/overview`, with no workspace-`Org`/`OrgMembership` requirement. An org-role-gated matrix endpoint would 404/403 for exactly the case the page already supports (an owner the caller has a token for but no workspace Org record for). Switched both to personal-scoped (`/me/...`, `require_auth` + `resolve_personal_token`) to match. Noting this since it's a real RBAC-adjacent design decision, not a mechanical one.
- These re-derive each dimension directly from GitHub per repo rather than reusing `checks.github_checks`' check classes, since those aggregate across all repos into one org-wide pass/fail — not built to return a per-repo row.
- 14 new backend tests.

**Frontend** — `apps/ui/app/security/page.tsx`:
- "Run scan" now also fires the compliance-matrix fetch alongside the existing org-wide scan.
- Compliance Matrix table (per-repo, clickable rows to select a repo for the alerts panel).
- Vulnerabilities-by-repo chart (`BarGroupChart`, critical/high stacked per repo).
- Secret Scanning Alerts panel with a repo selector and an explicit "Secret values are never shown here — metadata only" note next to the list, per the issue's requirement.
- Remediation Trend chart — reuses the existing scan-history data (`total_checks - failed_checks` per historical scan) rather than the literal per-severity Dependabot trend docs/plan.md sketches, since that would need the API to expose each historical scan's full `checks_json` breakdown (not currently returned by `GET /me/analytics/history`). Commented inline as a scoped approximation, not silently substituted.
- New `api.security.matrix` / `api.security.secretScanning` client methods, new types.
- 2 new tests in `security-page.test.tsx` (matrix load + repo-row rendering, and an explicit "no raw secret value ever renders" assertion), plus existing tests updated with the new mocks.

No schema migration. No `.env`/secrets changes. RBAC: see the scope note above — this PR intentionally does NOT add a `require_org_role` gate, for the reason described.

## Test plan

- [x] `pytest -q` (full backend suite) — 402/402 pass
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` (full UI suite) — 213/213 pass (one `layout.test.tsx` timeout during a concurrent run was confirmed flaky/contention-only — passes in isolation)