### PR TITLE
fix(ui): UI polish batch (collaborators, roster filters, repo-segment charset, security retry)

### DIFF
--- a/apps/ui/app/collaborators/page.tsx
+++ b/apps/ui/app/collaborators/page.tsx
@@ -50,6 +50,21 @@ export default function CollaboratorsPage() {
             title="Couldn't load your organizations"
             description="Something went wrong checking your organization memberships. Try refreshing the page."
           />
+        ) : memberships.length > 0 ? (
+          <div className="border border-dashed border-border rounded-md px-6 py-12">
+            <p className="text-sm text-muted-foreground">
+              Member management is only available for organizations where you&rsquo;re an admin. You&rsquo;re a
+              member (not admin) of:
+            </p>
+            <ul className="mt-2 text-sm text-foreground list-disc list-inside">
+              {memberships.map((m) => (
+                <li key={m.org_login}>{m.org_login}</li>
+              ))}
+            </ul>
+            <p className="mt-3 text-xs text-muted-foreground">
+              Ask an admin of one of these organizations to grant you admin access.
+            </p>
+          </div>
         ) : (
           <EmptyState
             title="No organization to manage"

--- a/apps/ui/app/repos/[repo]/page.tsx
+++ b/apps/ui/app/repos/[repo]/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Skeleton } from "@/components/ui/skeleton"
+import { SectionError } from "@/components/section-error"
 import { GitPullRequest, ArrowSquareOut, Star, GitFork, Eye, ShieldCheck, ShieldWarning, Shield } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { parseOwnerRepo } from "@/lib/repo-segment"
@@ -328,7 +329,11 @@ export default function RepoDetailPage() {
           {securityQuery.isLoading ? (
             <Skeleton className="h-16 w-full" />
           ) : securityQuery.isError ? (
-            <p className="text-xs text-destructive">{securityQuery.error.message}</p>
+            <SectionError
+              message={securityQuery.error.message}
+              onRetry={() => securityQuery.refetch()}
+              retrying={securityQuery.isFetching}
+            />
           ) : securityQuery.data ? (
             <div className="flex flex-col gap-2">
               <SecurityStatusRow

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation"
 import { useState } from "react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -55,6 +55,10 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
     queryKey: ["collab", "members", orgLogin, roleFilter],
     queryFn: () => api.collab.members(orgLogin, roleFilter, token),
     enabled: tab === "members" && tokenSettled,
+    // Keeps the previous role filter's rows on screen (with isFetching still true) while
+    // the new one loads, instead of flashing an empty table -- a role change now looks
+    // like a background refetch rather than a full reload, distinct from client-side search.
+    placeholderData: keepPreviousData,
   })
   const outsideQuery = useQuery({
     queryKey: ["collab", "outside", orgLogin],
@@ -97,7 +101,13 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
   const filteredMembers = (membersQuery.data?.members ?? []).filter((m) =>
     m.login.toLowerCase().includes(search.toLowerCase()),
   )
-  const membersWithout2fa = (membersQuery.data?.members ?? []).filter((m) => m.two_factor_enabled === false).length
+  // Derived from filteredMembers (not the unfiltered roster) so this count always matches
+  // what's actually visible in the table below it -- a stale org-wide total next to a
+  // filtered table reads as a data-integrity bug, especially for a 2FA-compliance number.
+  const membersWithout2fa = filteredMembers.filter((m) => m.two_factor_enabled === false).length
+  // roleFilter is part of membersQuery's queryKey (server-side refetch), while `search` is
+  // client-side -- distinguish the two so a role change doesn't look identical to typing.
+  const isRefetchingByRole = membersQuery.isFetching && !membersQuery.isLoading
 
   return (
     <div className="card">
@@ -142,6 +152,11 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
               <option value="member">Member</option>
               <option value="admin">Admin</option>
             </select>
+            {isRefetchingByRole && (
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <CircleNotch className="size-3 animate-spin" /> Updating…
+              </span>
+            )}
           </>
         )}
       </div>

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { Trash, Plus, CircleNotch, Check, ArrowSquareOut, CheckCircle } from "@p
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { SectionError } from "@/components/section-error"
 import Link from "next/link"
 import { api } from "@/lib/api/client"
 import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values"
@@ -168,21 +169,6 @@ function AppearanceSection() {
           )
         })}
       </div>
-    </div>
-  )
-}
-
-// ── Shared inline error state ────────────────────────────────────────────────
-
-function SectionError({ message, onRetry, retrying }: { message: string; onRetry: () => void; retrying?: boolean }) {
-  const retryContent: React.ReactNode = retrying ? <CircleNotch className="size-3 animate-spin" /> : "Retry"
-
-  return (
-    <div className="px-4 py-6 flex items-center justify-between gap-3">
-      <p className="text-sm text-destructive">{message}</p>
-      <Button size="sm" variant="outline" onClick={onRetry} disabled={retrying}>
-        {retryContent}
-      </Button>
     </div>
   )
 }

