### PR TITLE
fix(infra): add container memory limits and worker/ui healthchecks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Key variables:
 - `GITHUB_API_BASE` — default `https://api.github.com`; set for GitHub Enterprise (e.g. `https://github.yourco.com/api/v3`). Used by both the API and the worker. Not runtime-editable because it's where GitHub tokens are sent.
 
 **DB-backed config (editable in Settings → Instance Configuration):**
-- `worker_poll_seconds` — default `5`; the worker re-reads it each loop, so changes take effect live without a restart
+- `worker_poll_seconds` — default `5`, clamped to `[1, 30]`; the worker re-reads it each loop, so changes take effect live without a restart. The upper clamp keeps the worker's heartbeat healthcheck in `docker-compose.yml` meaningful (see `apps/worker/src/worker.py`'s `_MAX_POLL_SECONDS`).
 
 ## Running locally
 

--- a/apps/ui/app/api/health/route.ts
+++ b/apps/ui/app/api/health/route.ts
@@ -1,0 +1,6 @@
+// Liveness endpoint for the docker-compose healthcheck -- deliberately does not call the
+// API or DB, so it can't report "unhealthy" due to a downstream outage the UI container
+// itself isn't responsible for. It only confirms the Next.js server is up and responding.
+export function GET() {
+  return new Response("ok", { status: 200 })
+}

--- a/apps/ui/tests/components/health-route.test.ts
+++ b/apps/ui/tests/components/health-route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 without calling the API or DB", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+});

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -22,6 +22,14 @@ log = logging.getLogger(__name__)
 # from a genuinely healthy one -- `restart: unless-stopped` only fires on a hard crash,
 # not a hang, so without this a stuck worker container would never be restarted.
 HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")
+# The docker-compose healthcheck treats the heartbeat file as stale past 60s (see
+# docker-compose.yml). worker_poll_seconds is a live-editable app_config value with no
+# upper bound otherwise, and the heartbeat only gets touched once per loop iteration --
+# an operator setting it above this cap would make every iteration's normal sleep alone
+# exceed the healthcheck's staleness threshold, permanently false-positive-ing the worker
+# as hung. Kept comfortably below 60s so real job processing inside an iteration still
+# has margin before the healthcheck's threshold is reached.
+_MAX_POLL_SECONDS = 30
 
 # psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
@@ -49,11 +57,13 @@ def _read_app_config(key: str, default: str) -> str:
 
 
 def _read_poll_seconds() -> int:
-    """Read worker_poll_seconds, clamped to a minimum of 1. Falls back to 5 on a
-    malformed value so a bad config row can never crash or busy-loop the worker."""
+    """Read worker_poll_seconds, clamped to [1, _MAX_POLL_SECONDS]. Falls back to 5 on a
+    malformed value so a bad config row can never crash or busy-loop the worker. The upper
+    clamp keeps the heartbeat healthcheck's staleness threshold meaningful -- see
+    _MAX_POLL_SECONDS."""
     raw = _read_app_config("worker_poll_seconds", "5")
     try:
-        return max(1, int(raw))
+        return max(1, min(_MAX_POLL_SECONDS, int(raw)))
     except ValueError:
         log.warning("worker_poll_seconds %r is not an integer; using 5", raw)
         return 5

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from pathlib import Path
 
 import httpx
 import psycopg
@@ -15,6 +16,12 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
 )
 log = logging.getLogger(__name__)
+
+# Touched once per poll loop iteration so the docker-compose healthcheck can tell a hung
+# worker (process alive but stuck, e.g. blocked on a network call with no timeout) apart
+# from a genuinely healthy one -- `restart: unless-stopped` only fires on a hard crash,
+# not a hang, so without this a stuck worker container would never be restarted.
+HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")
 
 # psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
@@ -207,10 +214,20 @@ def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
         log.warning("reclaimed stale job %d -> %s", job_id, status)
 
 
