### PR TITLE
fix(checks): cap unbounded GitHub API pagination in _get_all_pages

### DIFF
--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -1,8 +1,19 @@
+import logging
 import time
 
 import httpx
 
 from checks.base import Check, CheckMetadata
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on pages fetched by _get_all_pages -- at per_page=100 this is 5,000 items max.
+# Without this, a large enough org (thousands of repos/members/workflow runs) can pull an
+# unbounded number of objects into one in-memory list during a scan, which is a plausible
+# direct cause of OOM crashes in the api process (see issue #214). Truncating with a warning
+# degrades a scan's completeness rather than crashing the whole run_all_checks() call, since
+# the runner.py prefetch that calls this isn't wrapped in try/except.
+_MAX_PAGES = 50
 
 
 def _get_with_retry(client: httpx.Client, url: str, headers: dict) -> httpx.Response:
@@ -43,16 +54,26 @@ def _get_all_pages(base_url: str, path: str, token: str) -> list:
     }
     results = []
     url: str | None = f"{base_url}{path}?per_page=100"
+    pages_fetched = 0
     with httpx.Client(timeout=20) as client:
         while url:
             r = _get_with_retry(client, url, headers)
             r.raise_for_status()
             results.extend(r.json())
+            pages_fetched += 1
             url = None
             for part in r.headers.get("Link", "").split(","):
                 part = part.strip()
                 if 'rel="next"' in part:
                     url = part.split(";")[0].strip().strip("<>")
+            if url and pages_fetched >= _MAX_PAGES:
+                logger.warning(
+                    "Truncating pagination for %s after %d pages (%d items) -- more pages were available",
+                    path,
+                    pages_fetched,
+                    len(results),
+                )
+                break
     return results
 
 

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from checks.github_checks import (
+    _MAX_PAGES,
     BranchProtectionEnabled,
     CodeScanningCheck,
     DefaultBranchNoForcePushCheck,
@@ -13,6 +14,7 @@ from checks.github_checks import (
     OrgMFARequired,
     SecretScanningEnabled,
     _get,
+    _get_all_pages,
 )
 
 
@@ -112,6 +114,42 @@ def test_get_gives_up_after_3_attempts_on_persistent_connection_error():
         with pytest.raises(httpx.ConnectError):
             _get("https://x/y", "tok")
     assert mock_get.call_count == 3
+
+
+# ── _get_all_pages pagination cap (issue #214: unbounded pagination -> OOM) ────
+
+
+def test_get_all_pages_follows_link_header_across_pages():
+    def fake_get(url, headers):
+        page = int(url.split("&page=")[-1]) if "&page=" in url else 1
+        if page < 3:
+            link = f'<https://x/y?per_page=100&page={page + 1}>; rel="next"'
+            return httpx.Response(200, json=[{"id": page}], headers={"Link": link}, request=httpx.Request("GET", url))
+        return httpx.Response(200, json=[{"id": page}], request=httpx.Request("GET", url))
+
+    with patch("httpx.Client.get", side_effect=fake_get):
+        results = _get_all_pages("https://x", "/y", "tok")
+    assert results == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+
+def test_get_all_pages_truncates_after_max_pages_and_logs_warning(caplog):
+    call_count = 0
+
+    def fake_get(url, headers):
+        nonlocal call_count
+        call_count += 1
+        link = '<https://x/y?page=next>; rel="next"'
+        return httpx.Response(200, json=[{"id": call_count}], headers={"Link": link}, request=httpx.Request("GET", url))
+
+    with patch("httpx.Client.get", side_effect=fake_get):
+        with caplog.at_level("WARNING"):
+            results = _get_all_pages("https://x", "/y", "tok")
+
+    # Stops at the cap rather than following the (still-present) Link header forever --
+    # this is the behavior that prevents an unbounded in-memory list on a huge org.
+    assert len(results) == _MAX_PAGES
+    assert call_count == _MAX_PAGES
+    assert "Truncating pagination" in caplog.text
 
 
 # ── DependabotAlertsCheck ────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Fixes #214. `_get_all_pages()` in `packages/checks/src/checks/github_checks.py` followed GitHub's `Link: rel="next"` header in an uncapped `while url:` loop, calling `results.extend(r.json())` on every page with no limit on page count or total result size.

## Why

This runs inside the `api` process on every analytics/security-check scan (`analytics_service.py` → `checks.runner.run_all_checks`), and again for `runner.py`'s org repo-list prefetch. Against a large enough org (thousands of repos, org members, or workflow runs), a single scan can pull tens of thousands of objects into one in-memory list with no cap — a plausible direct cause of the OOM-driven crashes reported after deploys, since a fresh scan is often triggered right after a redeploy.

## Fix

- Added a `_MAX_PAGES = 50` module-level constant (50 pages × `per_page=100` = 5,000 items cap), following this file's existing pattern of hardcoded module constants (retry count, timeout, `per_page` are all inline literals already — no env/config precedent in this package to break).
- Once the cap is hit, the loop stops fetching further pages and **logs a warning instead of raising**. `runner.py`'s prefetch call (`repos = _get_all_pages(...)` at line 17) isn't wrapped in try/except, so a raised exception there would crash the entire `run_all_checks()` call rather than degrading gracefully — truncating with a warning matches the issue's own suggested fix ("fail gracefully ... or truncate with a warning") and keeps a scan usable (partial results) instead of losing it entirely.
- All 5 call sites in this file (`BranchProtectionEnabled`, `SecretScanningEnabled`, `DependabotAlertsCheck`, `CodeScanningCheck`, `DefaultBranchNoForcePushCheck`) and the `runner.py` prefetch are pure iteration/`len()` consumers of the returned list — no other logic needed to change.

## Test plan

- [x] `packages/checks/tests/test_github_checks.py` — new tests: `_get_all_pages` still correctly follows the `Link` header across pages under the cap; and truncates at exactly `_MAX_PAGES` pages with a warning logged when more pages are available, following the existing `httpx.Client.get` monkeypatch/mock pattern already used in this file's retry tests.
- [x] `pytest -q packages/checks apps/api apps/worker` — 464 passed.