### PR TITLE
test(repos): regression coverage that the name filter searches the full org list

### DIFF
--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -70,6 +70,40 @@ def test_list_repos_returns_paginated_results(repos_client):
     )
 
 
+def test_list_repos_returns_the_full_org_list_spanning_multiple_github_pages(repos_client):
+    # Regression test for issue #220 ("repo name filter only searches the already-loaded
+    # first page"): request_paginated() already follows GitHub's Link header across every
+    # page before returning (see test_github_client.py::test_follows_link_header_across_pages
+    # for that mechanism in isolation) -- this asserts the repos router doesn't truncate that
+    # result on the way out, i.e. a 150-repo org (spanning two 100-per-page GitHub responses)
+    # comes back as all 150 repos in one response, not just the first page's worth.
+    repos = [
+        {
+            "name": f"repo-{i}",
+            "full_name": f"acme/repo-{i}",
+            "private": False,
+            "description": None,
+            "language": None,
+            "stargazers_count": 0,
+            "forks_count": 0,
+            "watchers_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2026-07-01T00:00:00Z",
+            "default_branch": "main",
+            "html_url": f"https://github.com/acme/repo-{i}",
+        }
+        for i in range(150)
+    ]
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = repos
+        resp = repos_client.post("/orgs/acme/repos", json={"token": "ghp_testtoken123456789012345678901234"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 150
+    assert len(body["repos"]) == 150
+    assert {r["name"] for r in body["repos"]} == {f"repo-{i}" for i in range(150)}
+
+
 def test_list_repos_no_installation_and_no_token_returns_400(repos_client):
     resp = repos_client.post("/orgs/acme/repos", json={})
     assert resp.status_code == 400

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -149,6 +149,43 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.getByText(/no repositories match your filter/i)).toBeInTheDocument());
   });
 
+  it("filters against the full org repo list, not just a first page of results (issue #220 regression)", async () => {
+    // The backend's /orgs/{org}/repos endpoint already exhausts every GitHub API page
+    // (see apps/api/src/services/github_client.py request_paginated) before responding, so
+    // listMutation.data.repos here represents the org's *complete* repo list in one shot --
+    // there's no separate "load more" page for the client-side filter to miss. Simulate an
+    // org large enough to have spanned multiple 100-per-page GitHub responses by including a
+    // repo past index 100, and assert the name filter still finds it.
+    const repos = Array.from({ length: 150 }, (_, i) => ({
+      name: `repo-${i}`,
+      full_name: `acme/repo-${i}`,
+      private: false,
+      description: null,
+      language: null,
+      stargazers_count: 0,
+      forks_count: 0,
+      watchers_count: 0,
+      open_issues_count: 0,
+      pushed_at: "2026-07-01T00:00:00Z",
+      default_branch: "main",
+      html_url: `https://github.com/acme/repo-${i}`,
+    }));
+    reposListMock.mockResolvedValue({ org: "acme", total: 150, repos });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+    await waitFor(() => expect(screen.getByText("repo-0")).toBeInTheDocument());
+
+    // repo-149 would only exist on GitHub's second 100-per-page response -- confirms the
+    // filter searches the entire fetched list, not a truncated first page of it.
+    fireEvent.change(screen.getByPlaceholderText("Filter by name…"), { target: { value: "repo-149" } });
+
+    await waitFor(() => expect(screen.getByText("repo-149")).toBeInTheDocument());
+    expect(screen.queryByText("repo-0")).not.toBeInTheDocument();
+  });
+
   it("shows an error message when loading repos fails", async () => {
     reposListMock.mockRejectedValue(new Error("No GitHub App installation found"));
 


### PR DESCRIPTION
## This PR does NOT reproduce or fix a bug — it closes #220 as not-reproducible, with regression coverage

#220 reported that `apps/ui/app/repos/page.tsx`'s "Filter by name…" input only searches the first page of a server-paginated repo list, so repos beyond page 1 in a large org would silently never match the filter.

**I could not reproduce this against current code**, and want to be explicit about why rather than silently closing the issue:

- The backend's `POST /orgs/{owner}/repos` endpoint (`apps/api/src/routers/repos.py` → `GitHubClient.request_paginated`, `apps/api/src/services/github_client.py`) already follows GitHub's `Link: rel="next"` header across **every** page (100 per page) before returning a response — it does not stop at page 1.
- `apps/ui/lib/api/client.ts`'s `repos.list()` sends no `page`/`offset`/`limit` params — it's a single POST that gets back the org's complete repo list in one response.
- The client-side filter in `repos/page.tsx` runs over that already-complete `listMutation.data.repos` array. There is no separate "page 1 only" subset for the filter to be limited to — the premise described in the issue doesn't hold against this code path.

## What this PR actually does

Adds regression tests on both ends so a real "only fetches/filters page 1" bug can't land silently in the future:

- `apps/api/tests/test_repos.py::test_list_repos_returns_the_full_org_list_spanning_multiple_github_pages` — mocks a 150-repo `GitHubClient.request_paginated` response (deliberately larger than one 100-per-page GitHub response) and asserts all 150 come back in the API response, not truncated to the first page.
- `apps/ui/tests/components/repos-page.test.tsx` — new test filters a loaded 150-repo list by a name only present past index 100 (i.e. only on what would be GitHub's second page) and asserts it's still found.

No production code changed. Recommending #220 be closed referencing this PR once merged, since it documents that the reported behavior doesn't reproduce and pins it with tests.

## Test plan

- [x] `pytest -q apps/api apps/worker` — 433 passed.
- [x] `bun run test -- repos-page` — 20 passed.
- [x] `bun run typecheck` / `bun run lint` — pass.