+def _touch_heartbeat() -> None:
+    try:
+        HEARTBEAT_FILE.write_text(str(time.time()))
+    except OSError as exc:
+        # Non-fatal -- the heartbeat is only a liveness signal for the healthcheck, not
+        # required for job processing itself.
+        log.warning("could not write heartbeat file %s: %s", HEARTBEAT_FILE, exc)
+
+
 def run() -> None:
     poll_seconds = _read_poll_seconds()
     log.info("worker started, polling every %ds", poll_seconds)
     while True:
+        _touch_heartbeat()
         # Re-read poll interval each cycle so changes in settings take effect without restart
         poll_seconds = _read_poll_seconds()
         try:

--- a/apps/worker/tests/test_heartbeat.py
+++ b/apps/worker/tests/test_heartbeat.py
@@ -1,0 +1,24 @@
+import time
+
+from worker import _touch_heartbeat
+
+
+def test_touch_heartbeat_writes_current_time(tmp_path, monkeypatch):
+    heartbeat_file = tmp_path / "worker_heartbeat"
+    monkeypatch.setattr("worker.HEARTBEAT_FILE", heartbeat_file)
+
+    before = time.time()
+    _touch_heartbeat()
+    after = time.time()
+
+    written = float(heartbeat_file.read_text())
+    assert before <= written <= after
+
+
+def test_touch_heartbeat_does_not_raise_if_the_path_is_unwritable(monkeypatch, tmp_path):
+    # e.g. a read-only filesystem or a permissions issue -- the heartbeat is only a
+    # liveness signal for the healthcheck, must never take down job processing itself.
+    unwritable_dir = tmp_path / "does-not-exist" / "worker_heartbeat"
+    monkeypatch.setattr("worker.HEARTBEAT_FILE", unwritable_dir)
+
+    _touch_heartbeat()  # must not raise

--- a/apps/worker/tests/test_poll_seconds.py
+++ b/apps/worker/tests/test_poll_seconds.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from worker import _MAX_POLL_SECONDS, _read_poll_seconds
+
+
+def test_read_poll_seconds_clamps_to_max():
+    # worker_poll_seconds is a live-editable app_config value -- an operator setting it
+    # above _MAX_POLL_SECONDS must not silently make the heartbeat healthcheck's staleness
+    # threshold trip on every normal iteration (see the comment on _MAX_POLL_SECONDS).
+    with patch("worker._read_app_config", return_value="600"):
+        assert _read_poll_seconds() == _MAX_POLL_SECONDS
+
+
+def test_read_poll_seconds_clamps_to_min():
+    with patch("worker._read_app_config", return_value="0"):
+        assert _read_poll_seconds() == 1
+
+
+def test_read_poll_seconds_passes_through_a_value_within_range():
+    with patch("worker._read_app_config", return_value="10"):
+        assert _read_poll_seconds() == 10
+
+
+def test_read_poll_seconds_falls_back_to_5_on_malformed_value():
+    with patch("worker._read_app_config", return_value="not-a-number"):
+        assert _read_poll_seconds() == 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,16 @@ name: clevis
 #            docker compose up --build       → full stack
 
 services:
+  # mem_limit values below are tuned for a 4GB host, leaving headroom for the OS and
+  # Traefik -- without a per-container cap, one service creeping up in RSS (e.g. the
+  # unbounded-pagination OOM risk fixed in issue #214) has nothing stopping it from
+  # starving the others, and the kernel OOM-killer's victim selection isn't necessarily
+  # the actual offender, so failures present as an unrelated service crashing. Revisit
+  # these if the host's RAM budget changes.
   db:
     container_name: db
     image: postgres:17
+    mem_limit: 1g
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -32,6 +39,7 @@ services:
     build:
       context: .
       dockerfile: apps/api/Dockerfile
+    mem_limit: 768m
     env_file:
       - .env
     expose:
@@ -54,6 +62,7 @@ services:
     build:
       context: .
       dockerfile: apps/worker/Dockerfile
+    mem_limit: 512m
     env_file:
       - .env
     depends_on:
@@ -62,6 +71,15 @@ services:
       api:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      # worker.py touches HEARTBEAT_FILE once per poll loop iteration -- a hung-but-alive
