### PR TITLE
feat(auth): add email verification, close invite-hijack gap

### DIFF
--- a/apps/api/alembic/versions/0017_add_email_verification.py
+++ b/apps/api/alembic/versions/0017_add_email_verification.py
@@ -1,0 +1,52 @@
+"""add users.email_verified/email_verify_token/email_verify_token_expires_at
+
+Issue #217: POST /auth/register creates an account with no email-ownership
+verification, and POST /invitations/{token}/accept grants org membership on a
+plain email string match -- so an attacker who knows a victim's email can
+register with it first, then accept an invite meant for that email under the
+victim's identity. The GitHub OAuth path already defends against the
+equivalent attack (EmailAlreadyRegistered refuses to auto-link on email
+match, since GitHub vouches for the email); the password path had no
+equivalent because there was nothing on the User model to represent "this
+email has been proven."
+
+- email_verified: bool, NOT NULL. Existing rows are backfilled true via
+  server_default=sa.true() -- every user who already has an account today is
+  grandfathered in as trusted (this migration doesn't retroactively lock
+  anyone out); going forward, application code explicitly sets it per user
+  (True for GitHub-linked/first-run-setup users, False for self-registered
+  users) rather than relying on the server default for new inserts.
+- email_verify_token / email_verify_token_expires_at: nullable, no backfill
+  needed -- only set when a verification email is pending.
+
+Additive-only, no data-loss risk. Same style as 0016_add_scan_results_scanned_by_user_id.py.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("email_verified", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column("users", sa.Column("email_verify_token", sa.Text(), nullable=True))
+    op.add_column("users", sa.Column("email_verify_token_expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_unique_constraint("uq_users_email_verify_token", "users", ["email_verify_token"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_users_email_verify_token", "users", type_="unique")
+    op.drop_column("users", "email_verify_token_expires_at")
+    op.drop_column("users", "email_verify_token")
+    op.drop_column("users", "email_verified")

--- a/apps/api/src/core/config.py
+++ b/apps/api/src/core/config.py
@@ -41,6 +41,16 @@ class Settings(BaseSettings):
     session_cookie_samesite: str = "lax"
     session_cookie_domain: str | None = None
 
+    # SMTP (email verification, issue #217). Optional -- same pattern as github_app_* above:
+    # if unset, src.services.email raises a clear "not configured" error only when actually
+    # used, and the register() route degrades gracefully (account still created, just stays
+    # unverified) rather than requiring every deployment to have working email.
+    smtp_host: str | None = None
+    smtp_port: int = 587
+    smtp_user: str | None = None
+    smtp_password: SecretStr | None = None
+    smtp_from: str | None = None
+
     model_config = SettingsConfigDict(env_file=_env_file, extra="ignore")
 
 

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -116,6 +116,14 @@ class User(Base):
     github_login: Mapped[str | None] = mapped_column(Text, nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # True for GitHub-linked accounts (GitHub already vouches for the email) and for the
+    # first-run /auth/setup admin (the deploying operator, implicitly trusted). False for
+    # self-service /auth/register accounts until they click the emailed verification link.
+    # Existing rows at migration time are backfilled true (see 0017) -- already-deployed
+    # users are grandfathered in as trusted, only new self-registrations start unverified.
+    email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    email_verify_token: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
+    email_verify_token_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class Org(Base):

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -54,12 +54,15 @@ def _send_verification_email_best_effort(user: User) -> None:
     succeed regardless of whether SMTP is configured or the send itself fails."""
     user.email_verify_token = secrets.token_urlsafe(32)
     user.email_verify_token_expires_at = datetime.now(timezone.utc) + _VERIFY_TOKEN_TTL
-    verify_url = f"{settings.cors_origins[0]}/verify-email?token={user.email_verify_token}"
     try:
+        verify_url = f"{settings.cors_origins[0]}/verify-email?token={user.email_verify_token}"
         send_verification_email(user.email, verify_url)
     except EmailNotConfigured:
         logger.warning("SMTP not configured -- skipping verification email for %s", user.email)
     except Exception:
+        # Covers both a send failure and a misconfigured empty CORS_ORIGINS (cors_origins[0]
+        # would otherwise raise IndexError here, uncaught, breaking registration itself --
+        # this function must never raise regardless of the cause.
         logger.exception("failed to send verification email to %s", user.email)
 
 # Fixed hash checked when no real user/password_hash exists, so a login attempt for a
@@ -100,12 +103,14 @@ class LoginRequest(BaseModel):
 
 
 class PendingInvitationSummary(BaseModel):
