### PR TITLE
fix(ui): thread invite/next context through GitHub OAuth sign-in

### DIFF
--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -89,9 +89,9 @@ def _clear_state_cookie(response: Response) -> None:
 
 
 @router.get("/login")
-def github_login(request: Request):
+def github_login(request: Request, next: str | None = None):
     try:
-        state, nonce = github_oauth.sign_state()
+        state, nonce = github_oauth.sign_state(next=next)
         url = github_oauth.build_authorize_url(state=state, redirect_uri=_callback_url(request))
     except github_oauth.GitHubOAuthNotConfigured:
         return _ui_login_error_redirect("github_not_configured")
@@ -124,6 +124,7 @@ def github_callback(
         error_response = _ui_login_error_redirect("github_invalid_state")
         _clear_state_cookie(error_response)
         return error_response
+    next_path = github_oauth.decode_state_next(state)
     try:
         user_token = github_oauth.exchange_code_for_token(code, redirect_uri=_callback_url(request))
         identity = github_oauth.fetch_identity(user_token)
@@ -144,7 +145,8 @@ def github_callback(
         return error_response
     org_provisioning.sync_org_admin_memberships(db, user, user_token)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
-    response = RedirectResponse(_ui_redirect_target(), status_code=303)
+    redirect_target = f"{_ui_redirect_target()}{next_path}" if next_path else _ui_redirect_target()
+    response = RedirectResponse(redirect_target, status_code=303)
     set_session_cookie(response, token)
     _clear_state_cookie(response)
     return response

--- a/apps/api/src/services/github_oauth.py
+++ b/apps/api/src/services/github_oauth.py
@@ -69,12 +69,31 @@ def _web_base() -> str:
     return base
 
 
-def sign_state(*, now: int | None = None) -> tuple[str, str]:
+def safe_next_path(next_path: str | None) -> str | None:
+    """Only accept unambiguous same-site relative paths -- mirrors safeNextPath() in
+    apps/ui/app/login/page.tsx. Rejects protocol-relative ("//..."), backslash variants,
+    and control characters that could let URL parsing reinterpret this as an external
+    navigation target. Used both to validate the incoming `next` query param before it's
+    embedded in the signed state, and again when reading it back out of the state at the
+    callback, so a malformed claim can never end up in a redirect."""
+    if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
+        return None
+    if "\\" in next_path or any(ord(c) < 0x20 or ord(c) == 0x7F for c in next_path):
+        return None
+    return next_path
+
+
+def sign_state(*, now: int | None = None, next: str | None = None) -> tuple[str, str]:
     """Returns (state, nonce). Callers must also set `nonce` as the STATE_COOKIE_NAME
-    cookie value on the browser and pass it back into verify_state() as cookie_nonce."""
+    cookie value on the browser and pass it back into verify_state() as cookie_nonce.
+    `next`, if a valid same-site path, is embedded in the signed payload so the callback
+    can redirect back to it -- see decode_state_next()."""
     issued = int(now if now is not None else time.time())
     nonce = secrets.token_urlsafe(24)
     payload = {"iat": issued, "exp": issued + _STATE_TTL_SECONDS, "purpose": _STATE_PURPOSE, "nonce": nonce}
+    validated_next = safe_next_path(next)
+    if validated_next:
+        payload["next"] = validated_next
     state = jwt.encode(payload, settings.auth_secret.get_secret_value(), algorithm=_STATE_ALG)
     return state, nonce
 
@@ -90,6 +109,17 @@ def verify_state(state: str, *, cookie_nonce: str | None = None) -> bool:
     if not token_nonce or not cookie_nonce or not hmac.compare_digest(token_nonce, cookie_nonce):
         return False
     return True
+
+
+def decode_state_next(state: str) -> str | None:
+    """Extract the `next` redirect path embedded by sign_state(), if any. Callers must call
+    verify_state() first -- this does not repeat the CSRF nonce/cookie check, only re-validates
+    the path shape as defense in depth."""
+    try:
+        payload = jwt.decode(state, settings.auth_secret.get_secret_value(), algorithms=[_STATE_ALG])
+    except jwt.InvalidTokenError:
+        return None
+    return safe_next_path(payload.get("next"))
 
 
 def build_authorize_url(*, state: str, redirect_uri: str) -> str:

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -10,10 +10,21 @@ from pydantic import SecretStr
 
 from src.core.config import settings
 from src.core.db import User, get_db
+from src.core.rate_limit import _buckets as _rate_limit_buckets
 from src.routers.github_auth import EmailAlreadyRegistered, find_or_create_user
 from src.routers.github_auth import router as gh_router
 from src.services import github_oauth
 from src.services.github_oauth import GitHubIdentity
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """/auth/github/callback is rate-limited per client IP via a module-level in-memory
+    bucket that persists across tests in the same process -- reset it so one test's request
+    volume can't tip a later, unrelated test over the threshold (same pattern as test_auth.py)."""
+    _rate_limit_buckets.clear()
+    yield
+    _rate_limit_buckets.clear()
 
 
 @pytest.fixture()
@@ -209,6 +220,62 @@ def test_replaying_a_captured_state_from_a_different_browser_is_rejected(gh_clie
     assert resp.status_code == 303
     assert resp.headers["location"].endswith("/login?error=github_invalid_state")
     assert db.query(User).count() == 0
+
+
+# ── next-path threading (invite-link OAuth fix) ─────────────────────────────────
+
+def test_login_embeds_next_into_state(gh_client, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login?next=/invite/abc123", follow_redirects=False)
+    state = _extract_state(login_resp)
+    assert github_oauth.decode_state_next(state) == "/invite/abc123"
+
+
+def test_login_drops_unsafe_next(gh_client, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login?next=//evil.com", follow_redirects=False)
+    state = _extract_state(login_resp)
+    assert github_oauth.decode_state_next(state) is None
+
+
+def test_callback_redirects_to_next_path_from_invite_link(gh_client, db, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login?next=/invite/abc123", follow_redirects=False)
+    state = _extract_state(login_resp)
+
+    with (
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
+    ):
+        resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "http://localhost:3000/invite/abc123"
+
+
+def test_callback_redirects_to_root_when_no_next_was_requested(gh_client, db, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login", follow_redirects=False)
+    state = _extract_state(login_resp)
+
+    with (
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
+    ):
+        resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "http://localhost:3000"
+
+
+def test_callback_ignores_unsafe_next_and_redirects_to_root(gh_client, db, oauth_configured):
+    login_resp = gh_client.get("/auth/github/login?next=//evil.com", follow_redirects=False)
+    state = _extract_state(login_resp)
+
+    with (
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
+        patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
+    ):
+        resp = gh_client.get(f"/auth/github/callback?code=c&state={state}", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "http://localhost:3000"
 
 
 def test_callback_clears_the_state_cookie_on_success(gh_client, db, oauth_configured):

--- a/apps/api/tests/test_github_oauth.py
+++ b/apps/api/tests/test_github_oauth.py
@@ -170,6 +170,44 @@ def test_list_user_org_memberships_follows_pagination():
     assert [(m.login, m.role) for m in memberships] == [("acme", "admin"), ("other-org", "member")]
 
 
+# ── next-path threading (invite-link OAuth fix) ─────────────────────────────────
+
+def test_safe_next_path_accepts_relative_paths():
+    assert github_oauth.safe_next_path("/invite/abc123") == "/invite/abc123"
+    assert github_oauth.safe_next_path("/") == "/"
+
+
+def test_safe_next_path_rejects_unsafe_values():
+    assert github_oauth.safe_next_path(None) is None
+    assert github_oauth.safe_next_path("") is None
+    assert github_oauth.safe_next_path("relative") is None
+    assert github_oauth.safe_next_path("//evil.com") is None
+    assert github_oauth.safe_next_path("/\\evil.com") is None
+    assert github_oauth.safe_next_path("/x\x00y") is None
+
+
+def test_sign_state_embeds_valid_next():
+    state, nonce = github_oauth.sign_state(next="/invite/abc123")
+    assert github_oauth.verify_state(state, cookie_nonce=nonce) is True
+    assert github_oauth.decode_state_next(state) == "/invite/abc123"
+
+
+def test_sign_state_drops_unsafe_next():
+    state, nonce = github_oauth.sign_state(next="//evil.com")
+    assert github_oauth.verify_state(state, cookie_nonce=nonce) is True
+    assert github_oauth.decode_state_next(state) is None
+
+
+def test_sign_state_without_next_has_no_next_claim():
+    state, nonce = github_oauth.sign_state()
+    assert github_oauth.verify_state(state, cookie_nonce=nonce) is True
+    assert github_oauth.decode_state_next(state) is None
+
+
+def test_decode_state_next_rejects_garbage():
+    assert github_oauth.decode_state_next("not-a-token") is None
+
+
 def test_not_configured_raises(monkeypatch):
     # Force unconfigured regardless of the ambient .env (a real App may be configured locally).
     monkeypatch.setattr(settings, "github_app_client_id", None)

--- a/apps/ui/app/invite/[token]/page.tsx
+++ b/apps/ui/app/invite/[token]/page.tsx
@@ -57,7 +57,7 @@ export default function InviteAcceptPage() {
                   >
                     Sign in
                   </a>
-                  {" "}(GitHub sign-in returns you to the dashboard instead — just revisit this link afterward).
+                  , with either your password or GitHub.
                 </p>
               ) : accept.isSuccess ? (
                 <p className="text-sm text-primary flex items-center gap-1.5">

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -159,7 +159,10 @@ export default function LoginPage() {
           type="button"
           variant="outline"
           className="w-full"
-          onClick={() => { window.location.href = `${API_BASE}/auth/github/login` }}
+          onClick={() => {
+            const qs = next !== "/" ? `?next=${encodeURIComponent(next)}` : ""
+            window.location.href = `${API_BASE}/auth/github/login${qs}`
+          }}
         >
           <GithubMark />
           Sign in with GitHub

--- a/apps/ui/tests/components/login-page.test.tsx
+++ b/apps/ui/tests/components/login-page.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const replace = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => searchParams,
+}));
+
+import LoginPage from "@/app/login/page";
+import { AuthProvider } from "@/lib/auth-context";
+
+function renderPage() {
+  return render(
+    <AuthProvider>
+      <LoginPage />
+    </AuthProvider>,
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("LoginPage GitHub OAuth button", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    replace.mockClear();
+    searchParams = new URLSearchParams();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) return Promise.resolve(new Response(null, { status: 401 }));
+        if (url.endsWith("/auth/setup-required")) return Promise.resolve(jsonResponse({ setup_required: false }));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    // jsdom throws "Not implemented: navigation" if window.location.href is actually
+    // assigned to a non-blank-page URL -- redefine it as a plain writable object so the
+    // button's onClick can be exercised without a real navigation attempt.
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { href: "" },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("appends the current next param to the GitHub OAuth login URL", async () => {
+    searchParams = new URLSearchParams({ next: "/invite/abc123" });
+    renderPage();
+
+    const button = await screen.findByRole("button", { name: /sign in with github/i });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(window.location.href).toBe("http://localhost:8080/auth/github/login?next=%2Finvite%2Fabc123"),
+    );
+  });
+
+  it("omits the next param when there is none (default '/')", async () => {
+    renderPage();
+
+    const button = await screen.findByRole("button", { name: /sign in with github/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(window.location.href).toBe("http://localhost:8080/auth/github/login"));
+  });
+});


### PR DESCRIPTION
## What changed

Fixes #222. The password-login path (`apps/ui/app/invite/[token]/page.tsx:55`) already carried `next=/invite/{token}` through `/login`, so a password sign-in resumes the invite afterward. The "Sign in with GitHub" button on `apps/ui/app/login/page.tsx` ignored `next` entirely, always sending the browser to `${API_BASE}/auth/github/login` with no param — so anyone who chose GitHub sign-in from an invite link landed on the dashboard with no memory of the invite.

**Frontend (`apps/ui/app/login/page.tsx`):** the GitHub button now appends `?next=<path>` to the OAuth login URL whenever `next` isn't the default `/`. Also removed the "GitHub sign-in returns you to the dashboard instead" caveat from `apps/ui/app/invite/[token]/page.tsx` now that it's no longer true.

**Backend — this is the sensitive part of the change** (touches OAuth/session code, flagging per AGENTS.md):
- `apps/api/src/services/github_oauth.py`: `sign_state()` now accepts an optional `next` param and embeds it in the signed OAuth-state JWT (the same token already used for CSRF protection between `/login` and `/callback`) rather than introducing a new cookie or query param to carry it through the GitHub round-trip. Added `safe_next_path()` — a server-side port of the frontend's `safeNextPath()` allowlist (same-origin relative paths only, rejects `//`, backslashes, control chars) — applied both when accepting the incoming `next` query param and again when decoding it back out of the state (`decode_state_next()`), so a malformed or external value can never end up in a redirect.
- `apps/api/src/routers/github_auth.py`: `/login` accepts `?next=`, passes it into `sign_state()`. `/callback` decodes `next` from the verified state and redirects there instead of always going to `_ui_redirect_target()` (the site root).
- No new state, no new cookie, no change to the existing CSRF nonce-cookie binding — `next` just rides along in the payload of the state token that was already being signed and verified.

## Test plan

- [x] `apps/api/tests/test_github_oauth.py` — new tests for `safe_next_path` (accepts/rejects), `sign_state`/`decode_state_next` round-trip with and without a valid/unsafe `next`.
- [x] `apps/api/tests/test_github_auth.py` — new router tests: `/login?next=` embeds it in the state; unsafe `next` is dropped at `/login`; `/callback` redirects to the next path on a full successful flow; falls back to root with no `next`; falls back to root when an unsafe `next` was requested. Also added the `_reset_rate_limiter` autouse fixture (mirroring the existing one in `test_auth.py`) — the module-level in-memory rate-limit bucket on `/auth/github/callback` is shared across tests in the same process, and the new tests' extra callback calls pushed the file over the default 10-request window, causing an unrelated pre-existing test to flake with a 429. Reset it the same way `test_auth.py` already does for `/auth/login`.
- [x] `pytest -q apps/api apps/worker` — 443 passed.
- [x] `bun run typecheck` / `bun run lint` — pass.