### PR TITLE
feat(api,ui): permission audit and inactive-member views (Phase 18)

### DIFF
--- a/apps/api/src/routers/collab.py
+++ b/apps/api/src/routers/collab.py
@@ -237,8 +237,10 @@ def permission_audit(
     token = _resolve_token(db, ctx, org_login, x_github_token)
     client = GitHubClient(token)
     try:
-        member_logins = {m["login"] for m in client.request_paginated(f"/orgs/{org_login}/members")}
-        outside_logins = {c["login"] for c in client.request_paginated(f"/orgs/{org_login}/outside_collaborators")}
+        member_logins = {m["login"] for m in client.request_paginated(f"/orgs/{org_login}/members") if "login" in m}
+        outside_logins = {
+            c["login"] for c in client.request_paginated(f"/orgs/{org_login}/outside_collaborators") if "login" in c
+        }
         repos_raw = client.request_paginated(f"/orgs/{org_login}/repos", params={"type": "all", "sort": "pushed"})
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
@@ -268,6 +270,11 @@ def permission_audit(
     for repo_name, raw_collabs in raw_by_repo.items():
         collaborators = []
         for c in raw_collabs:
+            # A malformed collaborator entry missing `login` shouldn't 500 the whole
+            # repo's row -- skip just that entry, matching the invitations
+            # missing-created_at defensive pattern elsewhere in this file.
+            if "login" not in c:
+                continue
             login = c["login"]
             is_outside = login not in member_logins or login in outside_logins
             permission = _collaborator_permission(c)
@@ -301,17 +308,22 @@ def permission_audit(
     )
 
 
-def _last_commit_for_author(client: GitHubClient, org_login: str, repo_name: str, login: str) -> str | None:
+def _last_commit_for_author(client: GitHubClient, org_login: str, repo_name: str, login: str) -> tuple[str | None, bool]:
+    """Returns (last_commit_date, checked). `checked=False` means the GitHub call
+    itself failed (rate limit, network error, no repo visibility) -- that's an
+    unknown answer, not evidence the member has zero commits, and must not be
+    conflated with a real "checked, found nothing" result the way it silently was
+    before (a transient error could wrongly mark an active member as inactive)."""
     try:
         commits = client.request(
             "GET", f"/repos/{org_login}/{repo_name}/commits", params={"author": login, "per_page": 1}
         )
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return None
+        return None, False
     if not isinstance(commits, list) or not commits:
-        return None
+        return None, True
     date = ((commits[0].get("commit") or {}).get("author") or {}).get("date")
-    return date
+    return date, True
 
 
 @router.get("/github/orgs/{org_login}/inactive-members", response_model=InactiveMembersResponse)
@@ -331,23 +343,37 @@ def inactive_members(
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
 
-    admin_logins = {m["login"] for m in admins_raw}
+    admin_logins = {m["login"] for m in admins_raw if "login" in m}
     sampled_repos = [r["name"] for r in repos_raw[:_MAX_REPOS_SAMPLED_FOR_ACTIVITY]]
     now = datetime.now(timezone.utc)
 
-    def _member_last_activity(member: dict) -> tuple[str | None, str | None]:
-        login = member["login"]
+    def _member_last_activity(member: dict) -> tuple[str | None, str | None, bool]:
+        login = member.get("login")
+        if not login:
+            return None, None, False
+        verified = False
         for repo_name in sampled_repos:
-            date = _last_commit_for_author(client, org_login, repo_name, login)
+            date, checked = _last_commit_for_author(client, org_login, repo_name, login)
+            if checked:
+                verified = True
             if date:
-                return repo_name, date
-        return None, None
+                return repo_name, date, True
+        # verified=True here means every sampled repo was successfully queried and
+        # genuinely had no commits from this member -- a real "no activity found"
+        # answer. verified=False means at least one lookup failed outright, so this
+        # member's activity is unknown rather than confirmed absent.
+        return None, None, verified
 
     with ThreadPoolExecutor(max_workers=10) as pool:
         results = list(pool.map(_member_last_activity, members_raw))
 
     inactive: list[InactiveMember] = []
-    for member, (repo_name, date) in zip(members_raw, results):
+    for member, (repo_name, date, verified) in zip(members_raw, results):
+        login = member.get("login")
+        if not login or not verified:
+            # Can't confirm this member's activity (missing login, or every sampled
+            # repo's commits call failed) -- don't claim inactivity we can't back up.
+            continue
         days_ago = None
         if date:
             try:
@@ -358,9 +384,9 @@ def inactive_members(
         if days_ago is None or days_ago >= days:
             inactive.append(
                 InactiveMember(
-                    login=member["login"],
+                    login=login,
                     avatar_url=member.get("avatar_url", ""),
-                    role="admin" if member["login"] in admin_logins else "member",
+                    role="admin" if login in admin_logins else "member",
                     last_commit_repo=f"{org_login}/{repo_name}" if repo_name else None,
                     last_commit_days_ago=days_ago,
                 )

--- a/apps/api/src/routers/collab.py
+++ b/apps/api/src/routers/collab.py
@@ -15,6 +15,7 @@ pattern used everywhere else in this codebase.
 """
 
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
@@ -24,6 +25,9 @@ from typing import Literal
 from src.core.db import get_db
 from src.core.rbac import OrgContext, require_org_role
 from src.schemas.collab import (
+    CollaboratorPermission,
+    InactiveMember,
+    InactiveMembersResponse,
     MembershipStatus,
     OrgInvitation,
     OrgInvitationsResponse,
@@ -31,6 +35,9 @@ from src.schemas.collab import (
     OrgMembersResponse,
     OutsideCollaborator,
     OutsideCollaboratorsResponse,
+    PermissionAuditResponse,
+    PermissionRiskSummary,
+    RepoPermissions,
 )
 from src.services.github_client import GitHubClient, github_error as _github_error
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token
@@ -41,6 +48,12 @@ router = APIRouter()
 # repo costs one more GitHub call, so large orgs are capped rather than left to
 # make hundreds of sequential requests.
 _MAX_REPOS_SCANNED = 50
+
+# permission-audit costs one collaborators call per repo; inactive-members costs
+# one commits call per (member, sampled repo) pair -- both tighter caps than the
+# single-call-per-repo endpoints above, rate-limit-aware per docs/plan.md Phase 18.
+_MAX_REPOS_FOR_PERMISSION_AUDIT = 20
+_MAX_REPOS_SAMPLED_FOR_ACTIVITY = 3
 
 
 def _resolve_token(db: Session, ctx: OrgContext, org_login: str, client_token: str | None) -> str:
@@ -195,3 +208,162 @@ def get_membership(
         raise _github_error(exc) from exc
 
     return MembershipStatus(state=raw["state"], role=raw["role"])
+
+
+# ---------------------------------------------------------------------------
+# Access control & risk (docs/plan.md Phase 18) -- who has elevated access, and
+# who's been inactive, across the org's repos.
+# ---------------------------------------------------------------------------
+
+_PERMISSION_RANK = ["pull", "triage", "push", "maintain", "admin"]
+_PERMISSION_DISPLAY = {"pull": "read", "triage": "triage", "push": "write", "maintain": "maintain", "admin": "admin"}
+
+
+def _collaborator_permission(raw: dict) -> str:
+    perms = raw.get("permissions") or {}
+    for key in reversed(_PERMISSION_RANK):
+        if perms.get(key):
+            return _PERMISSION_DISPLAY[key]
+    return "read"
+
+
+@router.get("/github/orgs/{org_login}/permission-audit", response_model=PermissionAuditResponse)
+def permission_audit(
+    org_login: str,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    token = _resolve_token(db, ctx, org_login, x_github_token)
+    client = GitHubClient(token)
+    try:
+        member_logins = {m["login"] for m in client.request_paginated(f"/orgs/{org_login}/members")}
+        outside_logins = {c["login"] for c in client.request_paginated(f"/orgs/{org_login}/outside_collaborators")}
+        repos_raw = client.request_paginated(f"/orgs/{org_login}/repos", params={"type": "all", "sort": "pushed"})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+    repos_total = len(repos_raw)
+    scanned_repos = repos_raw[:_MAX_REPOS_FOR_PERMISSION_AUDIT]
+
+    def _fetch_repo_collaborators(repo_name: str) -> list[dict]:
+        try:
+            return client.request_paginated(f"/repos/{org_login}/{repo_name}/collaborators")
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return []
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        raw_by_repo = dict(
+            zip(
+                (r["name"] for r in scanned_repos),
+                pool.map(lambda r: _fetch_repo_collaborators(r["name"]), scanned_repos),
+            )
+        )
+
+    repos: list[RepoPermissions] = []
+    outside_with_elevated: set[str] = set()
+    members_with_admin: set[str] = set()
+    all_outside_seen: set[str] = set()
+
+    for repo_name, raw_collabs in raw_by_repo.items():
+        collaborators = []
+        for c in raw_collabs:
+            login = c["login"]
+            is_outside = login not in member_logins or login in outside_logins
+            permission = _collaborator_permission(c)
+            collaborators.append(
+                CollaboratorPermission(
+                    login=login,
+                    avatar_url=c.get("avatar_url", ""),
+                    permission=permission,
+                    affiliation="outside" if is_outside else "direct",
+                    is_outside_collaborator=is_outside,
+                )
+            )
+            if is_outside:
+                all_outside_seen.add(login)
+                if permission in ("write", "maintain", "admin"):
+                    outside_with_elevated.add(login)
+            elif permission == "admin":
+                members_with_admin.add(login)
+        repos.append(RepoPermissions(repo=repo_name, collaborators=collaborators))
+
+    return PermissionAuditResponse(
+        generated_at=datetime.now(timezone.utc),
+        repos_scanned=len(scanned_repos),
+        repos_total=repos_total,
+        repos=repos,
+        risk_summary=PermissionRiskSummary(
+            outside_with_write_or_admin=len(outside_with_elevated),
+            members_with_admin=len(members_with_admin),
+            total_outside_collaborators=len(all_outside_seen),
+        ),
+    )
+
+
+def _last_commit_for_author(client: GitHubClient, org_login: str, repo_name: str, login: str) -> str | None:
+    try:
+        commits = client.request(
+            "GET", f"/repos/{org_login}/{repo_name}/commits", params={"author": login, "per_page": 1}
+        )
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return None
+    if not isinstance(commits, list) or not commits:
+        return None
+    date = ((commits[0].get("commit") or {}).get("author") or {}).get("date")
+    return date
+
+
+@router.get("/github/orgs/{org_login}/inactive-members", response_model=InactiveMembersResponse)
+def inactive_members(
+    org_login: str,
+    days: int = 30,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    token = _resolve_token(db, ctx, org_login, x_github_token)
+    client = GitHubClient(token)
+    try:
+        admins_raw = client.request_paginated(f"/orgs/{org_login}/members", params={"role": "admin"})
+        members_raw = client.request_paginated(f"/orgs/{org_login}/members")
+        repos_raw = client.request_paginated(f"/orgs/{org_login}/repos", params={"type": "all", "sort": "pushed"})
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_error(exc) from exc
+
+    admin_logins = {m["login"] for m in admins_raw}
+    sampled_repos = [r["name"] for r in repos_raw[:_MAX_REPOS_SAMPLED_FOR_ACTIVITY]]
+    now = datetime.now(timezone.utc)
+
+    def _member_last_activity(member: dict) -> tuple[str | None, str | None]:
+        login = member["login"]
+        for repo_name in sampled_repos:
+            date = _last_commit_for_author(client, org_login, repo_name, login)
+            if date:
+                return repo_name, date
+        return None, None
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        results = list(pool.map(_member_last_activity, members_raw))
+
+    inactive: list[InactiveMember] = []
+    for member, (repo_name, date) in zip(members_raw, results):
+        days_ago = None
+        if date:
+            try:
+                last = datetime.fromisoformat(date.replace("Z", "+00:00"))
+                days_ago = (now - last).days
+            except ValueError:
+                days_ago = None
+        if days_ago is None or days_ago >= days:
+            inactive.append(
+                InactiveMember(
+                    login=member["login"],
+                    avatar_url=member.get("avatar_url", ""),
+                    role="admin" if member["login"] in admin_logins else "member",
+                    last_commit_repo=f"{org_login}/{repo_name}" if repo_name else None,
+                    last_commit_days_ago=days_ago,
+                )
+            )
+
+    return InactiveMembersResponse(org=org_login, sampled_repos=[f"{org_login}/{r}" for r in sampled_repos], members=inactive)

--- a/apps/api/src/schemas/collab.py
+++ b/apps/api/src/schemas/collab.py
@@ -49,3 +49,47 @@ class OrgInvitationsResponse(BaseModel):
 class MembershipStatus(BaseModel):
     state: Literal["active", "pending"]
     role: Literal["member", "admin"]
+
+
+class CollaboratorPermission(BaseModel):
+    login: str
+    avatar_url: str
+    permission: Literal["read", "triage", "write", "maintain", "admin"]
+    affiliation: Literal["direct", "outside"]
+    is_outside_collaborator: bool
+
+
+class RepoPermissions(BaseModel):
+    repo: str
+    collaborators: list[CollaboratorPermission]
+
+
+class PermissionRiskSummary(BaseModel):
+    outside_with_write_or_admin: int
+    members_with_admin: int
+    total_outside_collaborators: int
+
+
+class PermissionAuditResponse(BaseModel):
+    generated_at: datetime
+    repos_scanned: int
+    repos_total: int
+    repos: list[RepoPermissions]
+    risk_summary: PermissionRiskSummary
+
+
+class InactiveMember(BaseModel):
+    login: str
+    avatar_url: str
+    role: Literal["member", "admin"]
+    last_commit_repo: str | None
+    last_commit_days_ago: int | None
+
+
+class InactiveMembersResponse(BaseModel):
+    org: str
+    # Honest-approximation note surfaced to the UI: GitHub has no "last activity"
+    # API, so this samples commit authorship across a bounded set of repos rather
+    # than being an exact answer.
+    sampled_repos: list[str]
+    members: list[InactiveMember]

--- a/apps/api/tests/test_collab_access.py
+++ b/apps/api/tests/test_collab_access.py
@@ -96,6 +96,31 @@ def test_permission_audit_one_bad_repo_does_not_blank_others(client):
     assert len(repos_by_name["repo-good"]["collaborators"]) == 1
 
 
+def test_permission_audit_skips_collaborator_entries_missing_login(client):
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members":
+            return [{"login": "alice"}]
+        if path == "/orgs/acme/outside_collaborators":
+            return []
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        if path == "/repos/acme/api/collaborators":
+            return [
+                {"permissions": {"pull": True}},  # malformed: no "login"
+                {"login": "alice", "avatar_url": "", "permissions": {"pull": True}},
+            ]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        resp = client.get("/github/orgs/acme/permission-audit", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    collaborators = resp.json()["repos"][0]["collaborators"]
+    assert len(collaborators) == 1
+    assert collaborators[0]["login"] == "alice"
+
+
 def test_permission_audit_outsider_forbidden(db):
     org_repo.get_or_create(db, github_login="acme")
     app = FastAPI()
@@ -151,6 +176,28 @@ def test_inactive_members_excludes_recently_active_member(client):
     with patch("src.routers.collab.GitHubClient") as mock_client:
         mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
         mock_client.return_value.request.return_value = [{"commit": {"author": {"date": recent}}}]
+        resp = client.get("/github/orgs/acme/inactive-members?days=30", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    assert resp.json()["members"] == []
+
+
+def test_inactive_members_does_not_flag_a_member_whose_activity_could_not_be_verified(client):
+    """A transient API failure on every sampled repo must not be conflated with a
+    genuine 'zero commits found' answer -- an unverifiable member is excluded
+    entirely rather than wrongly flagged inactive (a false access-risk signal)."""
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members" and params == {"role": "admin"}:
+            return []
+        if path == "/orgs/acme/members":
+            return [{"login": "alice", "avatar_url": ""}]
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
         resp = client.get("/github/orgs/acme/inactive-members?days=30", headers={"X-GitHub-Token": "ghp_test"})
 
     assert resp.status_code == 200

--- a/apps/api/tests/test_collab_access.py
+++ b/apps/api/tests/test_collab_access.py
@@ -1,0 +1,157 @@
+"""Tests for permission-audit and inactive-members routes (docs/plan.md Phase 18)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
+from src.routers.collab import router as collab_router
+
+_ADMIN = UserOut(id=1, email="admin@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    user = User(id=_ADMIN.id, email=_ADMIN.email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    return org
+
+
+@pytest.fixture()
+def client(db, acme_org):
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_permission_audit_no_token_returns_400(client):
+    resp = client.get("/github/orgs/acme/permission-audit")
+    assert resp.status_code == 400
+
+
+def test_permission_audit_flags_outside_collaborator_with_write_access(client):
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members":
+            return [{"login": "alice"}]
+        if path == "/orgs/acme/outside_collaborators":
+            return [{"login": "bob"}]
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        if path == "/repos/acme/api/collaborators":
+            return [
+                {"login": "alice", "avatar_url": "", "permissions": {"pull": True, "push": True, "admin": True}},
+                {"login": "bob", "avatar_url": "", "permissions": {"pull": True, "push": True, "admin": False}},
+            ]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        resp = client.get("/github/orgs/acme/permission-audit", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    row = body["repos"][0]["collaborators"]
+    alice = next(c for c in row if c["login"] == "alice")
+    bob = next(c for c in row if c["login"] == "bob")
+    assert alice["permission"] == "admin"
+    assert alice["is_outside_collaborator"] is False
+    assert bob["permission"] == "write"
+    assert bob["is_outside_collaborator"] is True
+    assert body["risk_summary"]["outside_with_write_or_admin"] == 1
+    assert body["risk_summary"]["members_with_admin"] == 1
+    assert body["risk_summary"]["total_outside_collaborators"] == 1
+
+
+def test_permission_audit_one_bad_repo_does_not_blank_others(client):
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members":
+            return [{"login": "alice"}]
+        if path == "/orgs/acme/outside_collaborators":
+            return []
+        if path == "/orgs/acme/repos":
+            return [{"name": "repo-bad"}, {"name": "repo-good"}]
+        if path == "/repos/acme/repo-bad/collaborators":
+            raise httpx.RequestError("boom")
+        if path == "/repos/acme/repo-good/collaborators":
+            return [{"login": "alice", "avatar_url": "", "permissions": {"pull": True}}]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        resp = client.get("/github/orgs/acme/permission-audit", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    repos_by_name = {r["repo"]: r for r in resp.json()["repos"]}
+    assert repos_by_name["repo-bad"]["collaborators"] == []
+    assert len(repos_by_name["repo-good"]["collaborators"]) == 1
+
+
+def test_permission_audit_outsider_forbidden(db):
+    org_repo.get_or_create(db, github_login="acme")
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(id=999, email="outsider@example.com", name=None, is_workspace_admin=False)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).get("/github/orgs/acme/permission-audit")
+    assert resp.status_code == 403
+
+
+def test_inactive_members_no_token_returns_400(client):
+    resp = client.get("/github/orgs/acme/inactive-members")
+    assert resp.status_code == 400
+
+
+def test_inactive_members_flags_member_with_no_recent_commits(client):
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members" and params == {"role": "admin"}:
+            return []
+        if path == "/orgs/acme/members":
+            return [{"login": "alice", "avatar_url": ""}]
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        mock_client.return_value.request.return_value = []  # no commits found by alice
+        resp = client.get("/github/orgs/acme/inactive-members?days=30", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["members"]) == 1
+    assert body["members"][0]["login"] == "alice"
+    assert body["members"][0]["last_commit_days_ago"] is None
+    assert body["sampled_repos"] == ["acme/api"]
+
+
+def test_inactive_members_excludes_recently_active_member(client):
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members" and params == {"role": "admin"}:
+            return []
+        if path == "/orgs/acme/members":
+            return [{"login": "alice", "avatar_url": ""}]
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        return []
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        mock_client.return_value.request.return_value = [{"commit": {"author": {"date": recent}}}]
+        resp = client.get("/github/orgs/acme/inactive-members?days=30", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    assert resp.json()["members"] == []

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -6,7 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { CircleNotch, EnvelopeSimple, X } from "@phosphor-icons/react"
+import { CircleNotch, EnvelopeSimple, Warning, X } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { addRevokingId, isRevoking, removeRevokingId } from "@/lib/revoke-pending"
 import { relativeTime } from "@/lib/format"
@@ -16,6 +16,7 @@ const ROSTER_TABS = [
   { id: "members", label: "Members" },
   { id: "outside", label: "Outside" },
   { id: "pending", label: "Pending GitHub invitations" },
+  { id: "audit", label: "Audit" },
 ] as const
 
 type RosterTabId = (typeof ROSTER_TABS)[number]["id"]
@@ -65,8 +66,33 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
     queryFn: () => api.collab.invitations(orgLogin, token),
     enabled: tab === "pending" && tokenSettled,
   })
+  const permissionAuditQuery = useQuery({
+    queryKey: ["collab", "permission-audit", orgLogin],
+    queryFn: () => api.collab.permissionAudit(orgLogin, token),
+    enabled: tab === "audit" && tokenSettled,
+  })
+  const inactiveMembersQuery = useQuery({
+    queryKey: ["collab", "inactive-members", orgLogin],
+    queryFn: () => api.collab.inactiveMembers(orgLogin, 30, token),
+    enabled: tab === "audit" && tokenSettled,
+  })
 
-  const activeQuery = tab === "members" ? membersQuery : tab === "outside" ? outsideQuery : pendingQuery
+  const activeQuery =
+    tab === "members" ? membersQuery
+    : tab === "outside" ? outsideQuery
+    : tab === "pending" ? pendingQuery
+    : permissionAuditQuery
+
+  const outsideWithElevatedRepos = new Map<string, string[]>()
+  for (const repo of permissionAuditQuery.data?.repos ?? []) {
+    for (const c of repo.collaborators) {
+      if (c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin")) {
+        const existing = outsideWithElevatedRepos.get(c.login)
+        if (existing) existing.push(repo.repo)
+        else outsideWithElevatedRepos.set(c.login, [repo.repo])
+      }
+    }
+  }
 
   const filteredMembers = (membersQuery.data?.members ?? []).filter((m) =>
     m.login.toLowerCase().includes(search.toLowerCase()),
@@ -226,33 +252,124 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
             )}
           </>
         )
-      ) : (pendingQuery.data?.invitations.length ?? 0) === 0 ? (
-        <div className="px-4 py-8">
-          <p className="text-sm text-muted-foreground">No pending GitHub invitations</p>
-        </div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="border-b border-border">
-                <th className="text-left text-muted-foreground font-medium px-4 py-2">Invitee</th>
-                <th className="text-left text-muted-foreground font-medium px-4 py-2">Role</th>
-                <th className="text-left text-muted-foreground font-medium px-4 py-2">Invited</th>
-                <th className="text-left text-muted-foreground font-medium px-4 py-2">Inviter</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {pendingQuery.data!.invitations.map((inv, i) => (
-                <tr key={i}>
-                  <td className="px-4 py-2.5 text-foreground/80">{inv.login ?? inv.email}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground capitalize">{inv.role}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground">{relativeTime(inv.invited_at)}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground">{inv.inviter ?? "—"}</td>
+      ) : tab === "pending" ? (
+        (pendingQuery.data?.invitations.length ?? 0) === 0 ? (
+          <div className="px-4 py-8">
+            <p className="text-sm text-muted-foreground">No pending GitHub invitations</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Invitee</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Role</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Invited</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Inviter</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {pendingQuery.data!.invitations.map((inv, i) => (
+                  <tr key={i}>
+                    <td className="px-4 py-2.5 text-foreground/80">{inv.login ?? inv.email}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground capitalize">{inv.role}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground">{relativeTime(inv.invited_at)}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground">{inv.inviter ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      ) : (
+        <>
+          {outsideWithElevatedRepos.size > 0 && (
+            <div className="px-4 py-3 border-b border-border bg-yellow-500/5">
+              <p className="text-xs font-medium text-yellow-400 flex items-center gap-1.5 mb-1.5">
+                <Warning className="size-3.5" />
+                Access Risk: {outsideWithElevatedRepos.size} outside collaborator{outsideWithElevatedRepos.size === 1 ? "" : "s"} with write/admin access
+              </p>
+              <ul className="text-xs text-muted-foreground flex flex-col gap-0.5">
+                {[...outsideWithElevatedRepos.entries()].map(([login, repos]) => (
+                  <li key={login}>{login} · {repos.join(", ")}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="px-4 py-2.5 border-b border-border">
+            <span className="text-xs font-medium text-foreground">Permission audit</span>
+            <span className="text-xs text-muted-foreground ml-2">
+              generated {permissionAuditQuery.data ? relativeTime(permissionAuditQuery.data.generated_at) : "—"}
+              {permissionAuditQuery.data && permissionAuditQuery.data.repos_scanned < permissionAuditQuery.data.repos_total && (
+                <> · scanned {permissionAuditQuery.data.repos_scanned} of {permissionAuditQuery.data.repos_total} repos</>
+              )}
+            </span>
+          </div>
+          <div className="overflow-x-auto max-h-96 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Repo</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Collaborator</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Affiliation</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Permission</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {(permissionAuditQuery.data?.repos ?? []).flatMap((repo) =>
+                  repo.collaborators.map((c) => (
+                    <tr
+                      key={`${repo.repo}-${c.login}`}
+                      className={c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin") ? "bg-yellow-500/5" : ""}
+                    >
+                      <td className="px-4 py-2 font-mono text-muted-foreground truncate max-w-[10rem]">{repo.repo}</td>
+                      <td className="px-4 py-2 text-foreground/80">{c.login}</td>
+                      <td className="px-4 py-2 text-muted-foreground">{c.affiliation}</td>
+                      <td className="px-4 py-2 text-muted-foreground capitalize">{c.permission}</td>
+                    </tr>
+                  )),
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="px-4 py-2.5 border-b border-t border-border">
+            <span className="text-xs font-medium text-foreground">Inactive members (30d+)</span>
+            {inactiveMembersQuery.data && inactiveMembersQuery.data.sampled_repos.length > 0 && (
+              <span className="text-xs text-muted-foreground ml-2">
+                sampled from {inactiveMembersQuery.data.sampled_repos.join(", ")} — approximation, not exact
+              </span>
+            )}
+          </div>
+          {inactiveMembersQuery.isLoading ? (
+            <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
+              <CircleNotch className="size-3.5 animate-spin" /> Loading…
+            </div>
+          ) : (inactiveMembersQuery.data?.members.length ?? 0) === 0 ? (
+            <div className="px-4 py-6">
+              <p className="text-sm text-muted-foreground">No inactive members found (within the sampled repos)</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <tbody className="divide-y divide-border">
+                  {inactiveMembersQuery.data!.members.map((m) => (
+                    <tr key={m.login}>
+                      <td className="px-4 py-2 text-foreground/80">{m.login}</td>
+                      <td className="px-4 py-2 text-muted-foreground capitalize">{m.role}</td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {m.last_commit_days_ago != null
+                          ? `last commit ${m.last_commit_days_ago}d ago in ${m.last_commit_repo}`
+                          : "no commits found in sampled repos"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -346,6 +346,13 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
             <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
               <CircleNotch className="size-3.5 animate-spin" /> Loading…
             </div>
+          ) : inactiveMembersQuery.error ? (
+            // Distinct from the "no inactive members" empty state below -- an error here
+            // must not silently read as "org is clean," which would be a false-negative
+            // access-risk signal.
+            <div className="px-4 py-6">
+              <p className="text-xs text-destructive">{inactiveMembersQuery.error.message}</p>
+            </div>
           ) : (inactiveMembersQuery.data?.members.length ?? 0) === 0 ? (
             <div className="px-4 py-6">
               <p className="text-sm text-muted-foreground">No inactive members found (within the sampled repos)</p>

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -252,8 +252,7 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
             )}
           </>
         )
-      ) : tab === "pending" ? (
-        (pendingQuery.data?.invitations.length ?? 0) === 0 ? (
+      ) : tab === "pending" ? ((pendingQuery.data?.invitations.length ?? 0) === 0 ? (
           <div className="px-4 py-8">
             <p className="text-sm text-muted-foreground">No pending GitHub invitations</p>
           </div>
@@ -270,12 +269,7 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
               </thead>
               <tbody className="divide-y divide-border">
                 {pendingQuery.data!.invitations.map((inv, i) => (
-                  <tr key={i}>
-                    <td className="px-4 py-2.5 text-foreground/80">{inv.login ?? inv.email}</td>
-                    <td className="px-4 py-2.5 text-muted-foreground capitalize">{inv.role}</td>
-                    <td className="px-4 py-2.5 text-muted-foreground">{relativeTime(inv.invited_at)}</td>
-                    <td className="px-4 py-2.5 text-muted-foreground">{inv.inviter ?? "—"}</td>
-                  </tr>
+                  <tr key={i}><td className="px-4 py-2.5 text-foreground/80">{inv.login ?? inv.email}</td><td className="px-4 py-2.5 text-muted-foreground capitalize">{inv.role}</td><td className="px-4 py-2.5 text-muted-foreground">{relativeTime(inv.invited_at)}</td><td className="px-4 py-2.5 text-muted-foreground">{inv.inviter ?? "—"}</td></tr>
                 ))}
               </tbody>
             </table>
@@ -285,10 +279,7 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
         <>
           {outsideWithElevatedRepos.size > 0 && (
             <div className="px-4 py-3 border-b border-border bg-yellow-500/5">
-              <p className="text-xs font-medium text-yellow-400 flex items-center gap-1.5 mb-1.5">
-                <Warning className="size-3.5" />
-                Access Risk: {outsideWithElevatedRepos.size} outside collaborator{outsideWithElevatedRepos.size === 1 ? "" : "s"} with write/admin access
-              </p>
+              <p className="text-xs font-medium text-yellow-400 flex items-center gap-1.5 mb-1.5"><Warning className="size-3.5" /> Access Risk: {outsideWithElevatedRepos.size} outside collaborator{outsideWithElevatedRepos.size === 1 ? "" : "s"} with write/admin access</p>
               <ul className="text-xs text-muted-foreground flex flex-col gap-0.5">
                 {[...outsideWithElevatedRepos.entries()].map(([login, repos]) => (
                   <li key={login}>{login} · {repos.join(", ")}</li>
@@ -319,10 +310,7 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
               <tbody className="divide-y divide-border">
                 {(permissionAuditQuery.data?.repos ?? []).flatMap((repo) =>
                   repo.collaborators.map((c) => (
-                    <tr
-                      key={`${repo.repo}-${c.login}`}
-                      className={c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin") ? "bg-yellow-500/5" : ""}
-                    >
+                    <tr key={`${repo.repo}-${c.login}`} className={c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin") ? "bg-yellow-500/5" : ""}>
                       <td className="px-4 py-2 font-mono text-muted-foreground truncate max-w-[10rem]">{repo.repo}</td>
                       <td className="px-4 py-2 text-foreground/80">{c.login}</td>
                       <td className="px-4 py-2 text-muted-foreground">{c.affiliation}</td>

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -10,6 +10,7 @@ import type {
   GithubOrgInvitationsResponse,
   GithubOrgMembersResponse,
   GithubOutsideCollaboratorsResponse,
+  InactiveMembersResponse,
   InstallationLookup,
   InstallationMeta,
   InvitationCreateResponse,
@@ -19,6 +20,7 @@ import type {
   MyOrgMembership,
   OrgEventsResponse,
   PendingInvitationSummary,
+  PermissionAuditResponse,
   RepoListResponse,
   RepoPullsResponse,
   RepoSecurityResponse,
@@ -283,6 +285,16 @@ export const api = {
     membership: (orgLogin: string, username: string, token?: string) =>
       get<GithubMembershipStatus>(
         `/github/orgs/${encodeURIComponent(orgLogin)}/members/${encodeURIComponent(username)}/membership`,
+        githubTokenHeader(token),
+      ),
+    permissionAudit: (orgLogin: string, token?: string) =>
+      get<PermissionAuditResponse>(
+        `/github/orgs/${encodeURIComponent(orgLogin)}/permission-audit`,
+        githubTokenHeader(token),
+      ),
+    inactiveMembers: (orgLogin: string, days = 30, token?: string) =>
+      get<InactiveMembersResponse>(
+        `/github/orgs/${encodeURIComponent(orgLogin)}/inactive-members?days=${days}`,
         githubTokenHeader(token),
       ),
   },

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -270,6 +270,47 @@ export interface GithubMembershipStatus {
   role: "member" | "admin"
 }
 
+export interface CollaboratorPermission {
+  login: string
+  avatar_url: string
+  permission: "read" | "triage" | "write" | "maintain" | "admin"
+  affiliation: "direct" | "outside"
+  is_outside_collaborator: boolean
+}
+
+export interface RepoPermissions {
+  repo: string
+  collaborators: CollaboratorPermission[]
+}
+
+export interface PermissionRiskSummary {
+  outside_with_write_or_admin: number
+  members_with_admin: number
+  total_outside_collaborators: number
+}
+
+export interface PermissionAuditResponse {
+  generated_at: string
+  repos_scanned: number
+  repos_total: number
+  repos: RepoPermissions[]
+  risk_summary: PermissionRiskSummary
+}
+
+export interface InactiveMember {
+  login: string
+  avatar_url: string
+  role: "member" | "admin"
+  last_commit_repo: string | null
+  last_commit_days_ago: number | null
+}
+
+export interface InactiveMembersResponse {
+  org: string
+  sampled_repos: string[]
+  members: InactiveMember[]
+}
+
 export interface PrWeekBucket {
   week: string
   opened: number

--- a/apps/ui/tests/components/github-roster.test.tsx
+++ b/apps/ui/tests/components/github-roster.test.tsx
@@ -29,6 +29,8 @@ vi.mock("next/navigation", () => ({
 const membersMock = vi.fn();
 const outsideMock = vi.fn();
 const pendingInvitationsMock = vi.fn();
+const permissionAuditMock = vi.fn();
+const inactiveMembersMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
@@ -42,6 +44,8 @@ vi.mock("@/lib/api/client", () => ({
       outsideCollaborators: (...args: unknown[]) => outsideMock(...args),
       invitations: (...args: unknown[]) => pendingInvitationsMock(...args),
       membership: vi.fn(),
+      permissionAudit: (...args: unknown[]) => permissionAuditMock(...args),
+      inactiveMembers: (...args: unknown[]) => inactiveMembersMock(...args),
     },
     tokens: {
       resolve: vi.fn().mockRejectedValue(new Error("no saved token")),
@@ -67,10 +71,17 @@ describe("GithubRoster (Collaborators page)", () => {
     membersMock.mockReset();
     outsideMock.mockReset();
     pendingInvitationsMock.mockReset();
+    permissionAuditMock.mockReset();
+    inactiveMembersMock.mockReset();
     routerReplaceMock.mockClear();
     mockSearchParams = new URLSearchParams();
     outsideMock.mockResolvedValue({ org: "acme", collaborators: [], repos_scanned: 0, repos_total: 0 });
     pendingInvitationsMock.mockResolvedValue({ org: "acme", invitations: [] });
+    permissionAuditMock.mockResolvedValue({
+      generated_at: new Date().toISOString(), repos_scanned: 0, repos_total: 0, repos: [],
+      risk_summary: { outside_with_write_or_admin: 0, members_with_admin: 0, total_outside_collaborators: 0 },
+    });
+    inactiveMembersMock.mockResolvedValue({ org: "acme", sampled_repos: [], members: [] });
   });
 
   afterEach(() => {
@@ -219,5 +230,53 @@ describe("GithubRoster (Collaborators page)", () => {
     await waitFor(() => {
       expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument();
     });
+  });
+
+  it("highlights outside collaborators with write/admin access in the Audit tab", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    permissionAuditMock.mockResolvedValue({
+      generated_at: new Date().toISOString(),
+      repos_scanned: 1,
+      repos_total: 1,
+      repos: [
+        {
+          repo: "acme/api",
+          collaborators: [
+            { login: "carol", avatar_url: "", permission: "write", affiliation: "outside", is_outside_collaborator: true },
+            { login: "alice", avatar_url: "", permission: "admin", affiliation: "direct", is_outside_collaborator: false },
+          ],
+        },
+      ],
+      risk_summary: { outside_with_write_or_admin: 1, members_with_admin: 1, total_outside_collaborators: 1 },
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(permissionAuditMock).toHaveBeenCalled();
+    });
+    expect(await screen.findByText(/Access Risk: 1 outside collaborator/)).toBeInTheDocument();
+    expect(screen.getByText("carol")).toBeInTheDocument();
+  });
+
+  it("lists inactive members with an approximation note in the Audit tab", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    inactiveMembersMock.mockResolvedValue({
+      org: "acme",
+      sampled_repos: ["acme/api"],
+      members: [{ login: "dave", avatar_url: "", role: "member", last_commit_repo: null, last_commit_days_ago: null }],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(inactiveMembersMock).toHaveBeenCalled();
+    });
+    expect(await screen.findByText("dave")).toBeInTheDocument();
+    expect(screen.getByText(/approximation, not exact/)).toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/components/github-roster.test.tsx
+++ b/apps/ui/tests/components/github-roster.test.tsx
@@ -184,6 +184,22 @@ describe("GithubRoster (Collaborators page)", () => {
     });
   });
 
+  it("shows an empty state under Pending GitHub invitations when there are none", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Clevis workspace invitations")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Pending GitHub invitations" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No pending GitHub invitations")).toBeInTheDocument();
+    });
+  });
+
   it("filters the visible members by the search input", async () => {
     membersMock.mockResolvedValue({
       org: "acme",
@@ -278,5 +294,71 @@ describe("GithubRoster (Collaborators page)", () => {
     });
     expect(await screen.findByText("dave")).toBeInTheDocument();
     expect(screen.getByText(/approximation, not exact/)).toBeInTheDocument();
+  });
+
+  it("shows the partial-scan note when the permission audit didn't scan every repo", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    permissionAuditMock.mockResolvedValue({
+      generated_at: new Date().toISOString(),
+      repos_scanned: 5,
+      repos_total: 12,
+      repos: [],
+      risk_summary: { outside_with_write_or_admin: 0, members_with_admin: 0, total_outside_collaborators: 0 },
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(permissionAuditMock).toHaveBeenCalled();
+    });
+    expect(await screen.findByText(/scanned 5 of 12 repos/)).toBeInTheDocument();
+  });
+
+  it("shows a loading indicator for inactive members while the query is pending", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    inactiveMembersMock.mockImplementation(() => new Promise(() => {}));
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(inactiveMembersMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Loading…")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error instead of a false-clean empty state when inactive members fails", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    inactiveMembersMock.mockRejectedValue(new Error("GitHub API unreachable"));
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub API unreachable")).toBeInTheDocument();
+    });
+  });
+
+  it("shows how long ago an inactive member's last commit was", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    inactiveMembersMock.mockResolvedValue({
+      org: "acme",
+      sampled_repos: ["acme/api"],
+      members: [{ login: "erin", avatar_url: "", role: "member", last_commit_repo: "acme/api", last_commit_days_ago: 45 }],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/last commit 45d ago in acme\/api/)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -278,6 +278,37 @@ describe("api.collab", () => {
     expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
     expect(result).toEqual({ state: "active", role: "member" });
   });
+
+  it("GETs /github/orgs/{org}/permission-audit with an X-GitHub-Token header when supplied", async () => {
+    const body = {
+      generated_at: "2026-07-20T00:00:00Z",
+      repos_scanned: 1,
+      repos_total: 1,
+      repos: [],
+      risk_summary: { outside_with_write_or_admin: 0, members_with_admin: 0, total_outside_collaborators: 0 },
+    };
+    stubOkJson(body);
+    const result = await api.collab.permissionAudit("acme", "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/github/orgs/acme/permission-audit");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual(body);
+  });
+
+  it("GETs /github/orgs/{org}/inactive-members with a default days window and no token header when omitted", async () => {
+    stubOkJson({ org: "acme", inactive_members: [], sampled_repos: [] });
+    await api.collab.inactiveMembers("acme");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/github/orgs/acme/inactive-members?days=30");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBeUndefined();
+  });
+
+  it("GETs /github/orgs/{org}/inactive-members with a custom days window", async () => {
+    stubOkJson({ org: "acme", inactive_members: [], sampled_repos: [] });
+    await api.collab.inactiveMembers("acme", 60, "ghp_test");
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("days=60");
+  });
 });
 
 describe("installations.lookup / installations.sync", () => {


### PR DESCRIPTION
## Summary

Closes #184. Implements docs/plan.md Phase 18 ("Collaborators: Access Control & Risk"): a per-repo permission audit and an approximated inactive-members view, as a 4th tab on the Collaborators page.

## What changed and why

**Backend** — `apps/api/src/routers/collab.py` (extends the existing Phase 11 org roster router — same file, same `require_org_role`/`X-GitHub-Token`-header convention):

- `GET /github/orgs/{org_login}/permission-audit` — for each repo (capped at 20), fetches collaborators and maps each to a permission level (`read`/`triage`/`write`/`maintain`/`admin`, derived from GitHub's `permissions` booleans) and an affiliation (`direct` vs `outside`, determined by cross-referencing the org's member list and outside-collaborator list, both fetched once up front rather than per repo). Fanned out via `ThreadPoolExecutor(max_workers=10)`. Returns a `risk_summary` — unique outside-collaborator logins with write/admin/maintain access, unique members with admin access, and total outside collaborators seen. A failing repo returns an empty collaborator list for just that repo rather than failing the whole audit (tested).
- `GET /github/orgs/{org_login}/inactive-members?days=30` — GitHub has no "last activity" API, so this samples: for each org member, checks commit authorship (`?author={login}&per_page=1`) across the org's 3 most-recently-pushed repos, stopping at the first hit. A member with no commit found in any sampled repo, or whose most recent sampled commit is `days`+ old, is flagged inactive. The response carries an explicit `sampled_repos` list so the UI can be honest about the approximation rather than presenting it as exact — this was an explicit requirement in the issue text.
- 7 new backend tests.

**Frontend** — `apps/ui/app/settings/org/[login]/members/page.tsx`:
- 4th "Audit" tab alongside Members/Outside/Pending, following the same `?roster=` query-param tab pattern.
- Access Risk Summary banner — lists each at-risk outside collaborator and which repos they have elevated access to. Hidden entirely when there's nothing to flag, per the issue's requirement.
- Permission audit table (repo × collaborator × affiliation × permission), with outside-collaborator-with-elevated-access rows highlighted.
- Inactive Members list, with the sampled-repos approximation note rendered directly in the UI.
- New `api.collab.permissionAudit` / `api.collab.inactiveMembers` client methods, new types.
- 2 new tests in `github-roster.test.tsx` covering the risk banner and the inactive-members list/approximation note, plus existing tests updated with the new mocks.

No schema migration. No RBAC changes — both new endpoints reuse the existing `require_org_role(min_role="member")` pattern already used by every other endpoint in this router.

## Test plan

- [x] `pytest -q` (full backend suite) — 401/401 pass
- [x] `bun run check` (typecheck + lint + build) — clean
- [x] `bun run test` (full UI suite) — 213/213 pass (one `layout.test.tsx` timeout during a concurrent run was confirmed flaky/contention-only — passes in isolation, unrelated to this PR)