### PR TITLE
fix(auth): concurrent /auth/register or /auth/setup calls can raise unhandled IntegrityError

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -142,8 +142,10 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
     # count()==0 check before either commits -- unlike /auth/register's email race, there's
     # no unique-constraint collision to catch this (the two rows don't share a column
     # value), so it would otherwise silently create two workspace admins. The advisory
-    # lock serializes the whole check-then-insert critical section; it's released
-    # automatically when this transaction commits or rolls back.
+    # lock serializes the whole check-then-insert critical section; it's transaction-scoped,
+    # so it's released whenever this transaction ends -- an explicit commit/rollback below,
+    # or (on the early-409 path, which does neither) get_db()'s finally: db.close(), which
+    # implicitly rolls back and returns the connection to the pool at the end of the request.
     db.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _SETUP_LOCK_KEY})
     if db.query(User).count() > 0:
         raise HTTPException(status_code=409, detail="Setup already complete")

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -21,6 +21,8 @@ import logging
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, ConfigDict, EmailStr
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.app_config import get_config
@@ -33,6 +35,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MIN_PASSWORD_LEN = 12
+
+# Arbitrary constant identifying the /auth/setup critical section for pg_advisory_xact_lock
+# (see setup()). Any int works; this one has no other significance.
+_SETUP_LOCK_KEY = 727100
 
 # Fixed hash checked when no real user/password_hash exists, so a login attempt for a
 # nonexistent email still pays the same bcrypt cost as a real one -- otherwise response
@@ -132,6 +138,13 @@ def setup_required(db: Session = Depends(get_db)):
 @router.post("/setup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 def setup(body: SetupRequest, db: Session = Depends(get_db)):
     """First-run only. Returns 409 if any user already exists."""
+    # Two concurrent /auth/setup calls with *different* emails can both pass the
+    # count()==0 check before either commits -- unlike /auth/register's email race, there's
+    # no unique-constraint collision to catch this (the two rows don't share a column
+    # value), so it would otherwise silently create two workspace admins. The advisory
+    # lock serializes the whole check-then-insert critical section; it's released
+    # automatically when this transaction commits or rolls back.
+    db.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _SETUP_LOCK_KEY})
     if db.query(User).count() > 0:
         raise HTTPException(status_code=409, detail="Setup already complete")
     if len(body.password) < _MIN_PASSWORD_LEN:
@@ -146,7 +159,11 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
         is_workspace_admin=True,
     )
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Setup already complete") from None
     db.refresh(user)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
@@ -173,7 +190,14 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         is_workspace_admin=False,
     )
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent /auth/register for the same email -- both passed
+        # the existence check above before either committed. users.email is unique, so the
+        # second commit raises here instead of racing to a raw 500.
+        db.rollback()
+        raise HTTPException(status_code=409, detail="An account with this email already exists") from None
     db.refresh(user)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -6,12 +6,15 @@ import bcrypt
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.orm import Query
 
 from src.core.auth import UserOut, require_auth, require_workspace_admin
 from src.core.db import get_db
 from src.core.rate_limit import _account_buckets as _account_rate_limit_buckets
 from src.core.rate_limit import _buckets as _rate_limit_buckets
 from src.repositories import invitation_repo, org_repo
+from src.routers.auth import _SETUP_LOCK_KEY
 from src.routers.auth import router as auth_router
 from src.routers.config import router as config_router
 
@@ -88,6 +91,35 @@ def test_setup_rejects_duplicate(auth_client):
     assert resp.status_code == 409
 
 
+def test_setup_advisory_lock_serializes_concurrent_holders(_engine):
+    # Regression test for issue #218: two concurrent /auth/setup calls with *different*
+    # emails both pass the count()==0 check before either commits, and (unlike the
+    # register-email race) there's no unique-constraint collision to catch it -- only a
+    # lock can. Verifies the lock primitive itself: a second connection can't acquire the
+    # same key while the first transaction holds it, and can once the first releases it.
+    with _engine.connect() as conn1, _engine.connect() as conn2:
+        conn1.begin()
+        conn2.begin()
+        try:
+            got1 = conn1.execute(
+                text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": _SETUP_LOCK_KEY}
+            ).scalar()
+            got2 = conn2.execute(
+                text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": _SETUP_LOCK_KEY}
+            ).scalar()
+            assert got1 is True
+            assert got2 is False
+
+            conn1.commit()  # releases conn1's advisory lock
+
+            got2_retry = conn2.execute(
+                text("SELECT pg_try_advisory_xact_lock(:key)"), {"key": _SETUP_LOCK_KEY}
+            ).scalar()
+            assert got2_retry is True
+        finally:
+            conn2.rollback()
+
+
 # register
 
 def test_register_creates_non_owner(auth_client):