--- a/apps/ui/components/section-error.tsx
+++ b/apps/ui/components/section-error.tsx
@@ -1,0 +1,18 @@
+import { CircleNotch } from "@phosphor-icons/react"
+import { Button } from "@/components/ui/button"
+
+// Shared inline error state with a manual retry action — used anywhere a TanStack Query
+// section can fail and would otherwise show the same cached error forever (default query
+// behavior doesn't retry just from switching tabs away and back).
+export function SectionError({ message, onRetry, retrying }: { message: string; onRetry: () => void; retrying?: boolean }) {
+  const retryContent: React.ReactNode = retrying ? <CircleNotch className="size-3 animate-spin" /> : "Retry"
+
+  return (
+    <div className="px-4 py-6 flex items-center justify-between gap-3">
+      <p className="text-sm text-destructive">{message}</p>
+      <Button size="sm" variant="outline" onClick={onRetry} disabled={retrying}>
+        {retryContent}
+      </Button>
+    </div>
+  )
+}

--- a/apps/ui/lib/repo-segment.ts
+++ b/apps/ui/lib/repo-segment.ts
@@ -1,9 +1,18 @@
 /** Parse /repos/{owner~repo} dynamic segment from the UI router. */
 
+// GitHub username rules: alphanumeric and single hyphens, no leading/trailing/consecutive
+// hyphens, max 39 characters. Repo name rules: alphanumeric, hyphen, underscore, period.
+// Splitting on "~" alone is currently safe (GitHub names can't contain "~"), but validating
+// the charset here is defense-in-depth so a malformed segment never reaches api.repos.stats(...)
+// relying entirely on the backend to reject it.
+const OWNER_PATTERN = /^(?!-)(?!.*--)[a-zA-Z0-9-]{1,39}(?<!-)$/
+const REPO_PATTERN = /^[\w.-]+$/
+
 export function parseOwnerRepo(segment: string): { owner: string; repo: string } | null {
   const parts = segment.split("~")
   if (parts.length !== 2) return null
-  const [owner, repo] = parts
-  if (!owner.trim() || !repo.trim()) return null
-  return { owner: owner.trim(), repo: repo.trim() }
+  const [owner, repo] = parts.map((p) => p.trim())
+  if (!owner || !repo) return null
+  if (!OWNER_PATTERN.test(owner) || !REPO_PATTERN.test(repo)) return null
+  return { owner, repo }
 }

--- a/apps/ui/tests/components/collaborators-page.test.tsx
+++ b/apps/ui/tests/components/collaborators-page.test.tsx
@@ -81,8 +81,22 @@ describe("CollaboratorsPage", () => {
     );
   });
 
