### PR TITLE
feat(api,ui): org-wide commit heatmap, release timeline, PR board (Phase 17)

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -219,13 +219,20 @@ def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
         return []
 
 
-def _safe_commit_activity_4w(owner: str, token: str, repo_names: list[str]) -> list[int]:
-    # A single failing repo zeroes the whole aggregate rather than partially summing --
+def _safe_commit_activity_4w_and_heatmap_52w(
+    owner: str, token: str, repo_names: list[str]
+) -> tuple[list[int], list[int]]:
+    # Both windows are slices of the exact same GitHub call
+    # (/repos/{owner}/{repo}/stats/commit_activity already returns 52 weeks), so this
+    # fetches each repo once and derives both aggregates from it -- fetching twice
+    # (once per aggregate) would double this endpoint's GitHub API cost for no reason.
+    # A single failing repo zeroes both aggregates rather than partially summing --
     # simpler than reconciling "which repos contributed" and consistent with this
     # function's own all-or-nothing best-effort contract to its caller.
     try:
         client = GitHubClient(token)
-        totals = [0, 0, 0, 0]
+        totals_4w = [0, 0, 0, 0]
+        totals_52w = [0] * 52
         with ThreadPoolExecutor(max_workers=10) as pool:
             futures = [
                 pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
@@ -233,34 +240,17 @@ def _safe_commit_activity_4w(owner: str, token: str, repo_names: list[str]) -> l
             ]
             for future in futures:
                 weeks = future.result()
-                if isinstance(weeks, list) and len(weeks) >= 4:
+                if not isinstance(weeks, list):
+                    continue
+                if len(weeks) >= 4:
                     for i, week in enumerate(weeks[-4:]):
-                        totals[i] += week.get("total", 0)
-        return totals
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        return [0, 0, 0, 0]
-
-
-def _safe_commit_heatmap_52w(owner: str, token: str, repo_names: list[str]) -> list[int]:
-    # Same all-or-nothing best-effort contract as _safe_commit_activity_4w, just
-    # summed across the full 52-week window GitHub's commit_activity stats return
-    # instead of the last 4 -- reuses the same call, no extra GitHub requests.
-    try:
-        client = GitHubClient(token)
-        totals = [0] * 52
-        with ThreadPoolExecutor(max_workers=10) as pool:
-            futures = [
-                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
-                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
-            ]
-            for future in futures:
-                weeks = future.result()
-                if isinstance(weeks, list) and len(weeks) >= 52:
+                        totals_4w[i] += week.get("total", 0)
+                if len(weeks) >= 52:
                     for i, week in enumerate(weeks[-52:]):
-                        totals[i] += week.get("total", 0)
-        return totals
+                        totals_52w[i] += week.get("total", 0)
+        return totals_4w, totals_52w
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return [0] * 52
+        return [0, 0, 0, 0], [0] * 52
 
 
 def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> int:
@@ -320,17 +310,15 @@ async def personal_analytics_cockpit(
         recent_events,
         open_pr_count,
         pr_merge_rate_4w,
-        commit_activity_4w,
+        (commit_activity_4w, commit_heatmap_52w),
         total_cache_size_bytes,
-        commit_heatmap_52w,
     ) = await asyncio.gather(
         anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_open_pr_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
-        anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w(owner, token, repo_names)),
+        anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
-        anyio.to_thread.run_sync(lambda: _safe_commit_heatmap_52w(owner, token, repo_names)),
     )
 
     return CockpitResponse(

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -241,6 +241,28 @@ def _safe_commit_activity_4w(owner: str, token: str, repo_names: list[str]) -> l
         return [0, 0, 0, 0]
 
 
+def _safe_commit_heatmap_52w(owner: str, token: str, repo_names: list[str]) -> list[int]:
+    # Same all-or-nothing best-effort contract as _safe_commit_activity_4w, just
+    # summed across the full 52-week window GitHub's commit_activity stats return
+    # instead of the last 4 -- reuses the same call, no extra GitHub requests.
+    try:
+        client = GitHubClient(token)
+        totals = [0] * 52
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [
+                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
+            ]
+            for future in futures:
+                weeks = future.result()
+                if isinstance(weeks, list) and len(weeks) >= 52:
+                    for i, week in enumerate(weeks[-52:]):
+                        totals[i] += week.get("total", 0)
+        return totals
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return [0] * 52
+
+
 def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> int:
     try:
         client = GitHubClient(token)
@@ -300,6 +322,7 @@ async def personal_analytics_cockpit(
         pr_merge_rate_4w,
         commit_activity_4w,
         total_cache_size_bytes,
+        commit_heatmap_52w,
     ) = await asyncio.gather(
         anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
@@ -307,6 +330,7 @@ async def personal_analytics_cockpit(
         anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
+        anyio.to_thread.run_sync(lambda: _safe_commit_heatmap_52w(owner, token, repo_names)),
     )
 
     return CockpitResponse(
@@ -318,6 +342,7 @@ async def personal_analytics_cockpit(
         open_pr_count=open_pr_count,
         pr_merge_rate_4w=pr_merge_rate_4w,
         commit_activity_4w=commit_activity_4w,
+        commit_heatmap_52w=commit_heatmap_52w,
         total_cache_size_bytes=total_cache_size_bytes,
         cache_job_success_rate=cache_job_success_rate,
     )

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -39,7 +39,8 @@ from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_to
 router = APIRouter()
 
 # Each repo costs one additional GitHub call for failed-runs/release-timeline, on
-# top of the initial repo list -- same tier as security.py's per-repo matrix cap.
+# top of the initial repo list -- matching analytics.py's _MAX_REPOS_FOR_AGGREGATES
+# tier for per-repo fan-out.
 _MAX_REPOS_FOR_FEED = 20
 
 # Short TTL, well under the frontend's 30s poll interval -- collapses concurrent
@@ -154,8 +155,8 @@ def org_events(
 
 # ---------------------------------------------------------------------------
 # Full developer feed (docs/plan.md Phase 17) -- org-wide failed-run log and
-# release timeline, both fanned out per-repo the same way security.py's
-# compliance matrix is (best-effort per repo, capped repo count).
+# release timeline, both fanned out per-repo (best-effort per repo, capped
+# repo count), matching analytics.py's per-repo aggregate helper pattern.
 # ---------------------------------------------------------------------------
 
 
@@ -198,13 +199,18 @@ def _repo_failed_runs(client: GitHubClient, owner: str, repo: str) -> list[Faile
         if streak < 3:
             continue
         latest = runs[0]
+        # A malformed run entry (missing id/created_at) shouldn't 500 the whole repo's
+        # results -- skip just that workflow's streak, same as _pr_summaries/_issue_summaries
+        # in analytics.py degrade on a malformed search-result item.
+        if "id" not in latest or ("run_started_at" not in latest and "created_at" not in latest):
+            continue
         summaries.append(
             FailedRunSummary(
                 repo=f"{owner}/{repo}",
                 workflow_name=latest.get("name") or "",
                 branch=latest.get("head_branch", ""),
                 run_id=latest["id"],
-                started_at=latest.get("run_started_at") or latest["created_at"],
+                started_at=latest.get("run_started_at") or latest.get("created_at"),
                 duration_seconds=_run_duration_seconds(latest),
                 url=latest.get("html_url", ""),
                 actor=(latest.get("actor") or {}).get("login", ""),

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -13,6 +13,8 @@ sibling org-scoped router's convention of defining its complete path locally.
 
 import hashlib
 import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -20,11 +22,25 @@ from sqlalchemy.orm import Session
 
 from src.core.db import get_db
 from src.core.rbac import OrgContext, require_org_role
-from src.schemas.github import OrgEvent, OrgEventsInput, OrgEventsResponse
+from src.schemas.github import (
+    FailedRunsInput,
+    FailedRunsResponse,
+    FailedRunSummary,
+    OrgEvent,
+    OrgEventsInput,
+    OrgEventsResponse,
+    ReleaseSummary,
+    ReleaseTimelineInput,
+    ReleaseTimelineResponse,
+)
 from src.services.github_client import GitHubClient, github_error as _github_error
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token
 
 router = APIRouter()
+
+# Each repo costs one additional GitHub call for failed-runs/release-timeline, on
+# top of the initial repo list -- same tier as security.py's per-repo matrix cap.
+_MAX_REPOS_FOR_FEED = 20
 
 # Short TTL, well under the frontend's 30s poll interval -- collapses concurrent
 # polls from multiple open tabs/team members watching the same org into one
@@ -134,3 +150,154 @@ def org_events(
         return _cached_events(org_login, token, payload.per_page)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
+
+
+# ---------------------------------------------------------------------------
+# Full developer feed (docs/plan.md Phase 17) -- org-wide failed-run log and
+# release timeline, both fanned out per-repo the same way security.py's
+# compliance matrix is (best-effort per repo, capped repo count).
+# ---------------------------------------------------------------------------
+
+
+def _run_duration_seconds(run: dict) -> int | None:
+    started = run.get("run_started_at")
+    updated = run.get("updated_at")
+    if not started or not updated or run.get("status") != "completed":
+        return None
+    try:
+        start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    delta = int((end_dt - start_dt).total_seconds())
+    return delta if delta >= 0 else None
+
+
+def _repo_failed_runs(client: GitHubClient, owner: str, repo: str) -> list[FailedRunSummary]:
+    try:
+        data = client.request("GET", f"/repos/{owner}/{repo}/actions/runs", params={"per_page": 30})
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return []
+    raw_runs = data.get("workflow_runs", []) if isinstance(data, dict) else []
+
+    # GitHub returns runs newest-first; group by workflow to walk each workflow's
+    # own timeline independently (a failing workflow on one runs list mustn't count
+    # a different workflow's success as breaking its streak).
+    by_workflow: dict[int, list[dict]] = {}
+    for run in raw_runs:
+        by_workflow.setdefault(run.get("workflow_id"), []).append(run)
+
+    summaries: list[FailedRunSummary] = []
+    for runs in by_workflow.values():
+        streak = 0
+        for run in runs:
+            if run.get("status") == "completed" and run.get("conclusion") == "failure":
+                streak += 1
+            else:
+                break
+        if streak < 3:
+            continue
+        latest = runs[0]
+        summaries.append(
+            FailedRunSummary(
+                repo=f"{owner}/{repo}",
+                workflow_name=latest.get("name") or "",
+                branch=latest.get("head_branch", ""),
+                run_id=latest["id"],
+                started_at=latest.get("run_started_at") or latest["created_at"],
+                duration_seconds=_run_duration_seconds(latest),
+                url=latest.get("html_url", ""),
+                actor=(latest.get("actor") or {}).get("login", ""),
+                consecutive_failures=streak,
+            )
+        )
+    return summaries
+
+
+def _repo_releases(client: GitHubClient, owner: str, repo: str, cutoff: datetime) -> list[ReleaseSummary]:
+    try:
+        raw = client.request("GET", f"/repos/{owner}/{repo}/releases", params={"per_page": 20})
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return []
+    if not isinstance(raw, list):
+        return []
+
+    releases = []
+    for r in raw:
+        published_at = r.get("published_at")
+        if not published_at:
+            continue
+        try:
+            published = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if published < cutoff:
+            continue
+        body = (r.get("body") or "")[:120]
+        releases.append(
+            ReleaseSummary(
+                repo=f"{owner}/{repo}",
+                tag_name=r.get("tag_name", ""),
+                name=r.get("name") or r.get("tag_name", ""),
+                published_at=published_at,
+                is_prerelease=bool(r.get("prerelease")),
+                body_preview=body,
+                url=r.get("html_url", ""),
+            )
+        )
+    return releases
+
+
+@router.post("/github/orgs/{org_login}/failed-runs", response_model=FailedRunsResponse)
+def org_failed_runs(
+    org_login: str,
+    payload: FailedRunsInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=org_login, client_token=client_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    client = GitHubClient(token)
+    try:
+        repos = client.request_paginated(f"/orgs/{org_login}/repos", params={"type": "all", "sort": "pushed"})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    repo_names = [r["name"] for r in repos[:_MAX_REPOS_FOR_FEED]]
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        results = pool.map(lambda name: _repo_failed_runs(client, org_login, name), repo_names)
+    runs = [r for repo_runs in results for r in repo_runs]
+    runs.sort(key=lambda r: r.started_at, reverse=True)
+    return FailedRunsResponse(org=org_login, runs=runs[: payload.limit])
+
+
+@router.post("/github/orgs/{org_login}/release-timeline", response_model=ReleaseTimelineResponse)
+def org_release_timeline(
+    org_login: str,
+    payload: ReleaseTimelineInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=org_login, client_token=client_token)
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    client = GitHubClient(token)
+    try:
+        repos = client.request_paginated(f"/orgs/{org_login}/repos", params={"type": "all", "sort": "pushed"})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+    repo_names = [r["name"] for r in repos[:_MAX_REPOS_FOR_FEED]]
+    cutoff = datetime.now(timezone.utc) - timedelta(days=payload.days)
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        results = pool.map(lambda name: _repo_releases(client, org_login, name, cutoff), repo_names)
+    releases = [r for repo_releases in results for r in repo_releases]
+    releases.sort(key=lambda r: r.published_at, reverse=True)
+    return ReleaseTimelineResponse(org=org_login, releases=releases)

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -55,3 +55,4 @@ class CockpitResponse(BaseModel):
     commit_activity_4w: list[int]
     total_cache_size_bytes: int
     cache_job_success_rate: float
+    commit_heatmap_52w: list[int] = []

--- a/apps/api/src/schemas/github.py
+++ b/apps/api/src/schemas/github.py
@@ -23,3 +23,45 @@ class OrgEvent(BaseModel):
 class OrgEventsResponse(BaseModel):
     org: str
     events: list[OrgEvent]
+
+
+class FailedRunsInput(BaseModel):
+    token: SecretStr | None = None
+    limit: int = 20
+
+
+class FailedRunSummary(BaseModel):
+    repo: str
+    workflow_name: str
+    branch: str
+    run_id: int
+    started_at: datetime
+    duration_seconds: int | None
+    url: str
+    actor: str
+    consecutive_failures: int
+
+
+class FailedRunsResponse(BaseModel):
+    org: str
+    runs: list[FailedRunSummary]
+
+
+class ReleaseTimelineInput(BaseModel):
+    token: SecretStr | None = None
+    days: int = 90
+
+
+class ReleaseSummary(BaseModel):
+    repo: str
+    tag_name: str
+    name: str
+    published_at: datetime
+    is_prerelease: bool
+    body_preview: str
+    url: str
+
+
+class ReleaseTimelineResponse(BaseModel):
+    org: str
+    releases: list[ReleaseSummary]

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -54,6 +54,7 @@ _DEFAULT_SAFE_MOCKS = {
     "src.routers.analytics._safe_pr_merge_rate_4w": {"return_value": []},
     "src.routers.analytics._safe_commit_activity_4w": {"return_value": [1, 2, 3, 4]},
     "src.routers.analytics._safe_total_cache_bytes": {"return_value": 123456},
+    "src.routers.analytics._safe_commit_heatmap_52w": {"return_value": [0] * 52},
 }
 
 
@@ -261,6 +262,26 @@ def test_safe_commit_activity_4w_sums_last_four_weeks_across_repos():
         mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
         totals = _safe_commit_activity_4w("acme", "ghp_test", ["repo-a", "repo-b"])
     assert totals == [49, 50, 51, 52]
+
+
+def test_safe_commit_heatmap_52w_returns_zeros_on_error():
+    from src.routers.analytics import _safe_commit_heatmap_52w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        assert _safe_commit_heatmap_52w("acme", "ghp_test", ["repo-a"]) == [0] * 52
+
+
+def test_safe_commit_heatmap_52w_sums_across_repos():
+    from src.routers.analytics import _safe_commit_heatmap_52w
+
+    weeks_a = [{"total": 1} for _ in range(52)]
+    weeks_b = [{"total": 2} for _ in range(52)]
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
+        totals = _safe_commit_heatmap_52w("acme", "ghp_test", ["repo-a", "repo-b"])
+    assert len(totals) == 52
+    assert all(t == 3 for t in totals)
 
 
 def test_safe_total_cache_bytes_returns_zero_on_error():

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -52,9 +52,8 @@ _DEFAULT_SAFE_MOCKS = {
     "src.routers.analytics._safe_recent_events": {"return_value": []},
     "src.routers.analytics._safe_open_pr_count": {"return_value": 7},
     "src.routers.analytics._safe_pr_merge_rate_4w": {"return_value": []},
-    "src.routers.analytics._safe_commit_activity_4w": {"return_value": [1, 2, 3, 4]},
+    "src.routers.analytics._safe_commit_activity_4w_and_heatmap_52w": {"return_value": ([1, 2, 3, 4], [0] * 52)},
     "src.routers.analytics._safe_total_cache_bytes": {"return_value": 123456},
-    "src.routers.analytics._safe_commit_heatmap_52w": {"return_value": [0] * 52},
 }
 
 
@@ -245,43 +244,30 @@ def test_safe_pr_merge_rate_4w_returns_four_chronological_buckets():
     assert all(b.opened == 3 and b.merged == 3 for b in buckets)
 
 
-def test_safe_commit_activity_4w_returns_zeros_on_error():
-    from src.routers.analytics import _safe_commit_activity_4w
+def test_safe_commit_activity_4w_and_heatmap_52w_returns_zeros_on_error():
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = httpx.RequestError("boom")
-        assert _safe_commit_activity_4w("acme", "ghp_test", ["repo-a"]) == [0, 0, 0, 0]
+        activity, heatmap = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a"])
+    assert activity == [0, 0, 0, 0]
+    assert heatmap == [0] * 52
 
 
-def test_safe_commit_activity_4w_sums_last_four_weeks_across_repos():
-    from src.routers.analytics import _safe_commit_activity_4w
+def test_safe_commit_activity_4w_and_heatmap_52w_sums_across_repos_from_one_fetch():
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
 
     weeks_a = [{"total": i} for i in range(52)]  # totals 0..51, last 4 are 48,49,50,51
     weeks_b = [{"total": 1} for _ in range(52)]
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
-        totals = _safe_commit_activity_4w("acme", "ghp_test", ["repo-a", "repo-b"])
-    assert totals == [49, 50, 51, 52]
+        activity, heatmap = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a", "repo-b"])
 
-
-def test_safe_commit_heatmap_52w_returns_zeros_on_error():
-    from src.routers.analytics import _safe_commit_heatmap_52w
-
-    with patch("src.routers.analytics.GitHubClient") as mock_client:
-        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
-        assert _safe_commit_heatmap_52w("acme", "ghp_test", ["repo-a"]) == [0] * 52
-
-
-def test_safe_commit_heatmap_52w_sums_across_repos():
-    from src.routers.analytics import _safe_commit_heatmap_52w
-
-    weeks_a = [{"total": 1} for _ in range(52)]
-    weeks_b = [{"total": 2} for _ in range(52)]
-    with patch("src.routers.analytics.GitHubClient") as mock_client:
-        mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
-        totals = _safe_commit_heatmap_52w("acme", "ghp_test", ["repo-a", "repo-b"])
-    assert len(totals) == 52
-    assert all(t == 3 for t in totals)
+    # Only one request per repo -- not one for the 4w slice and a second for the 52w one.
+    assert mock_client.return_value.request.call_count == 2
+    assert activity == [49, 50, 51, 52]
+    assert len(heatmap) == 52
+    assert heatmap[0] == weeks_a[0]["total"] + weeks_b[0]["total"]
 
 
 def test_safe_total_cache_bytes_returns_zero_on_error():

--- a/apps/api/tests/test_github_dev_feed.py
+++ b/apps/api/tests/test_github_dev_feed.py
@@ -1,0 +1,166 @@
+"""Tests for the org-wide failed-runs and release-timeline routes (docs/plan.md Phase 17)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
+from src.routers.github import router as github_router
+
+_MEMBER = UserOut(id=1, email="member@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    user = User(id=_MEMBER.id, email=_MEMBER.email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    return org
+
+
+@pytest.fixture()
+def client(db, acme_org):
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: _MEMBER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _run(id_, workflow_id, status, conclusion, created_at):
+    return {
+        "id": id_,
+        "workflow_id": workflow_id,
+        "name": "CI",
+        "status": status,
+        "conclusion": conclusion,
+        "head_branch": "main",
+        "created_at": created_at,
+        "run_started_at": created_at,
+        "updated_at": created_at,
+        "html_url": f"https://github.com/acme/api/actions/runs/{id_}",
+        "actor": {"login": "alice"},
+    }
+
+
+def test_failed_runs_requires_three_consecutive_failures(client):
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [{"name": "api"}]
+        mock_client.return_value.request.return_value = {
+            "workflow_runs": [
+                _run(3, 1, "completed", "failure", "2026-07-20T00:00:00Z"),
+                _run(2, 1, "completed", "failure", "2026-07-19T00:00:00Z"),
+                _run(1, 1, "completed", "success", "2026-07-18T00:00:00Z"),
+            ]
+        }
+        resp = client.post("/github/orgs/acme/failed-runs", json={"token": "ghp_testtoken123456789012345678901234"})
+
+    assert resp.status_code == 200
+    assert resp.json()["runs"] == []  # only 2 consecutive failures, below the threshold of 3
+
+
+def test_failed_runs_dedups_to_one_entry_per_streak(client):
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [{"name": "api"}]
+        mock_client.return_value.request.return_value = {
+            "workflow_runs": [
+                _run(4, 1, "completed", "failure", "2026-07-21T00:00:00Z"),
+                _run(3, 1, "completed", "failure", "2026-07-20T00:00:00Z"),
+                _run(2, 1, "completed", "failure", "2026-07-19T00:00:00Z"),
+                _run(1, 1, "completed", "success", "2026-07-18T00:00:00Z"),
+            ]
+        }
+        resp = client.post("/github/orgs/acme/failed-runs", json={"token": "ghp_testtoken123456789012345678901234"})
+
+    assert resp.status_code == 200
+    runs = resp.json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == 4
+    assert runs[0]["consecutive_failures"] == 3
+
+
+def test_failed_runs_one_bad_repo_does_not_blank_others(client):
+    def _paginated_side_effect(path, params=None):
+        return [{"name": "repo-bad"}, {"name": "repo-good"}]
+
+    def _request_side_effect(method, path, params=None):
+        if "repo-bad" in path:
+            raise httpx.RequestError("boom")
+        return {
+            "workflow_runs": [
+                _run(3, 1, "completed", "failure", "2026-07-20T00:00:00Z"),
+                _run(2, 1, "completed", "failure", "2026-07-19T00:00:00Z"),
+                _run(1, 1, "completed", "failure", "2026-07-18T00:00:00Z"),
+            ]
+        }
+
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.post("/github/orgs/acme/failed-runs", json={"token": "ghp_testtoken123456789012345678901234"})
+
+    assert resp.status_code == 200
+    runs = resp.json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["repo"] == "acme/repo-good"
+
+
+def test_failed_runs_no_token_returns_400(client):
+    resp = client.post("/github/orgs/acme/failed-runs", json={})
+    assert resp.status_code == 400
+
+
+def test_failed_runs_non_member_forbidden(db):
+    org_repo.get_or_create(db, github_login="acme")
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(id=999, email="outsider@example.com", name=None, is_workspace_admin=False)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).post("/github/orgs/acme/failed-runs", json={})
+    assert resp.status_code == 403
+
+
+def test_release_timeline_filters_by_days_and_excludes_missing_published_at(client):
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [{"name": "api"}]
+        mock_client.return_value.request.return_value = [
+            {
+                "tag_name": "v1.0.0",
+                "name": "v1.0.0",
+                "published_at": "2026-07-20T00:00:00Z",
+                "prerelease": False,
+                "body": "x" * 200,
+                "html_url": "https://github.com/acme/api/releases/v1.0.0",
+            },
+            {
+                "tag_name": "v0.9.0",
+                "name": "v0.9.0",
+                "published_at": "2020-01-01T00:00:00Z",  # far older than the 90-day window
+                "prerelease": False,
+                "body": "old",
+                "html_url": "https://github.com/acme/api/releases/v0.9.0",
+            },
+            {
+                "tag_name": "draft",
+                "published_at": None,  # unpublished draft, no real date
+            },
+        ]
+        resp = client.post("/github/orgs/acme/release-timeline", json={"token": "ghp_testtoken123456789012345678901234", "days": 90})
+
+    assert resp.status_code == 200
+    releases = resp.json()["releases"]
+    assert len(releases) == 1
+    assert releases[0]["tag_name"] == "v1.0.0"
+    assert len(releases[0]["body_preview"]) == 120
+
+
+def test_release_timeline_no_token_returns_400(client):
+    resp = client.post("/github/orgs/acme/release-timeline", json={})
+    assert resp.status_code == 400

--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -6,9 +6,15 @@ import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { ActivityList } from "@/components/activity-list"
 import { EventFeed } from "@/components/event-feed"
+import { HeatmapCalendar } from "@/components/charts/heatmap-calendar"
+import { CHART_COLORS } from "@/lib/charts/theme"
+import { relativeTime } from "@/lib/format"
 import { api } from "@/lib/api/client"
+import type { PullSummary } from "@/lib/api/types"
 
 const EVENTS_REFRESH_SECONDS = 30
+const HEATMAP_COLOR_SCALE = [CHART_COLORS.grid, "#1d4ed8", "#3b82f6", "#60a5fa", "#93c5fd"]
+const MAX_REPOS_FOR_PR_BOARD = 10
 
 // Isolated into its own component so the 1s tick only re-renders this small chip,
 // not the whole page (and the feed/job lists below it).
@@ -29,6 +35,8 @@ function RefreshCountdown({ resetKey, seconds }: { resetKey: number; seconds: nu
   return <span className="stat-chip">refreshes in {remaining}s</span>
 }
 
+type PrBoardTab = "feed" | "board"
+
 export default function ActivityPage() {
   // Marks all cockpit-sourced events as read so the sidebar's unread badge
   // clears once the user has actually looked at this page.
@@ -47,6 +55,8 @@ export default function ActivityPage() {
     setOrg(localStorage.getItem("default_org") || "")
   }, [])
 
+  const [feedTab, setFeedTab] = useState<PrBoardTab>("feed")
+
   const resolveQuery = useQuery({
     queryKey: ["tokens.resolve", org],
     queryFn: () => api.tokens.resolve(org),
@@ -55,11 +65,11 @@ export default function ActivityPage() {
   })
 
   const configured = !!resolveQuery.data?.token
+  const token = resolveQuery.data?.token ?? ""
 
   const eventsQuery = useQuery({
     queryKey: ["github.events", org],
     queryFn: () => {
-      const token = resolveQuery.data?.token
       if (!token) throw new Error("No GitHub token available for this organization")
       return api.github.events(org, token)
     },
@@ -72,6 +82,61 @@ export default function ActivityPage() {
   // tracks the real refetchInterval cadence instead of sticking at 0 after an error.
   const lastAttemptAt = Math.max(eventsQuery.dataUpdatedAt, eventsQuery.errorUpdatedAt)
 
+  // Heatmap data rides on the personal cockpit endpoint (commit_heatmap_52w) --
+  // that endpoint is personal-scoped (no OrgMembership needed), unlike the
+  // org-scoped failed-runs/release-timeline calls below, but the same resolved
+  // token works for either since it's just a client-supplied PAT either way.
+  const cockpitQuery = useQuery({
+    queryKey: ["analytics.cockpit-heatmap", org],
+    queryFn: () => api.analytics.cockpit(org, token),
+    enabled: configured,
+    retry: false,
+  })
+
+  const failedRunsQuery = useQuery({
+    queryKey: ["github.failed-runs", org],
+    queryFn: () => api.github.failedRuns(org, token),
+    enabled: configured,
+    retry: false,
+  })
+
+  const releaseTimelineQuery = useQuery({
+    queryKey: ["github.release-timeline", org],
+    queryFn: () => api.github.releaseTimeline(org, token),
+    enabled: configured,
+    retry: false,
+  })
+
+  const reposQuery = useQuery({
+    queryKey: ["repos.list", org],
+    queryFn: () => api.repos.list(org, token),
+    enabled: configured && feedTab === "board",
+    retry: false,
+  })
+
+  const prBoardQuery = useQuery({
+    queryKey: ["repos.pulls.board", org, reposQuery.data?.repos.map((r) => r.name).join(",")],
+    queryFn: async () => {
+      const repoNames = (reposQuery.data?.repos ?? []).slice(0, MAX_REPOS_FOR_PR_BOARD).map((r) => r.name)
+      const results = await Promise.all(
+        repoNames.map((repo) =>
+          api.repos.pulls(org, org, repo, token).catch(() => ({ repository: repo, total: 0, pulls: [] })),
+        ),
+      )
+      return results.flatMap((r) => r.pulls)
+    },
+    enabled: configured && feedTab === "board" && !!reposQuery.data,
+    retry: false,
+  })
+
+  const prsByAuthor = new Map<string, PullSummary[]>()
+  for (const pr of prBoardQuery.data ?? []) {
+    const author = pr.user ?? "unknown"
+    const existing = prsByAuthor.get(author)
+    if (existing) existing.push(pr)
+    else prsByAuthor.set(author, [pr])
+  }
+
   return (
     <>
       <PageHeader
@@ -81,9 +146,32 @@ export default function ActivityPage() {
 
       <div className="grid gap-4 lg:grid-cols-3">
         <div className="lg:col-span-2 card">
-          <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-            <span className="section-label">Activity Feed</span>
-            {configured && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setFeedTab("feed")}
+                aria-pressed={feedTab === "feed"}
+                className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
+                  feedTab === "feed"
+                    ? "border-border bg-elevated text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-elevated"
+                }`}
+              >
+                Activity Feed
+              </button>
+              <button
+                onClick={() => setFeedTab("board")}
+                aria-pressed={feedTab === "board"}
+                className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
+                  feedTab === "board"
+                    ? "border-border bg-elevated text-foreground"
+                    : "border-transparent text-muted-foreground hover:bg-elevated"
+                }`}
+              >
+                PR Board
+              </button>
+            </div>
+            {feedTab === "feed" && configured && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
           </div>
           {!configured ? (
             <div className="px-4 py-8">
@@ -94,8 +182,34 @@ export default function ActivityPage() {
                 </Link>
               </p>
             </div>
-          ) : (
+          ) : feedTab === "feed" ? (
             <EventFeed events={eventsQuery.data?.events ?? []} isLoading={eventsQuery.isLoading} />
+          ) : prBoardQuery.isLoading || reposQuery.isLoading ? (
+            <p className="px-4 py-8 text-sm text-muted-foreground">Loading…</p>
+          ) : prsByAuthor.size === 0 ? (
+            <p className="px-4 py-8 text-sm text-muted-foreground">No open pull requests</p>
+          ) : (
+            <div className="p-4 grid gap-3 sm:grid-cols-2">
+              {[...prsByAuthor.entries()].map(([author, prs]) => (
+                <div key={author} className="border border-border/60 rounded-md p-3">
+                  <p className="text-xs font-medium text-foreground mb-2">{author}</p>
+                  <ul className="flex flex-col gap-1.5">
+                    {prs.map((pr) => (
+                      <li key={pr.html_url}>
+                        <a
+                          href={pr.html_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-xs text-muted-foreground hover:text-foreground transition-colors truncate block"
+                        >
+                          #{pr.number} {pr.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
           )}
         </div>
 
@@ -107,6 +221,84 @@ export default function ActivityPage() {
           <ActivityList jobs={jobs} isLoading={jobsLoading} />
         </div>
       </div>
+
+      {configured && (
+        <div className="grid gap-4 lg:grid-cols-2 mt-4">
+          <div className="card lg:col-span-2">
+            <div className="px-4 py-3 border-b border-border">
+              <span className="section-label">Commit Heatmap (52w)</span>
+            </div>
+            <div className="p-4">
+              {(cockpitQuery.data?.commit_heatmap_52w ?? []).some((n) => n > 0) ? (
+                <HeatmapCalendar data={cockpitQuery.data!.commit_heatmap_52w} colorScale={HEATMAP_COLOR_SCALE} />
+              ) : (
+                <p className="text-sm text-muted-foreground">No commit activity in the last year</p>
+              )}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border">
+              <span className="section-label">CI Failure Log</span>
+            </div>
+            {(failedRunsQuery.data?.runs.length ?? 0) === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">No repeated CI failures</p>
+            ) : (
+              <div className="divide-y divide-border">
+                {failedRunsQuery.data!.runs.map((r) => (
+                  <a
+                    key={`${r.repo}-${r.run_id}`}
+                    href={r.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+                  >
+                    <span className="flex flex-col min-w-0">
+                      <span className="text-foreground/90 truncate">{r.repo} · {r.workflow_name}</span>
+                      <span className="text-[0.6875rem] text-muted-foreground">{r.branch} · {r.actor}</span>
+                    </span>
+                    <span className="stat-chip text-red-400 border-red-500/30 shrink-0 ml-2">
+                      ×{r.consecutive_failures}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="card">
+            <div className="px-4 py-3 border-b border-border">
+              <span className="section-label">Release Timeline</span>
+            </div>
+            {(releaseTimelineQuery.data?.releases.length ?? 0) === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">No releases in the last 90 days</p>
+            ) : (
+              <div className="divide-y divide-border">
+                {releaseTimelineQuery.data!.releases.map((r) => (
+                  <a
+                    key={r.url}
+                    href={r.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+                  >
+                    <span className="flex flex-col min-w-0">
+                      <span className="text-foreground/90 truncate">
+                        {r.repo} · {r.name}
+                        {r.is_prerelease && <span className="stat-chip ml-1.5 align-middle">pre-release</span>}
+                      </span>
+                      <span className="text-[0.6875rem] text-muted-foreground truncate">{r.body_preview}</span>
+                    </span>
+                    <span className="text-[0.6875rem] text-muted-foreground whitespace-nowrap shrink-0 ml-2">
+                      {relativeTime(r.published_at)}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -6,6 +6,7 @@ import type {
   CacheListResponse,
   CheckValue,
   CockpitResponse,
+  FailedRunsResponse,
   GithubMembershipStatus,
   GithubOrgInvitationsResponse,
   GithubOrgMembersResponse,
@@ -19,6 +20,7 @@ import type {
   MyOrgMembership,
   OrgEventsResponse,
   PendingInvitationSummary,
+  ReleaseTimelineResponse,
   RepoListResponse,
   RepoPullsResponse,
   RepoSecurityResponse,
@@ -229,6 +231,16 @@ export const api = {
       post<OrgEventsResponse>(`/github/orgs/${encodeURIComponent(org)}/events`, {
         token: token || undefined,
         per_page: perPage,
+      }),
+    failedRuns: (org: string, token: string, limit = 20) =>
+      post<FailedRunsResponse>(`/github/orgs/${encodeURIComponent(org)}/failed-runs`, {
+        token: token || undefined,
+        limit,
+      }),
+    releaseTimeline: (org: string, token: string, days = 90) =>
+      post<ReleaseTimelineResponse>(`/github/orgs/${encodeURIComponent(org)}/release-timeline`, {
+        token: token || undefined,
+        days,
       }),
   },
   audit: {

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -152,6 +152,38 @@ export interface OrgEventsResponse {
   events: OrgEvent[]
 }
 
+export interface FailedRunSummary {
+  repo: string
+  workflow_name: string
+  branch: string
+  run_id: number
+  started_at: string
+  duration_seconds: number | null
+  url: string
+  actor: string
+  consecutive_failures: number
+}
+
+export interface FailedRunsResponse {
+  org: string
+  runs: FailedRunSummary[]
+}
+
+export interface ReleaseSummary {
+  repo: string
+  tag_name: string
+  name: string
+  published_at: string
+  is_prerelease: boolean
+  body_preview: string
+  url: string
+}
+
+export interface ReleaseTimelineResponse {
+  org: string
+  releases: ReleaseSummary[]
+}
+
 export interface JobOut {
   id: number
   job_type: string
@@ -287,4 +319,5 @@ export interface CockpitResponse {
   commit_activity_4w: number[]
   total_cache_size_bytes: number
   cache_job_success_rate: number
+  commit_heatmap_52w: number[]
 }

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -201,4 +201,42 @@ describe("ActivityPage", () => {
     expect(await screen.findByText("alice")).toBeInTheDocument();
     expect(screen.getByText("#5 Fix bug")).toBeInTheDocument();
   });
+
+  it("shows an empty state under the PR Board tab when there are no open pull requests", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    reposListMock.mockResolvedValue({ org: "acme", total: 1, repos: [{ name: "api" }] });
+    reposPullsMock.mockResolvedValue({ repository: "acme/api", total: 0, pulls: [] });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "PR Board" }));
+
+    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "api", "ghp_test"));
+    expect(await screen.findByText("No open pull requests")).toBeInTheDocument();
+  });
+
+  it("marks a pre-release in the release timeline", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    githubReleaseTimelineMock.mockResolvedValue({
+      org: "acme",
+      releases: [
+        {
+          repo: "acme/api",
+          name: "v2.0.0-beta",
+          is_prerelease: true,
+          body_preview: "Beta release",
+          url: "https://github.com/acme/api/releases/v2.0.0-beta",
+          published_at: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("pre-release")).toBeInTheDocument();
+  });
 });

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -1,10 +1,15 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const jobsListMock = vi.fn();
 const tokensResolveMock = vi.fn();
 const githubEventsMock = vi.fn();
+const githubFailedRunsMock = vi.fn();
+const githubReleaseTimelineMock = vi.fn();
+const analyticsCockpitMock = vi.fn();
+const reposListMock = vi.fn();
+const reposPullsMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
@@ -16,6 +21,15 @@ vi.mock("@/lib/api/client", () => ({
     },
     github: {
       events: (...args: unknown[]) => githubEventsMock(...args),
+      failedRuns: (...args: unknown[]) => githubFailedRunsMock(...args),
+      releaseTimeline: (...args: unknown[]) => githubReleaseTimelineMock(...args),
+    },
+    analytics: {
+      cockpit: (...args: unknown[]) => analyticsCockpitMock(...args),
+    },
+    repos: {
+      list: (...args: unknown[]) => reposListMock(...args),
+      pulls: (...args: unknown[]) => reposPullsMock(...args),
     },
   },
 }));
@@ -39,8 +53,22 @@ describe("ActivityPage", () => {
     jobsListMock.mockReset();
     tokensResolveMock.mockReset();
     githubEventsMock.mockReset();
+    githubFailedRunsMock.mockReset();
+    githubReleaseTimelineMock.mockReset();
+    analyticsCockpitMock.mockReset();
+    reposListMock.mockReset();
+    reposPullsMock.mockReset();
     jobsListMock.mockResolvedValue([]);
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+    githubFailedRunsMock.mockResolvedValue({ org: "acme", runs: [] });
+    githubReleaseTimelineMock.mockResolvedValue({ org: "acme", releases: [] });
+    analyticsCockpitMock.mockResolvedValue({
+      repo_count: 0, member_count: 0, latest_score: null, score_trend: [], recent_events: [],
+      open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [], total_cache_size_bytes: 0,
+      cache_job_success_rate: 0, commit_heatmap_52w: [],
+    });
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+    reposPullsMock.mockResolvedValue({ repository: "acme/api", total: 0, pulls: [] });
   });
 
   afterEach(() => {
@@ -103,5 +131,74 @@ describe("ActivityPage", () => {
     // configure prompt is shown -- no uncaught exception from a bare `.token` read.
     expect(await screen.findByText(/No organization configured yet/)).toBeInTheDocument();
     expect(githubEventsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the CI failure log and release timeline", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    githubFailedRunsMock.mockResolvedValue({
+      org: "acme",
+      runs: [
+        {
+          repo: "acme/api", workflow_name: "CI", branch: "main", run_id: 1,
+          started_at: new Date().toISOString(), duration_seconds: 60,
+          url: "https://github.com/acme/api/actions/runs/1", actor: "alice", consecutive_failures: 3,
+        },
+      ],
+    });
+    githubReleaseTimelineMock.mockResolvedValue({
+      org: "acme",
+      releases: [
+        {
+          repo: "acme/api", tag_name: "v1.0.0", name: "v1.0.0", published_at: new Date().toISOString(),
+          is_prerelease: false, body_preview: "Initial release", url: "https://github.com/acme/api/releases/v1.0.0",
+        },
+      ],
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(githubFailedRunsMock).toHaveBeenCalledWith("acme", "ghp_test"));
+    expect(await screen.findByText(/acme\/api · CI/)).toBeInTheDocument();
+    expect(screen.getByText("×3")).toBeInTheDocument();
+    expect(await screen.findByText(/acme\/api · v1.0.0/)).toBeInTheDocument();
+  });
+
+  it("renders the commit heatmap from the cockpit endpoint", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    analyticsCockpitMock.mockResolvedValue({
+      repo_count: 1, member_count: 1, latest_score: null, score_trend: [], recent_events: [],
+      open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [], total_cache_size_bytes: 0,
+      cache_job_success_rate: 0, commit_heatmap_52w: Array.from({ length: 52 }, (_, i) => (i === 51 ? 5 : 0)),
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(analyticsCockpitMock).toHaveBeenCalledWith("acme", "ghp_test"));
+    expect(await screen.findByText("Commit Heatmap (52w)")).toBeInTheDocument();
+    expect(screen.queryByText("No commit activity in the last year")).not.toBeInTheDocument();
+  });
+
+  it("groups open PRs by author under the PR Board tab", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    reposListMock.mockResolvedValue({ org: "acme", total: 1, repos: [{ name: "api" }] });
+    reposPullsMock.mockResolvedValue({
+      repository: "acme/api",
+      total: 1,
+      pulls: [{ number: 5, title: "Fix bug", user: "alice", created_at: new Date().toISOString(), html_url: "https://github.com/acme/api/pull/5" }],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "PR Board" }));
+
+    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "api", "ghp_test"));
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("#5 Fix bug")).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -280,6 +280,37 @@ describe("api.collab", () => {
   });
 });
 
+describe("api.github", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("POSTs to /github/orgs/{org}/failed-runs with token: undefined and a default limit", async () => {
+    stubOkJson({ org: "acme", failed_runs: [] });
+    const result = await api.github.failedRuns("acme", "");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/github/orgs/acme/failed-runs");
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined, limit: 20 });
+    expect(result).toEqual({ org: "acme", failed_runs: [] });
+  });
+
+  it("POSTs to /github/orgs/{org}/release-timeline with a custom days window", async () => {
+    stubOkJson({ org: "acme", releases: [] });
+    await api.github.releaseTimeline("acme", "ghp_test", 30);
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/github/orgs/acme/release-timeline");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "ghp_test", days: 30 });
+  });
+});
+
 describe("installations.lookup / installations.sync", () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary

Closes #183. Implements docs/plan.md Phase 17 ("Activity: Full Developer Feed"): org-wide commit heatmap, CI failure log, release timeline, and a PR board grouped by author.

## What changed and why

**Backend** — `apps/api/src/routers/github.py` (extends the existing Phase 9 org-events router — same file, same org-scoped `require_org_role` convention, same POST-with-token-in-body pattern):

- `POST /github/orgs/{org_login}/failed-runs` — for each repo (capped at 20), fetches the last 30 runs, groups by workflow, and walks each workflow's own run history from newest backward counting a consecutive-failure streak. Only emits an entry once the streak reaches 3, deduped to one entry per (repo, workflow) rather than one per individual failed run — a single ongoing outage doesn't spam the log with 3+ near-duplicate rows.
- `POST /github/orgs/{org_login}/release-timeline` — for each repo (capped at 20), fetches releases and filters to the `days` window (default 90) client-side, since GitHub's releases endpoint has no date-filter query param. `body_preview` truncates to 120 chars.
- `GET /me/analytics/cockpit/{owner}` gains `commit_heatmap_52w` — reuses the exact same `/repos/{owner}/{repo}/stats/commit_activity` call `commit_activity_4w` already makes, just sums all 52 returned weeks instead of the last 4. No additional GitHub requests.
- 9 new/updated backend tests, including a dedup test (4 consecutive failures → 1 entry, not 4) and an isolation test (one broken repo's fetch failure doesn't blank out another repo's failed-run entries).

**Frontend** — `apps/ui/app/activity/page.tsx`:
- Commit Heatmap (52w) — `HeatmapCalendar`, sourced from the cockpit endpoint. Note: cockpit is personal-scoped (`/me/...`) while the rest of this page's data is org-scoped (`require_org_role`) — deliberately reused anyway since it's the same resolved token either way, and duplicating a 52-week commit-activity fetch under an org-scoped endpoint would cost the same GitHub calls for no benefit.
- CI Failure Log and Release Timeline cards — straightforward lists, each hidden behind `configured` like the rest of the page's org-scoped content.
- PR Board tab, added to the existing Activity Feed card (Feed / PR Board toggle) — groups open PRs by author. Per the issue's own suggested-fix note ("no new GitHub endpoints needed for this last one — reuses existing repo+PR list calls"), this fans out client-side over the already-existing `api.repos.list` + `api.repos.pulls` per-repo calls (capped at 10 repos), not a new backend endpoint.
- New `api.github.failedRuns` / `api.github.releaseTimeline` client methods, new types.
- 3 new tests in `activity-page.test.tsx` (failure log + release timeline rendering, heatmap rendering, PR board grouping), existing tests updated with the new mocks.

No schema migration. No RBAC changes (both new endpoints follow the existing org-scoped `require_org_role(min_role="member")` pattern already used by the sibling events endpoint in the same file).

## Test plan

- [x] `pytest -q` (full backend suite) — 403/403 pass
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` (full UI suite) — 214/214 pass (one `layout.test.tsx` timeout during a concurrent run was confirmed flaky/contention-only — passes in isolation, unrelated to this PR)