+      # process (e.g. blocked on a network call) stops updating it, so this catches hangs
+      # that `restart: unless-stopped` alone wouldn't (that only fires on a hard crash).
+      test: ["CMD", "python", "-c", "import time,sys; sys.exit(0 if time.time() - __import__('os').path.getmtime('/tmp/worker_heartbeat') < 60 else 1)"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - clevis
 
@@ -73,6 +91,7 @@ services:
         # NEXT_PUBLIC_* vars must be available at build time
         NEXT_PUBLIC_API_BASE: ${NEXT_PUBLIC_API_BASE}
         NEXT_PUBLIC_GITHUB_APP_SLUG: ${NEXT_PUBLIC_GITHUB_APP_SLUG:-}
+    mem_limit: 512m
     env_file:
       - .env
     expose:
@@ -82,6 +101,14 @@ services:
         condition: service_healthy
         required: false
     restart: unless-stopped
+    healthcheck:
+      # node, not curl -- the ui image's runner stage is node:22-alpine, which has no
+      # curl/wget by default.
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/api/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - clevis
 


### PR DESCRIPTION
## What changed — this touches deploy-relevant infra config (`docker-compose.yml`), flagging per AGENTS.md

Fixes #216. `docker-compose.yml` set no `mem_limit`/`deploy.resources.limits` on any service, and only `db`/`api` had a `healthcheck` — `worker` and `ui` had none, only `restart: unless-stopped`.

## Why

On a memory-constrained host, one service creeping up in RSS (e.g. the unbounded-pagination OOM risk fixed in #214, which runs inside the `api` process) had nothing stopping it from consuming host memory until the kernel OOM-killer intervened. Without per-container limits, the OOM killer's victim selection isn't necessarily the actual offender, so the failure can present as an unrelated service crashing — consistent with the reported "crashes on almost every deploy" with no clear single cause. Separately, without a healthcheck, a hung-but-technically-alive `worker`/`ui` container wouldn't be auto-restarted — only a hard crash triggers `restart: unless-stopped`.

## Fix

- **Memory limits** (asked the maintainer for the target host's specs, given a 4GB host budget): `db: 1g`, `api: 768m`, `worker: 512m`, `ui: 512m` — leaves ~1.25g headroom for the OS/Traefik. Uses `mem_limit` (the classic-compose key), not `deploy.resources.limits.memory` — this file has no top-level `version:`/swarm mode, so `deploy.*` would be silently ignored under plain `docker compose up`. Comment in the file notes these are tuned for a 4GB host and should be revisited if that changes.
- **Worker healthcheck**: `apps/worker/src/worker.py` now touches a heartbeat file (`/tmp/worker_heartbeat`) once per poll-loop iteration. The healthcheck CMD is a `python` one-liner checking the file's mtime is <60s old, matching the `api` service's existing `python -c` style (avoids relying on curl/wget, which aren't guaranteed on `python:3.12-slim`).
- **UI healthcheck**: added `apps/ui/app/api/health/route.ts` — a plain 200 response, deliberately not calling the API or DB so it can't report "unhealthy" due to a downstream outage the UI container isn't responsible for. Healthcheck CMD uses `node`, not curl, since the `ui` image's runner stage (`node:22-alpine`) doesn't have curl by default.

## Test plan

- [x] `docker compose config` — parses cleanly, confirms `mem_limit` and both new `healthcheck` blocks apply correctly (didn't run a full `docker compose up --build`, which is slower and wasn't necessary to validate the compose syntax and app-level changes).
- [x] `apps/worker/tests/test_heartbeat.py` — new tests: `_touch_heartbeat` writes a current timestamp; doesn't raise if the path is unwritable (heartbeat failures must never take down job processing).
- [x] `apps/ui/tests/components/health-route.test.ts` — new test: `GET /api/health` returns 200 with no API/DB calls.
- [x] `pytest -q apps/worker apps/api packages/checks` — 464 passed.
- [x] `bun run test` — 257 passed, 1 pre-existing flaky failure in `layout.test.tsx` (a jsdom "navigation to another Document" timeout, unrelated to this change) — passes in isolation.
- [x] `bun run typecheck` / `bun run lint` — pass.