-  it("shows a message instead of redirecting when the user has no admin org", async () => {
-    orgsMineMock.mockResolvedValue([{ org_login: "acme", role: "member" }]);
+  it("lists the user's non-admin memberships instead of a bare empty state", async () => {
+    orgsMineMock.mockResolvedValue([
+      { org_login: "acme", role: "member" },
+      { org_login: "widgets", role: "member" },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("acme")).toBeInTheDocument());
+    expect(screen.getByText("widgets")).toBeInTheDocument();
+    expect(screen.getByText(/member \(not admin\) of/i)).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the generic empty state when the user has no org memberships at all", async () => {
+    orgsMineMock.mockResolvedValue([]);
 
     renderPage();
 

--- a/apps/ui/tests/components/github-roster.test.tsx
+++ b/apps/ui/tests/components/github-roster.test.tsx
@@ -127,6 +127,46 @@ describe("GithubRoster (Collaborators page)", () => {
     expect(screen.queryByText(/Members without 2FA/)).not.toBeInTheDocument();
   });
 
+  it("recomputes the 'Members without 2FA' count from the search-filtered members, not the full roster", async () => {
+    membersMock.mockResolvedValue({
+      org: "acme",
+      members: [
+        { login: "alice", avatar_url: "", role: "member", site_admin: false, two_factor_enabled: false },
+        { login: "bob", avatar_url: "", role: "member", site_admin: false, two_factor_enabled: false },
+      ],
+      two_factor_overlay_available: true,
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Members without 2FA: 2")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText("Search by login…"), { target: { value: "alice" } });
+
+    await waitFor(() => expect(screen.getByText("Members without 2FA: 1")).toBeInTheDocument());
+    expect(screen.queryByText("bob")).not.toBeInTheDocument();
+  });
+
+  it("shows an 'Updating…' indicator while a role-filter change refetches, distinct from client-side search", async () => {
+    let resolveRefetch: (v: unknown) => void = () => {};
+    membersMock
+      .mockResolvedValueOnce({ org: "acme", members: [], two_factor_overlay_available: true })
+      .mockReturnValueOnce(new Promise((resolve) => { resolveRefetch = resolve }));
+
+    renderPage();
+    await waitFor(() => expect(membersMock).toHaveBeenCalledWith("acme", "all", undefined));
+    await waitFor(() => expect(screen.getByText("No members found")).toBeInTheDocument());
+
+    expect(screen.queryByText(/Updating…/)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByDisplayValue("All roles"), { target: { value: "admin" } });
+
+    await waitFor(() => expect(screen.getByText(/Updating…/)).toBeInTheDocument());
+
+    resolveRefetch({ org: "acme", members: [], two_factor_overlay_available: true });
+    await waitFor(() => expect(screen.queryByText(/Updating…/)).not.toBeInTheDocument());
+  });
+
   it("only fetches the active tab's data, gating other tabs", async () => {
     membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
 

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -253,6 +253,20 @@ describe("RepoDetailPage", () => {
     expect(await screen.findByText(/no github app installation found/i)).toBeInTheDocument();
   });
 
+  it("retries the security status request when Retry is clicked after an error", async () => {
+    reposSecurityMock.mockRejectedValueOnce(new Error("No GitHub App installation found"));
+    reposSecurityMock.mockResolvedValueOnce({ branch_protection: "protected", secret_scanning: "enabled" });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /security/i }));
+
+    await screen.findByText(/no github app installation found/i);
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByText("Protected")).toBeInTheDocument());
+    expect(reposSecurityMock).toHaveBeenCalledTimes(2);
+  });
+
   it("renders the Overview stats grid (stars, forks, watchers, default branch, open issues, latest release)", async () => {
     reposStatsMock.mockResolvedValue({
       repository: "acme/demo",

--- a/apps/ui/tests/lib/repo-segment.test.ts
+++ b/apps/ui/tests/lib/repo-segment.test.ts
@@ -11,4 +11,17 @@ describe("repo-segment", () => {
   it("parses valid owner~repo segments", () => {
     expect(parseOwnerRepo("acme~demo")).toEqual({ owner: "acme", repo: "demo" });
   });
+
+  it("accepts hyphens in owner and hyphens/underscores/periods in repo", () => {
+    expect(parseOwnerRepo("my-org~my_repo.name")).toEqual({ owner: "my-org", repo: "my_repo.name" });
+  });
+
+  it("rejects owner/repo values outside GitHub's allowed charset", () => {
+    expect(parseOwnerRepo("acme/evil~demo")).toBeNull();
+    expect(parseOwnerRepo("acme~demo/../etc")).toBeNull();
+    expect(parseOwnerRepo("-leading-hyphen~demo")).toBeNull();
+    expect(parseOwnerRepo("trailing-hyphen-~demo")).toBeNull();
+    expect(parseOwnerRepo("double--hyphen~demo")).toBeNull();
+    expect(parseOwnerRepo("acme~demo?query=1")).toBeNull();
+  });
 });


### PR DESCRIPTION
## What changed

Fixes #226 (4-item polish bundle) and #221 (bundled into the same PR since it's the same file as one of #226's items).

1. **Collaborators page dead-end** (`apps/ui/app/collaborators/page.tsx`) — when a user has org memberships but no `admin` role in any of them, the page now lists which orgs they're a member of instead of a bare "No organization to manage" message, so they don't have to dig through Settings to find out.
2. **"Members without 2FA" ignores active search filter (#221)** (`apps/ui/app/settings/org/[login]/members/page.tsx:100`) — now derives from `filteredMembers` instead of the unfiltered roster, so it can't disagree with what's visibly in the table.
3. **Roster search/role-filter latency mismatch** (same file) — added a distinct "Updating…" indicator for role-filter refetches (server-side, part of the TanStack Query key) vs. the client-side search filter. Also switched the query to `placeholderData: keepPreviousData` so a role change no longer flashes an empty table while refetching — this ended up being the more correct fix for the underlying "looks like one filter bar, behaves with different latency" complaint than just adding a spinner would have been.
4. **`parseOwnerRepo` has no charset validation** (`apps/ui/lib/repo-segment.ts`) — added GitHub's actual allowed owner/repo charset validation (previously only checked for a single `~` separator) as defense-in-depth before the value reaches `api.repos.stats(...)`.
5. **Security tab has no retry-on-error affordance** (`apps/ui/app/repos/[repo]/page.tsx`) — added a Retry action reusing the existing `SectionError` component, extracted from `apps/ui/app/settings/page.tsx` (where it was a local, unexported function) into `apps/ui/components/section-error.tsx` so both pages can share it, instead of duplicating it.

## Test plan

- [x] `apps/ui/tests/lib/repo-segment.test.ts` — new tests for valid/invalid charset segments.
- [x] `apps/ui/tests/components/collaborators-page.test.tsx` — updated for the new non-admin-memberships listing; added a case for the truly-empty-memberships generic message.
- [x] `apps/ui/tests/components/github-roster.test.tsx` — new tests: 2FA count follows search filter; "Updating…" shows during a role-filter refetch and clears after.
- [x] `apps/ui/tests/components/repo-detail-page.test.tsx` — new test: clicking Retry on a failed security fetch re-fetches and renders the result.
- [x] `bun run test` (touched files) — 58 passed.
- [x] `bun run typecheck` / `bun run lint` — pass.