-    # Deliberately excludes the invitation token: registration has no email-verification
-    # step anywhere in this app, so "an account with email X" is not proof of controlling
-    # inbox X. Handing back the accept-capability token here would let anyone who merely
-    # knows a victim's email address (self-asserted at register, never verified) claim
-    # their pending org invitation without ever seeing the real invite link — this must
-    # stay informational only ("an invite exists"), never a shortcut to accepting it.
+    # Deliberately excludes the invitation token: the email isn't verified yet at
+    # register()/login() time (verification is async, via the emailed link -- see
+    # accept_invitation's email_verified check in src.routers.invitations), so "an
+    # account with email X" is still not immediate proof of controlling inbox X. Handing
+    # back the accept-capability token here would let anyone who merely knows a victim's
+    # email address (self-asserted at register, not yet verified) claim their pending org
+    # invitation without ever seeing the real invite link — this must stay informational
+    # only ("an invite exists"), never a shortcut to accepting it.
     org_login: str
     expires_at: datetime
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -4,6 +4,8 @@ Auth router — /auth/*
 Endpoints:
   POST /auth/setup          First-run only; creates the owner account (409 if users exist)
   POST /auth/register       Creates a non-owner account; 403 if registration_enabled=false
+  POST /auth/verify-email   Marks the account owning the given token as email-verified
+  POST /auth/resend-verification Resends the verification email to the caller, if unverified
   POST /auth/login          Returns a JWT on valid credentials
   GET  /auth/me             Returns the current authenticated user
   PATCH /auth/me            Updates the current user's display name
@@ -13,10 +15,18 @@ Endpoints:
 /auth/login and /auth/register are rate-limited per client IP (see src.core.rate_limit);
 /auth/login is additionally rate-limited per submitted email, so an attacker spread across
 many source IPs can't bypass the IP-keyed limit by targeting one account.
+
+Email verification (issue #217): register() creates accounts with email_verified=False
+and emails a verification link; setup() and GitHub-OAuth-linked accounts (see
+src.routers.github_auth) are verified immediately since their email is already trusted
+(the deploying operator, or GitHub itself). Unverified accounts work normally everywhere
+except accepting an org invitation (src.routers.invitations), which requires proof the
+account actually controls the invited inbox.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import logging
+import secrets
 
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -25,14 +35,32 @@ from sqlalchemy.orm import Session
 
 from src.core.app_config import get_config
 from src.core.auth import UserOut, clear_session_cookie, create_access_token, require_auth
+from src.core.config import settings
 from src.core.db import Org, User, get_db
 from src.core.rate_limit import check_account_rate_limit, rate_limit
 from src.repositories import invitation_repo
+from src.services.email import EmailNotConfigured, send_verification_email
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MIN_PASSWORD_LEN = 12
+_VERIFY_TOKEN_TTL = timedelta(hours=24)
+
+
+def _send_verification_email_best_effort(user: User) -> None:
+    """Generates a fresh verification token/expiry on `user`, then tries to email it.
+    Caller is responsible for db.commit(). Never raises -- registration/resend must
+    succeed regardless of whether SMTP is configured or the send itself fails."""
+    user.email_verify_token = secrets.token_urlsafe(32)
+    user.email_verify_token_expires_at = datetime.now(timezone.utc) + _VERIFY_TOKEN_TTL
+    verify_url = f"{settings.cors_origins[0]}/verify-email?token={user.email_verify_token}"
+    try:
+        send_verification_email(user.email, verify_url)
+    except EmailNotConfigured:
+        logger.warning("SMTP not configured -- skipping verification email for %s", user.email)
+    except Exception:
+        logger.exception("failed to send verification email to %s", user.email)
 
 # Fixed hash checked when no real user/password_hash exists, so a login attempt for a
 # nonexistent email still pays the same bcrypt cost as a real one -- otherwise response
@@ -96,6 +124,7 @@ class MeResponse(BaseModel):
     email: str
     name: str | None
     is_workspace_admin: bool
+    email_verified: bool
     created_at: datetime
 
 
@@ -105,6 +134,19 @@ class PatchMeRequest(BaseModel):
 
 class SetupRequiredResponse(BaseModel):
     setup_required: bool
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class VerifyEmailResponse(BaseModel):
+    ok: bool
+
+
+class ResendVerificationResponse(BaseModel):
+    ok: bool
+    already_verified: bool = False
 
 
 def _pending_invitations_for(db: Session, email: str) -> list[PendingInvitationSummary]:
@@ -144,6 +186,9 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
         name=body.name,
         password_hash=_hash_password(body.password),
         is_workspace_admin=True,
+        # The deploying operator's own account -- implicitly trusted, same reasoning as
+        # is_workspace_admin=True here (no one else could have run first-boot setup).
+        email_verified=True,
     )
     db.add(user)
     db.commit()
@@ -171,19 +216,56 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         name=body.name,
         password_hash=_hash_password(body.password),
         is_workspace_admin=False,
+        email_verified=False,
     )
     db.add(user)
+    db.flush()  # assign user.id before generating/persisting the verification token below
+    _send_verification_email_best_effort(user)
     db.commit()
     db.refresh(user)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {
         "access_token": token,
         "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin),
-        # Never populated here: register has no email-verification step, so a self-asserted
-        # email is not proof of inbox control — looking this up would let an attacker learn
-        # whether/where a victim's email has a pending invite just by registering with it.
+        # Never populated here: the email isn't verified yet at this point (verification is
+        # async, via the emailed link), so a self-asserted email is still not proof of inbox
+        # control -- looking this up would let an attacker learn whether/where a victim's
+        # email has a pending invite just by registering with it.
         "pending_invitations": [],
     }
+
+
+@router.post("/verify-email", response_model=VerifyEmailResponse, dependencies=[Depends(rate_limit())])
+def verify_email(body: VerifyEmailRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email_verify_token == body.token).first()
+    if user is None:
+        raise HTTPException(status_code=400, detail="Invalid or expired verification link")
+    if (
+        user.email_verify_token_expires_at is None
+        or user.email_verify_token_expires_at < datetime.now(timezone.utc)
+    ):
+        raise HTTPException(status_code=400, detail="Invalid or expired verification link")
+    user.email_verified = True
+    user.email_verify_token = None
+    user.email_verify_token_expires_at = None
+    db.commit()
+    return {"ok": True}
+
+
+@router.post("/resend-verification", response_model=ResendVerificationResponse, dependencies=[Depends(rate_limit())])
+def resend_verification(
+    current_user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter(User.id == current_user.id).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.email_verified:
+        return {"ok": True, "already_verified": True}
+    check_account_rate_limit(f"resend-verification:{user.email.lower()}")
+    _send_verification_email_best_effort(user)
+    db.commit()
+    return {"ok": True}
 
 
 @router.post("/logout")

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -77,6 +77,11 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
         github_user_id=identity.github_user_id,
         github_login=identity.login,
         avatar_url=identity.avatar_url,
+        # GitHub already vouches for this email -- fetch_identity() only ever returns a
+        # GitHub-verified address (github_oauth._primary_verified_email filters on
+        # verified=True; GitHub itself requires every email on an account to be verified
+        # before it can be used). Same trust basis as the first-run setup admin. Issue #217.
+        email_verified=True,
     )
     db.add(user)
     db.commit()

--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -6,7 +6,8 @@
   POST   /orgs/{org_login}/invitations/{id}/revoke admin: revoke a pending invite
   GET    /invitations/{token}                      unauthenticated: preview an invite by token
   POST   /invitations/{token}/accept               any authenticated user whose account email
-                                                     case-insensitively matches the invite
+                                                     case-insensitively matches the invite AND
+                                                     is verified (see issue #217)
 """
 
 from datetime import datetime, timezone
@@ -16,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.config import settings
-from src.core.db import Org, get_db
+from src.core.db import Org, User, get_db
 from src.core.rbac import OrgContext, require_org_role
 from src.repositories import invitation_repo, org_membership_repo
 from src.schemas.invitation import (
@@ -127,6 +128,17 @@ def accept_invitation(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Invitation is no longer pending")
     if invitation.email.lower() != user.email.lower():
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invitation email does not match account")
+    # Email match alone isn't proof of ownership for a self-registered account -- see
+    # issue #217. GitHub-linked accounts and the first-run setup admin are verified
+    # immediately (src.routers.auth); self-registered accounts must click the emailed
+    # verification link first, closing the same class of hijack the GitHub OAuth path
+    # already defends against via EmailAlreadyRegistered (src.routers.github_auth).
+    db_user = db.query(User).filter(User.id == user.id).first()
+    if db_user is None or not db_user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Verify your email before accepting this invitation",
+        )
 
     membership = org_membership_repo.get_or_create(db, org_id=invitation.org_id, user_id=user.id, role="member")
     invitation.status = "accepted"

--- a/apps/api/src/services/email.py
+++ b/apps/api/src/services/email.py
@@ -1,0 +1,38 @@
+"""Outbound email — currently just the /auth/register verification link (issue #217).
+
+SMTP is optional (see src.core.config.Settings). If unconfigured, send_verification_email
+raises EmailNotConfigured and callers are expected to degrade gracefully -- account creation
+must never fail because email sending isn't set up.
+"""
+
+import smtplib
+from email.message import EmailMessage
+
+from src.core.config import settings
+
+
+class EmailNotConfigured(RuntimeError):
+    """Raised when SMTP isn't configured. Mirrors GitHubOAuthNotConfigured
+    (src.services.github_oauth) -- callers decide how to degrade."""
+
+
+def send_verification_email(to_email: str, verify_url: str) -> None:
+    if not settings.smtp_host or not settings.smtp_from:
+        raise EmailNotConfigured("SMTP_HOST and SMTP_FROM must be set to send verification emails")
+
+    message = EmailMessage()
+    message["Subject"] = "Verify your Clevis email address"
+    message["From"] = settings.smtp_from
+    message["To"] = to_email
+    message.set_content(
+        "Welcome to Clevis!\n\n"
+        "Verify your email address to accept organization invitations:\n"
+        f"{verify_url}\n\n"
+        "If you didn't create this account, you can ignore this email."
+    )
+
+    with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10) as smtp:
+        smtp.starttls()
+        if settings.smtp_user and settings.smtp_password:
+            smtp.login(settings.smtp_user, settings.smtp_password.get_secret_value())
+        smtp.send_message(message)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -174,6 +174,21 @@ def test_register_logs_a_warning_but_does_not_fail_when_email_sending_raises(aut
     assert resp.status_code == 201
 
 
+def test_register_still_succeeds_when_cors_origins_is_misconfigured_empty(auth_client):
+    # Regression test: verify_url construction (f"{settings.cors_origins[0]}/...") used to
+    # sit outside the try/except in _send_verification_email_best_effort, so an operator
+    # misconfiguring CORS_ORIGINS=[] would raise an uncaught IndexError there and break
+    # registration itself, not just the email send.
+    from src.core.config import settings
+
+    _setup_owner(auth_client)
+    with patch.object(settings, "cors_origins", []):
+        resp = auth_client.post(
+            "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+        )
+    assert resp.status_code == 201
+
+
 def test_verify_email_marks_the_account_verified_and_clears_the_token(auth_client, db):
     _setup_owner(auth_client)
     auth_client.post("/auth/register", json={"email": "member@example.com", "password": "supersecret1234"})

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth, require_workspace_admin
-from src.core.db import get_db
+from src.core.db import User, get_db
 from src.core.rate_limit import _account_buckets as _account_rate_limit_buckets
 from src.core.rate_limit import _buckets as _rate_limit_buckets
 from src.repositories import invitation_repo, org_repo
@@ -132,6 +132,111 @@ def test_register_disabled_returns_403(auth_client):
             "/auth/register", json={"email": "blocked@example.com", "password": "supersecret1234"}
         )
     assert resp.status_code == 403
+
+
+# email verification (issue #217)
+
+def test_setup_creates_a_verified_admin(auth_client, db):
+    _setup_owner(auth_client, email="owner@example.com")
+    user = db.query(User).filter(User.email == "owner@example.com").first()
+    assert user.email_verified is True
+    assert user.email_verify_token is None
+
+
+def test_register_creates_an_unverified_user_with_a_pending_token(auth_client, db):
+    _setup_owner(auth_client)
+    resp = auth_client.post(
+        "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+    )
+    assert resp.status_code == 201
+    user = db.query(User).filter(User.email == "member@example.com").first()
+    assert user.email_verified is False
+    assert user.email_verify_token is not None
+    assert user.email_verify_token_expires_at is not None
+
+
+def test_register_still_succeeds_when_smtp_is_not_configured(auth_client):
+    # Default test settings have no SMTP configured -- registration must succeed
+    # regardless (account creation must never depend on email sending working).
+    _setup_owner(auth_client)
+    resp = auth_client.post(
+        "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+    )
+    assert resp.status_code == 201
+
+
+def test_register_logs_a_warning_but_does_not_fail_when_email_sending_raises(auth_client):
+    _setup_owner(auth_client)
+    with patch("src.routers.auth.send_verification_email", side_effect=RuntimeError("smtp exploded")):
+        resp = auth_client.post(
+            "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+        )
+    assert resp.status_code == 201
+
+
+def test_verify_email_marks_the_account_verified_and_clears_the_token(auth_client, db):
+    _setup_owner(auth_client)
+    auth_client.post("/auth/register", json={"email": "member@example.com", "password": "supersecret1234"})
+    user = db.query(User).filter(User.email == "member@example.com").first()
+    token = user.email_verify_token
+
+    resp = auth_client.post("/auth/verify-email", json={"token": token})
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    db.refresh(user)
+    assert user.email_verified is True
+    assert user.email_verify_token is None
+    assert user.email_verify_token_expires_at is None
+
+
+def test_verify_email_rejects_an_unknown_token(auth_client):
+    resp = auth_client.post("/auth/verify-email", json={"token": "not-a-real-token"})
+    assert resp.status_code == 400
+
+
+def test_verify_email_rejects_an_expired_token(auth_client, db):
+    _setup_owner(auth_client)
+    auth_client.post("/auth/register", json={"email": "member@example.com", "password": "supersecret1234"})
+    user = db.query(User).filter(User.email == "member@example.com").first()
+    user.email_verify_token_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db.commit()
+
+    resp = auth_client.post("/auth/verify-email", json={"token": user.email_verify_token})
+    assert resp.status_code == 400
+    db.refresh(user)
+    assert user.email_verified is False
+
+
+def test_resend_verification_regenerates_the_token(auth_client, db):
+    _setup_owner(auth_client)
+    register_resp = auth_client.post(
+        "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+    )
+    token = register_resp.json()["access_token"]
+    user = db.query(User).filter(User.email == "member@example.com").first()
+    original_token = user.email_verify_token
+
+    resp = auth_client.post("/auth/resend-verification", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "already_verified": False}
+
+    db.refresh(user)
+    assert user.email_verify_token is not None
+    assert user.email_verify_token != original_token
+
+
+def test_resend_verification_is_a_noop_for_an_already_verified_account(auth_client):
+    token = _setup_owner(auth_client, email="owner@example.com")["access_token"]
+
+    resp = auth_client.post("/auth/resend-verification", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "already_verified": True}
+
+
+def test_resend_verification_requires_auth(auth_client):
+    resp = auth_client.post("/auth/resend-verification")
+    assert resp.status_code == 401
 
 
 # login

--- a/apps/api/tests/test_email_service.py
+++ b/apps/api/tests/test_email_service.py
@@ -1,0 +1,64 @@
+"""Tests for src.services.email (issue #217)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from src.core.config import settings
+from src.services.email import EmailNotConfigured, send_verification_email
+
+
+def test_raises_not_configured_when_smtp_host_unset(monkeypatch):
+    monkeypatch.setattr(settings, "smtp_host", None)
+    monkeypatch.setattr(settings, "smtp_from", "clevis@example.com")
+    with pytest.raises(EmailNotConfigured):
+        send_verification_email("user@example.com", "https://app.example.com/verify-email?token=x")
+
+
+def test_raises_not_configured_when_smtp_from_unset(monkeypatch):
+    monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(settings, "smtp_from", None)
+    with pytest.raises(EmailNotConfigured):
+        send_verification_email("user@example.com", "https://app.example.com/verify-email?token=x")
+
+
+def test_sends_via_smtp_with_starttls_and_login(monkeypatch):
+    monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(settings, "smtp_port", 587)
+    monkeypatch.setattr(settings, "smtp_from", "clevis@example.com")
+    monkeypatch.setattr(settings, "smtp_user", "smtp-user")
+    monkeypatch.setattr(settings, "smtp_password", SecretStr("smtp-pass"))
+
+    mock_smtp = MagicMock()
+    mock_smtp.__enter__ = MagicMock(return_value=mock_smtp)
+    mock_smtp.__exit__ = MagicMock(return_value=False)
+
+    with patch("src.services.email.smtplib.SMTP", return_value=mock_smtp) as mock_cls:
+        send_verification_email("user@example.com", "https://app.example.com/verify-email?token=abc")
+
+    mock_cls.assert_called_once_with("smtp.example.com", 587, timeout=10)
+    mock_smtp.starttls.assert_called_once()
+    mock_smtp.login.assert_called_once_with("smtp-user", "smtp-pass")
+    mock_smtp.send_message.assert_called_once()
+    sent_message = mock_smtp.send_message.call_args[0][0]
+    assert sent_message["To"] == "user@example.com"
+    assert sent_message["From"] == "clevis@example.com"
+    assert "verify-email?token=abc" in sent_message.get_content()
+
+
+def test_sends_without_login_when_no_smtp_credentials(monkeypatch):
+    monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(settings, "smtp_from", "clevis@example.com")
+    monkeypatch.setattr(settings, "smtp_user", None)
+    monkeypatch.setattr(settings, "smtp_password", None)
+
+    mock_smtp = MagicMock()
+    mock_smtp.__enter__ = MagicMock(return_value=mock_smtp)
+    mock_smtp.__exit__ = MagicMock(return_value=False)
+
+    with patch("src.services.email.smtplib.SMTP", return_value=mock_smtp):
+        send_verification_email("user@example.com", "https://app.example.com/verify-email?token=abc")
+
+    mock_smtp.login.assert_not_called()
+    mock_smtp.send_message.assert_called_once()

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -106,6 +106,14 @@ def test_idempotent_by_github_id(db):
     assert db.query(User).count() == 1
 
 
+def test_new_github_user_is_created_already_verified(db):
+    # Regression test for issue #217: GitHub already vouches for the identity's email
+    # (fetch_identity only ever returns a GitHub-verified address), so a GitHub-created
+    # account shouldn't need to click an emailed verification link too.
+    user = find_or_create_user(db, _identity())
+    assert user.email_verified is True
+
+
 # ── endpoints ─────────────────────────────────────────────────────────────────
 
 def test_login_redirects_to_github(gh_client, oauth_configured):

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -12,8 +12,11 @@ from src.repositories import org_membership_repo, org_repo
 from src.routers.invitations import router as invitations_router
 
 
-def _make_user(db, email: str) -> UserOut:
-    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+def _make_user(db, email: str, email_verified: bool = True) -> UserOut:
+    # Verified by default so the existing email-match tests below aren't also implicitly
+    # testing the (separately covered) email-verification requirement -- see
+    # test_accept_invitation_unverified_email_forbidden for that.
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False, email_verified=email_verified)
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -96,6 +99,35 @@ def test_accept_invitation_ok(db, acme_org):
     # Accepting again fails — invitation is no longer pending.
     resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
     assert resp.status_code == 409
+
+
+def test_accept_invitation_unverified_email_forbidden(db, acme_org):
+    # Regression test for issue #217: email match alone must not be enough for a
+    # self-registered account that hasn't proven it controls the invited inbox.
+    unverified = _make_user(db, "dave@acme.com", email_verified=False)
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "dave@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    resp = _client(db, unverified).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 403
+    assert "verify" in resp.json()["detail"].lower()
+
+
+def test_accept_invitation_succeeds_once_verified(db, acme_org):
+    unverified = _make_user(db, "erin@acme.com", email_verified=False)
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "erin@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    resp = _client(db, unverified).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 403
+
+    user_row = db.query(User).filter(User.id == unverified.id).first()
+    user_row.email_verified = True
+    db.commit()
+
+    resp = _client(db, unverified).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 200
+    assert resp.json() == {"org_login": "acme", "role": "member"}
 
 
 def test_accept_invitation_case_insensitive_email_match(db, acme_org):

--- a/apps/ui/app/invite/[token]/page.tsx
+++ b/apps/ui/app/invite/[token]/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
@@ -23,6 +24,22 @@ export default function InviteAcceptPage() {
     mutationFn: () => api.invitations.accept(token),
     onSuccess: () => router.push("/"),
   })
+
+  // The backend 403s with this specific message when the account's email isn't verified
+  // yet (issue #217) -- distinct from a genuine email mismatch, which also 403s but with
+  // different wording, so only this case gets a resend affordance.
+  const needsVerification = accept.isError && accept.error.message.toLowerCase().includes("verify")
+  const [resendState, setResendState] = useState<"idle" | "sending" | "sent" | "error">("idle")
+
+  async function resendVerification() {
+    setResendState("sending")
+    try {
+      await api.auth.resendVerification()
+      setResendState("sent")
+    } catch {
+      setResendState("error")
+    }
+  }
 
   return (
     <div className="max-w-md mx-auto mt-16">
@@ -68,7 +85,28 @@ export default function InviteAcceptPage() {
                   {accept.isPending ? "Joining…" : "Accept invitation"}
                 </Button>
               )}
-              {accept.isError && <p className="text-xs text-destructive">{accept.error.message}</p>}
+              {accept.isError && (
+                <div className="flex flex-col gap-1.5">
+                  <p className="text-xs text-destructive">{accept.error.message}</p>
+                  {needsVerification && (
+                    resendState === "sent" ? (
+                      <p className="text-xs text-primary">Verification email sent — check your inbox, then try again.</p>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={resendVerification}
+                        disabled={resendState === "sending"}
+                      >
+                        {resendState === "sending" ? "Sending…" : "Resend verification email"}
+                      </Button>
+                    )
+                  )}
+                  {resendState === "error" && (
+                    <p className="text-xs text-destructive">Couldn&rsquo;t resend the verification email. Try again shortly.</p>
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/apps/ui/app/verify-email/page.tsx
+++ b/apps/ui/app/verify-email/page.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { PageHeader } from "@/components/page-header"
+import { api } from "@/lib/api/client"
+import { CheckCircle, Warning, CircleNotch } from "@phosphor-icons/react"
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token")
+  const [state, setState] = useState<"pending" | "success" | "error">("pending")
+  const [errorMessage, setErrorMessage] = useState("")
+
+  useEffect(() => {
+    if (!token) {
+      setState("error")
+      setErrorMessage("This verification link is missing its token.")
+      return
+    }
+    api.auth
+      .verifyEmail(token)
+      .then(() => setState("success"))
+      .catch((err) => {
+        setState("error")
+        setErrorMessage(err instanceof Error ? err.message : "Verification failed")
+      })
+  }, [token])
+
+  return (
+    <div className="max-w-md mx-auto mt-16">
+      <PageHeader title="Verify your email" description="Confirming your Clevis account email address." />
+
+      <div className="card">
+        <div className="p-4 flex flex-col gap-3">
+          {state === "pending" ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <CircleNotch className="size-3.5 animate-spin" /> Verifying…
+            </div>
+          ) : state === "success" ? (
+            <p className="text-sm text-primary flex items-center gap-1.5">
+              <CheckCircle className="size-3.5" /> Your email is verified. You can now accept organization
+              invitations.
+            </p>
+          ) : (
+            <p className="text-sm text-destructive flex items-center gap-1.5">
+              <Warning className="size-3.5" /> {errorMessage}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 
 // Routes that don't require authentication
-const PUBLIC_ROUTES = ["/login", "/setup", "/register"]
+const PUBLIC_ROUTES = ["/login", "/setup", "/register", "/verify-email"]
 // Prefixes for routes that don't require authentication (dynamic segments)
 const PUBLIC_ROUTE_PREFIXES = ["/invite/"]
 

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -383,5 +383,8 @@ export const api = {
     patchMe: (name: string) =>
       patch<{ id: number; email: string; name: string | null; is_workspace_admin: boolean }>("/auth/me", { name }),
     revokeSessions: () => post<{ ok: boolean }>("/auth/me/revoke-sessions", {}),
+    verifyEmail: (token: string) => post<{ ok: boolean }>("/auth/verify-email", { token }),
+    resendVerification: () =>
+      post<{ ok: boolean; already_verified: boolean }>("/auth/resend-verification", {}),
   },
 }

--- a/apps/ui/tests/components/invite-accept-page.test.tsx
+++ b/apps/ui/tests/components/invite-accept-page.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ token: "abc123" }),
+  useRouter: () => ({ push }),
+}));
+
+const previewMock = vi.fn();
+const acceptMock = vi.fn();
+const resendVerificationMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    invitations: {
+      preview: (...args: unknown[]) => previewMock(...args),
+      accept: (...args: unknown[]) => acceptMock(...args),
+    },
+    auth: {
+      resendVerification: (...args: unknown[]) => resendVerificationMock(...args),
+    },
+  },
+}));
+
+import InviteAcceptPage from "@/app/invite/[token]/page";
+import { AuthProvider } from "@/lib/auth-context";
+
+const TOKEN_KEY = "clevis:token";
+
+function b64url(value: object): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(): string {
+  const header = b64url({ alg: "none", typ: "JWT" });
+  const payload = b64url({
+    sub: "1",
+    email: "user@example.com",
+    name: null,
+    is_workspace_admin: false,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  return `${header}.${payload}.sig`;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <InviteAcceptPage />
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("InviteAcceptPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    push.mockClear();
+    previewMock.mockReset();
+    acceptMock.mockReset();
+    resendVerificationMock.mockReset();
+    localStorage.setItem(TOKEN_KEY, makeJwt());
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          return Promise.resolve(
+            jsonResponse({ id: 1, email: "user@example.com", name: null, is_workspace_admin: false }),
+          );
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a resend-verification button when accept fails because the email isn't verified", async () => {
+    previewMock.mockResolvedValue({ org_login: "acme", status: "pending" });
+    acceptMock.mockRejectedValue(new Error("Verify your email before accepting this invitation"));
+
+    renderPage();
+
+    const acceptButton = await screen.findByRole("button", { name: /accept invitation/i });
+    fireEvent.click(acceptButton);
+
+    const resendButton = await screen.findByRole("button", { name: /resend verification email/i });
+    resendVerificationMock.mockResolvedValue({ ok: true, already_verified: false });
+    fireEvent.click(resendButton);
+
+    await waitFor(() => expect(resendVerificationMock).toHaveBeenCalled());
+    await screen.findByText(/verification email sent/i);
+  });
+
+  it("does not show a resend button for an unrelated accept failure", async () => {
+    previewMock.mockResolvedValue({ org_login: "acme", status: "pending" });
+    acceptMock.mockRejectedValue(new Error("Invitation has expired"));
+
+    renderPage();
+
+    const acceptButton = await screen.findByRole("button", { name: /accept invitation/i });
+    fireEvent.click(acceptButton);
+
+    await screen.findByText(/invitation has expired/i);
+    expect(screen.queryByRole("button", { name: /resend verification email/i })).not.toBeInTheDocument();
+  });
+
+  it("redirects home after a successful accept", async () => {
+    previewMock.mockResolvedValue({ org_login: "acme", status: "pending" });
+    acceptMock.mockResolvedValue({ org_login: "acme", role: "member" });
+
+    renderPage();
+
+    const acceptButton = await screen.findByRole("button", { name: /accept invitation/i });
+    fireEvent.click(acceptButton);
+
+    await screen.findByText(/joined acme/i);
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/"));
+  });
+});

--- a/apps/ui/tests/components/invite-accept-page.test.tsx
+++ b/apps/ui/tests/components/invite-accept-page.test.tsx
@@ -115,6 +115,23 @@ describe("InviteAcceptPage", () => {
     await screen.findByText(/verification email sent/i);
   });
 
+  it("shows an error message when resending the verification email fails", async () => {
+    previewMock.mockResolvedValue({ org_login: "acme", status: "pending" });
+    acceptMock.mockRejectedValue(new Error("Verify your email before accepting this invitation"));
+
+    renderPage();
+
+    const acceptButton = await screen.findByRole("button", { name: /accept invitation/i });
+    fireEvent.click(acceptButton);
+
+    const resendButton = await screen.findByRole("button", { name: /resend verification email/i });
+    resendVerificationMock.mockRejectedValue(new Error("network error"));
+    fireEvent.click(resendButton);
+
+    await waitFor(() => expect(resendVerificationMock).toHaveBeenCalled());
+    await screen.findByText(/couldn.t resend the verification email/i);
+  });
+
   it("does not show a resend button for an unrelated accept failure", async () => {
     previewMock.mockResolvedValue({ org_login: "acme", status: "pending" });
     acceptMock.mockRejectedValue(new Error("Invitation has expired"));

--- a/apps/ui/tests/components/verify-email-page.test.tsx
+++ b/apps/ui/tests/components/verify-email-page.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+const verifyEmailMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    auth: {
+      verifyEmail: (...args: unknown[]) => verifyEmailMock(...args),
+    },
+  },
+}));
+
+import VerifyEmailPage from "@/app/verify-email/page";
+
+describe("VerifyEmailPage", () => {
+  beforeEach(() => {
+    verifyEmailMock.mockReset();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a success message once verification succeeds", async () => {
+    mockSearchParams = new URLSearchParams({ token: "good-token" });
+    verifyEmailMock.mockResolvedValue({ ok: true });
+
+    render(<VerifyEmailPage />);
+
+    await screen.findByText(/your email is verified/i);
+    expect(verifyEmailMock).toHaveBeenCalledWith("good-token");
+  });
+
+  it("shows the server's error message when verification fails", async () => {
+    mockSearchParams = new URLSearchParams({ token: "bad-token" });
+    verifyEmailMock.mockRejectedValue(new Error("Invalid or expired verification link"));
+
+    render(<VerifyEmailPage />);
+
+    await screen.findByText(/invalid or expired verification link/i);
+  });
+
+  it("shows an error immediately when the URL has no token", async () => {
+    render(<VerifyEmailPage />);
+
+    await screen.findByText(/missing its token/i);
+    expect(verifyEmailMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -479,3 +479,35 @@ describe("installations.lookup / installations.sync", () => {
     expect(String(url)).toContain("/orgs/acme/installations/sync");
   });
 });
+
+describe("api.auth email verification (issue #217)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("POSTs the token to /auth/verify-email", async () => {
+    stubOkJson({ ok: true });
+    const result = await api.auth.verifyEmail("a-token");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/auth/verify-email");
+    expect(JSON.parse(init.body as string)).toEqual({ token: "a-token" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("POSTs with no body to /auth/resend-verification", async () => {
+    stubOkJson({ ok: true, already_verified: false });
+    const result = await api.auth.resendVerification();
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/auth/resend-verification");
+    expect(JSON.parse(init.body as string)).toEqual({});
+    expect(result).toEqual({ ok: true, already_verified: false });
+  });
+});


### PR DESCRIPTION
## ⚠️ This PR includes a schema change AND touches auth-sensitive code — flagging both per AGENTS.md

Fixes #217. `POST /auth/register` created accounts with no email-ownership verification (the code's own comment already acknowledged this), and `POST /invitations/{token}/accept` granted org membership purely on a case-insensitive email string match. Combined, this let an attacker who knows a victim's email pre-register with it, then accept an invite meant for that email under the victim's identity — the exact attack class `github_auth.py`'s `EmailAlreadyRegistered` already defends against on the GitHub OAuth path (GitHub vouches for the email there), but the password path had no equivalent since there was nothing on the `User` model to represent "this email has been proven."

**User decision on scope**: after presenting three options (mirror the OAuth path's refuse-only defense / restrict invites to GitHub-linked accounts only / build a real email verification pipeline), the maintainer chose the full email verification pipeline, using plain SMTP (no third-party vendor) with SMTP config optional (graceful degrade if unset).

## Migration — why it was necessary

`0017_add_email_verification.py` adds `users.email_verified` (bool, NOT NULL), `email_verify_token`, `email_verify_token_expires_at` (both nullable). There is genuinely nothing to represent "has this email been proven" without a new column — additive-only, no data-loss risk. Existing rows are backfilled `email_verified=true` via `server_default` (already-deployed users are grandfathered in as trusted; this migration doesn't retroactively lock anyone out). New inserts set the value explicitly in application code. Ran `alembic revision --autogenerate` afterward to confirm zero drift between the model and the migration.

## What changed

- `users.email_verified`: `True` for GitHub-linked accounts (GitHub already verifies the email — `github_oauth.fetch_identity` only ever returns a GitHub-verified address) and the first-run `/auth/setup` admin (implicitly trusted, same reasoning as `is_workspace_admin=True` there). `False` for self-service `/auth/register` accounts until they click the emailed verification link.
- New `apps/api/src/services/email.py` sends the verification link via plain SMTP (stdlib `smtplib`, no new dependency). SMTP config is optional (`src.core.config.Settings`, same optional-block pattern already used for `github_app_*`) — if unset, `EmailNotConfigured` is raised and **registration proceeds anyway** with the account left unverified, logging a warning. Account creation must never depend on email sending working.
- New `POST /auth/verify-email` (token → marks verified, 24h expiry, rate-limited) and `POST /auth/resend-verification` (auth required, rate-limited per account).
- `invitations.py`'s `accept_invitation` now also requires `email_verified`, in addition to the existing email-match check, with a distinct 403 message the UI keys off of.
- UI: new `/verify-email` page (public route); the invite-accept page shows a "Resend verification email" button specifically when accept fails for this reason (distinct from a genuine email mismatch, which also 403s but with different wording). Registration's UI flow is otherwise unchanged — the account still logs the user in immediately; it just can't accept an org invite until verified.

## Test plan

- [x] `apps/api/tests/test_email_service.py` — new: raises `EmailNotConfigured` when SMTP unset; sends via SMTP with STARTTLS + login when credentials are set; sends without login when they aren't.
- [x] `apps/api/tests/test_auth.py` — new: setup creates a verified admin; register creates an unverified user with a pending token; register still succeeds when SMTP is unconfigured or email sending raises; verify-email happy path clears the token; verify-email rejects unknown/expired tokens; resend-verification regenerates the token / is a no-op for an already-verified account / requires auth.
- [x] `apps/api/tests/test_invitations.py` — new: accept is 403'd for an unverified account (distinct message), succeeds once verified. Updated the existing `_make_user` test helper to default `email_verified=True` so the pre-existing email-match tests keep testing exactly what they were testing before.
- [x] `apps/api/tests/test_github_auth.py` — new: a GitHub-created user is already verified.
- [x] `apps/ui/tests/components/verify-email-page.test.tsx`, `invite-accept-page.test.tsx` — new: success/error/missing-token states for the verify page; resend button appears only for the verification-specific 403, not other accept failures.
- [x] `pytest -q` — 513 passed.
- [x] `bun run test` — 286 passed (1 pre-existing unrelated flake in `repos-page.test.tsx`, confirmed passes in isolation).
- [x] `bun run typecheck` / `bun run lint` — pass.
- [x] `alembic upgrade head` applied cleanly; `alembic revision --autogenerate` afterward confirmed zero model/migration drift.