### PR TITLE
fix(ui): scope the 401-triggered logout to non-public routes

### DIFF
--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useRouter, usePathname } from "next/navigation"
 import { X } from "@phosphor-icons/react"
 import { useAuth } from "@/lib/auth-context"
@@ -39,9 +39,20 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     }
   }, [isLoading, user, isPublic, router])
 
-  // Listen for 401 events from the API client
+  // Listen for 401 events from the API client. A ref (not a useEffect dependency) tracks
+  // the current isPublic so the listener reads it fresh on every event without needing to
+  // re-subscribe on every pathname change.
+  const isPublicRef = useRef(isPublic)
+  useEffect(() => {
+    isPublicRef.current = isPublic
+  }, [isPublic])
+
   useEffect(() => {
     function handle401() {
+      // A stale/garbage token from a previous session can still get attached to a
+      // best-effort call on a public route (e.g. an invite preview) -- that must not
+      // force-log-out or redirect someone who was never "logged in" on this page.
+      if (isPublicRef.current) return
       logout()
       router.replace("/login")
     }

--- a/apps/ui/tests/components/auth-guard.test.tsx
+++ b/apps/ui/tests/components/auth-guard.test.tsx
@@ -1,11 +1,12 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const replace = vi.fn();
+let mockPathname = "/repos";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace }),
-  usePathname: () => "/repos",
+  usePathname: () => mockPathname,
 }));
 
 import { AuthGuard } from "@/components/auth-guard";
@@ -43,6 +44,7 @@ describe("AuthGuard clevis:unauthorized handling", () => {
   beforeEach(() => {
     localStorage.clear();
     replace.mockClear();
+    mockPathname = "/repos";
     localStorage.setItem(TOKEN_KEY, makeJwt(1, "user@example.com"));
 
     vi.stubGlobal(
@@ -66,6 +68,7 @@ describe("AuthGuard clevis:unauthorized handling", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -94,16 +97,51 @@ describe("AuthGuard clevis:unauthorized handling", () => {
 
     expect(replace).toHaveBeenCalledWith("/login");
   });
+
+  it("does not log out or redirect on a clevis:unauthorized event while on a public route", async () => {
+    // e.g. a stale token from a previous session sitting in localStorage, attached to a
+    // best-effort call (like an invite preview) that happens to 401 -- must not force-log-out
+    // someone merely viewing a public page.
+    mockPathname = "/invite/abc123";
+
+    render(
+      <AuthProvider>
+        <AuthGuard>
+          <div>invite preview</div>
+        </AuthGuard>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("invite preview")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("clevis:unauthorized"));
+    });
+
+    // Give any (incorrect) async logout/redirect a chance to have fired before asserting
+    // it didn't -- avoids a false-pass from asserting too early.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(localStorage.getItem(TOKEN_KEY)).not.toBeNull();
+    expect(replace).not.toHaveBeenCalledWith("/login");
+    expect(screen.getByText("invite preview")).toBeInTheDocument();
+  });
 });
 
 describe("AuthGuard authUnconfirmed banner", () => {
   beforeEach(() => {
     localStorage.clear();
     replace.mockClear();
+    mockPathname = "/repos";
     localStorage.setItem(TOKEN_KEY, makeJwt(1, "user@example.com"));
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -162,6 +200,7 @@ describe("AuthGuard pending invitations banner", () => {
   beforeEach(() => {
     localStorage.clear();
     replace.mockClear();
+    mockPathname = "/repos";
     localStorage.setItem(TOKEN_KEY, makeJwt(1, "user@example.com"));
 
     vi.stubGlobal(
@@ -179,6 +218,7 @@ describe("AuthGuard pending invitations banner", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## What changed

Fixes #223. `apps/ui/lib/api/client.ts`'s `handleResponse` and `del` both dispatch a global `clevis:unauthorized` event on **any** 401 response, with no check for whether the current call is expected to be unauthenticated — this includes calls like `api.invitations.preview()` used on the public `/invite/[token]` page. `AuthGuard`'s `handle401` listener always called `logout()` + redirected to `/login` on that event, ignoring `PUBLIC_ROUTE_PREFIXES`.

## Why

A visitor could have a stale/garbage token sitting in `localStorage` from a previous session (e.g. after a password reset invalidated `token_version` server-side) without being actively "logged in" from the UI's perspective. If they open a public invite link and the preview call attaches that stale token and the backend ever returns 401 for it, the client would force-clear state and fire a global logout/redirect — on a page `AuthGuard` otherwise treats as public.

## Fix

Scoped the fix to the one listener in `apps/ui/components/auth-guard.tsx` rather than auditing every public-route call site for whether it happens to attach a token. A `useRef` tracks the current `isPublic` value so `handle401` reads it fresh on every event without needing to re-subscribe the `window` listener on every pathname change (which would happen if `isPublic` were added directly to the effect's dependency array).

## Also fixed: a pre-existing test-infra gap this PR's new test exposed

`apps/ui/tests/components/auth-guard.test.tsx`'s `afterEach` blocks never called testing-library's `cleanup()`. This repo's vitest config doesn't enable `globals: true`, so RTL's automatic cleanup-on-`afterEach` never registers — every other test file in this suite (`app-sidebar.test.tsx`, `repos-page.test.tsx`, etc.) calls `cleanup()` explicitly, but this one file was missing it. It happened to not matter before since no two tests in the file rendered overlapping visible text; adding a second test to the same `describe` block for this fix surfaced it as a duplicate-element query error. Added `cleanup()` to all three `afterEach` blocks, matching the established pattern.

## Test plan

- [x] New test in `auth-guard.test.tsx`: a `clevis:unauthorized` event while on a public route (`/invite/abc123`) does not clear the token or redirect.
- [x] Existing test (protected route) still passes: the event still logs out and redirects as before.
- [x] `bun run test` — 259 passed, 1 pre-existing unrelated flaky failure in `layout.test.tsx` (confirmed passes in isolation, same as noted on PR #235).
- [x] `pytest -q` — 471 passed (UI-only change, backend unaffected).
- [x] `bun run typecheck` / `bun run lint` — pass.