@@ -123,6 +155,30 @@ def test_register_rejects_duplicate_email(auth_client):
         "/auth/register", json={"email": "dupe@example.com", "password": "supersecret1234"}
     )
     assert resp.status_code == 409
+
+
+def test_register_concurrent_same_email_returns_409_not_500(auth_client, db):
+    # Regression test for issue #218: simulates two near-simultaneous /auth/register calls
+    # for the same email, same pattern as test_org_repo.py's concurrent-insert-race test --
+    # a row for this email is already committed (the "other request" that won the race),
+    # then the existence check is patched to fake a miss so this call proceeds to the real
+    # insert, which must collide on the genuine users.email unique constraint and return a
+    # clean 409 instead of an unhandled 500.
+    _setup_owner(auth_client, email="owner@example.com")
+    from src.core.db import User
+
+    db.add(User(email="race@example.com", name=None, password_hash="x", is_workspace_admin=False))
+    db.commit()
+
+    def racy_first(self):
+        return None
+
+    with patch.object(Query, "first", racy_first):
+        resp = auth_client.post(
+            "/auth/register", json={"email": "race@example.com", "password": "supersecret1234"}
+        )
+    assert resp.status_code == 409
+    assert db.query(User).filter(User.email == "race@example.com").count() == 1
 
 
 def test_register_disabled_returns_403(auth_client):

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -120,6 +120,27 @@ def test_setup_advisory_lock_serializes_concurrent_holders(_engine):
             conn2.rollback()
 
 
+def test_setup_concurrent_duplicate_email_returns_409_not_500(auth_client, db):
+    # Regression test for issue #218: the try/except around setup()'s db.commit() is a
+    # second line of defense behind the advisory lock (which serializes the count()==0
+    # check but doesn't stop two callers from racing on the *same* email specifically) --
+    # same pattern as test_register_concurrent_same_email_returns_409_not_500: fake the
+    # count() check to a miss so the real insert hits the genuine users.email unique
+    # constraint and returns a clean 409 instead of an unhandled 500.
+    _setup_owner(auth_client, email="owner@example.com")
+    from src.core.db import User
+
+    def racy_count(self):
+        return 0
+
+    with patch.object(Query, "count", racy_count):
+        resp = auth_client.post(
+            "/auth/setup", json={"email": "owner@example.com", "password": "supersecret1234"}
+        )
+    assert resp.status_code == 409
+    assert db.query(User).filter(User.email == "owner@example.com").count() == 1
+
+
 # register
 
 def test_register_creates_non_owner(auth_client):


### PR DESCRIPTION
## What changed — this touches auth-sensitive code (`apps/api/src/routers/auth.py`), flagging per AGENTS.md

Fixes #218. `setup()` and `register()` in `apps/api/src/routers/auth.py` (lines ~132-186) both did check-then-insert without catching `IntegrityError`:

- **`register()`**: checks `db.query(User).filter(User.email == body.email)` then commits — if two requests race with the same email, the second `db.commit()` raised `sqlalchemy.exc.IntegrityError` (the unique constraint on `User.email`), unhandled anywhere, producing a raw 500.
- **`setup()`**: checks `db.query(User).count() > 0` then commits a new admin `User` row — no unique constraint stops two concurrent calls with *different* emails from both passing the count check and both becoming workspace admins.

This is inconsistent with the repo's own established pattern elsewhere (`org_repo.get_or_create`, `org_membership_repo.get_or_create`, `installation_repo.upsert`), which explicitly catch `IntegrityError` around the same class of race window.

## Fix

- **`register()`**: wraps `db.commit()` in `try/except IntegrityError: db.rollback()`, returning a clean 409 — mirrors the existing get-or-create pattern exactly, since `users.email` is genuinely unique and the second commit will collide for real.
- **`setup()`**: this one needed more than just try/except. The two-*different*-emails race has **no column collision** for a unique constraint to catch — both rows would insert successfully. Added a `pg_advisory_xact_lock` around the whole check-then-insert critical section instead: it serializes concurrent `/auth/setup` calls so the second call's `count()` check correctly sees the first call's already-committed row before attempting its own insert. Released automatically at commit/rollback — no schema change, no new dependency (Postgres builtin). Kept the `try/except IntegrityError` too, as defense-in-depth.

## Test plan

- [x] `apps/api/tests/test_auth.py::test_register_concurrent_same_email_returns_409_not_500` — same simulated-race pattern already used in `test_org_repo.py`'s concurrent-insert-race test (patches `Query.first` to fake a miss on the existence check, forcing the real insert into a genuine unique-constraint collision).
- [x] `apps/api/tests/test_auth.py::test_setup_advisory_lock_serializes_concurrent_holders` — directly verifies the lock primitive using two independent DB connections: a second connection can't acquire the same advisory-lock key while the first transaction holds it, and can once it's released.
- [x] `pytest -q` — 484 passed.