### PR TITLE
fix(ui): mark unshipped sidebar nav items with a Coming soon badge

### DIFF
--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -34,8 +34,8 @@ const groups = [
   [
     { title: "Overview",         href: "/" },
     { title: "Activity",         href: "/activity", showUnreadBadge: true },
-    { title: "Pull Requests",    href: "/pulls" },
-    { title: "Releases",         href: "/releases" },
+    { title: "Pull Requests",    href: "/pulls", comingSoon: true },
+    { title: "Releases",         href: "/releases", comingSoon: true },
   ],
   [
     { title: "Repositories",     href: "/repos" },
@@ -48,9 +48,9 @@ const groups = [
     { title: "Job Queue",        href: "/jobs" },
   ],
   [
-    { title: "My PRs",     href: "/my/prs" },
-    { title: "My Reviews", href: "/my/reviews" },
-    { title: "My Issues",  href: "/my/issues" },
+    { title: "My PRs",     href: "/my/prs", comingSoon: true },
+    { title: "My Reviews", href: "/my/reviews", comingSoon: true },
+    { title: "My Issues",  href: "/my/issues", comingSoon: true },
   ],
 ]
 
@@ -280,6 +280,11 @@ export function AppSidebar() {
                           {"showUnreadBadge" in item && item.showUnreadBadge && unreadCount > 0 && (
                             <span className="ml-auto text-[0.625rem] font-medium bg-primary/20 text-primary rounded-full px-1.5 py-0.5 tabular-nums">
                               {unreadCount}
+                            </span>
+                          )}
+                          {"comingSoon" in item && item.comingSoon && (
+                            <span className="ml-auto text-[0.625rem] font-medium text-sidebar-foreground/40 border border-sidebar-border/60 rounded-full px-1.5 py-0.5">
+                              Soon
                             </span>
                           )}
                         </SidebarMenuButton>

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -300,3 +300,86 @@ describe("AppSidebar health dot and unread badge", () => {
     await waitFor(() => expect(link.querySelector(".bg-primary\\/20")).toBeNull());
   });
 });
+
+describe("AppSidebar coming-soon badges", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    replace.mockClear();
+    localStorage.setItem(TOKEN_KEY, makeJwt());
+    orgMemberships = [];
+    cockpitResponse = { latest_score: null, recent_events: [] };
+
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          return Promise.resolve(
+            jsonResponse({ id: 1, email: "user@example.com", name: "User", is_workspace_admin: false }),
+          );
+        }
+        if (url.endsWith("/me/orgs")) {
+          return Promise.resolve(jsonResponse(orgMemberships));
+        }
+        if (url.endsWith("/tokens/resolve")) {
+          return Promise.resolve(jsonResponse({ detail: "No saved token for this org" }, 404));
+        }
+        if (url.includes("/me/analytics/cockpit/")) {
+          return Promise.resolve(
+            jsonResponse({
+              repo_count: 0,
+              member_count: 0,
+              latest_score: cockpitResponse.latest_score,
+              score_trend: [],
+              recent_events: cockpitResponse.recent_events,
+              open_pr_count: 0,
+              pr_merge_rate_4w: [],
+              commit_activity_4w: [],
+              total_cache_size_bytes: 0,
+              cache_job_success_rate: 0,
+            }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["Pull Requests", "Releases", "My PRs", "My Reviews", "My Issues"])(
+    "shows a 'Soon' badge on the unshipped '%s' nav item",
+    async (title) => {
+      renderSidebar();
+      const link = await screen.findByRole("link", { name: new RegExp(title) });
+      expect(link).toHaveTextContent("Soon");
+    },
+  );
+
+  it.each(["Overview", "Activity", "Repositories", "Health & Security", "Collaborators", "Automation", "Audit Log", "Job Queue"])(
+    "shows no 'Soon' badge on the shipped '%s' nav item",
+    async (title) => {
+      renderSidebar();
+      const link = await screen.findByRole("link", { name: new RegExp(title) });
+      expect(link).not.toHaveTextContent("Soon");
+    },
+  );
+});


### PR DESCRIPTION
## What changed

`apps/ui/components/app-sidebar.tsx` — added a `comingSoon?: boolean` flag to the 5 stub nav items (`Pull Requests` → `/pulls`, `Releases` → `/releases`, `My PRs` → `/my/prs`, `My Reviews` → `/my/reviews`, `My Issues` → `/my/issues`) and rendered a small "Soon" pill next to their label when the flag is set, in the same `SidebarMenuButton` rendering block that already conditionally renders the health dot and unread-count badge.

## Why

Fixes #225. These 5 items (of ~14 total nav destinations) route to stub pages that render nothing but `EmptyStatePage message="... — coming soon"`. There was no visual distinction in the nav itself, so a new user could click into a third of the sidebar and hit a dead end with no warning. The badge surfaces that fact before the click instead of after.

## Implementation notes

- Reused the existing inline-conditional-badge idiom already in this file (`"showHealthDot" in item && ...`, `"showUnreadBadge" in item && ...`) rather than introducing the separate `Badge` component from `components/ui/badge.tsx`, to keep the new badge visually and structurally consistent with the sidebar's existing compact pills (the `Badge` component's default height/padding didn't match the sidebar's tighter `text-[0.625rem]` sizing used elsewhere in this file).
- No changes to the 5 stub pages — they already correctly say "coming soon"; this only makes that visible from the nav.

## Test plan

- [x] Added `AppSidebar coming-soon badges` test block to `apps/ui/tests/components/app-sidebar.test.tsx`: asserts each of the 5 stub nav links renders "Soon", and each of the 8 shipped nav links does not.
- [x] `bun run test` — all 23 sidebar tests pass.
- [x] `bun run typecheck` — passes.
- [x] `bun run lint` — passes.