### PR TITLE
fix(worker): stale-job reclaim can duplicate execution and mislabel successful jobs as failed

### DIFF
--- a/apps/api/alembic/versions/0017_add_jobs_heartbeat_at.py
+++ b/apps/api/alembic/versions/0017_add_jobs_heartbeat_at.py
@@ -9,7 +9,7 @@ duplicate its external side effect, and depending on timing the job can end
 up mislabeled 'failed' even though the original attempt actually succeeded.
 
 heartbeat_at is touched by the worker every ~10s while a job handler is
-actually running (apps/worker/src/worker.py's _heartbeat_while_running), so
+actually running (apps/worker/src/worker.py's _JobHeartbeat / _touch_job_heartbeat), so
 _reclaim_stale_jobs can check it instead of/alongside updated_at and leave a
 genuinely-still-running job alone past 30 minutes.
 

--- a/apps/api/alembic/versions/0017_add_jobs_heartbeat_at.py
+++ b/apps/api/alembic/versions/0017_add_jobs_heartbeat_at.py
@@ -1,0 +1,38 @@
+"""add jobs.heartbeat_at
+
+Issue #215: _reclaim_stale_jobs resets any job stuck in 'processing' for
+longer than RECLAIM_TIMEOUT_MINUTES (30 min) back to 'queued', assuming its
+worker crashed -- but updated_at is only set once, at claim time, so a
+legitimately slow (not crashed) job looks identical to a crashed one once
+that window elapses. A second worker can then pick up the same job and
+duplicate its external side effect, and depending on timing the job can end
+up mislabeled 'failed' even though the original attempt actually succeeded.
+
+heartbeat_at is touched by the worker every ~10s while a job handler is
+actually running (apps/worker/src/worker.py's _heartbeat_while_running), so
+_reclaim_stale_jobs can check it instead of/alongside updated_at and leave a
+genuinely-still-running job alone past 30 minutes.
+
+Nullable, no backfill needed -- additive-only. Same style as
+0014_add_jobs_retry_count.py.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "heartbeat_at")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -85,6 +85,13 @@ class Job(Base):
     retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    # Touched by the worker every ~10s while a job handler is actually running (see
+    # apps/worker/src/worker.py's _heartbeat_while_running). Lets _reclaim_stale_jobs tell
+    # a genuinely slow-but-alive job apart from one whose worker crashed -- updated_at alone
+    # can't, since it's only set at claim time and doesn't change again until the job
+    # finishes. Null for a job that was claimed before this column existed, or hasn't had
+    # its first heartbeat tick yet.
+    heartbeat_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class SavedToken(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -86,7 +86,7 @@ class Job(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     # Touched by the worker every ~10s while a job handler is actually running (see
-    # apps/worker/src/worker.py's _heartbeat_while_running). Lets _reclaim_stale_jobs tell
+    # apps/worker/src/worker.py's _JobHeartbeat / _touch_job_heartbeat). Lets _reclaim_stale_jobs tell
     # a genuinely slow-but-alive job apart from one whose worker crashed -- updated_at alone
     # can't, since it's only set at claim time and doesn't change again until the job
     # finishes. Null for a job that was claimed before this column existed, or hasn't had

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -254,6 +254,12 @@ def _touch_job_heartbeat(job_id: int) -> None:
         # Non-fatal -- worst case the reclaim sweep sees a stale heartbeat and reclaims a
         # job that's actually still running, the same failure mode as before this existed.
         log.warning("could not touch heartbeat for job %d: %s", job_id, exc)
+    # Also refresh the container-level file heartbeat (see _touch_heartbeat/HEARTBEAT_FILE):
+    # run()'s loop only touches it once per poll iteration, before a job is even claimed, so
+    # without this a job handler running past the healthcheck's 60s staleness threshold would
+    # get the worker marked unhealthy mid-job -- exactly during the long-running handlers this
+    # DB heartbeat was added to support.
+    _touch_heartbeat()
 
 
 class _JobHeartbeat:

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -39,8 +40,14 @@ _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg:/
 # the job 'failed' once exceeded, so a job can't retry forever regardless of cause.
 MAX_RETRIES = 5
 # A job left in 'processing' longer than this almost certainly had its worker crash or
-# get killed mid-job (see _reclaim_stale_jobs) rather than still being genuinely in flight.
+# get killed mid-job (see _reclaim_stale_jobs) rather than still being genuinely in flight
+# -- unless its heartbeat_at is still fresh (see _JobHeartbeat / _reclaim_stale_jobs).
 RECLAIM_TIMEOUT_MINUTES = 30
+
+# How often _JobHeartbeat touches jobs.heartbeat_at while a handler is running. Comfortably
+# below RECLAIM_TIMEOUT_MINUTES so a genuinely slow-but-alive job's heartbeat always stays
+# fresh well ahead of the reclaim sweep's staleness check.
+_JOB_HEARTBEAT_INTERVAL_SECONDS = 10
 
 
 def _read_app_config(key: str, default: str) -> str:
@@ -199,7 +206,14 @@ def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
     poll query only ever selects 'queued' rows, so without this such a job is stuck
     forever. Shares retry_count/MAX_RETRIES with process_job's transient-failure retry so
     a job that repeatedly crashes its worker eventually gets marked 'failed' instead of
-    looping indefinitely."""
+    looping indefinitely.
+
+    Only reclaims a job whose heartbeat_at is ALSO stale (or null, for a job claimed before
+    this column existed / before its handler's first heartbeat tick) -- updated_at alone is
+    set once at claim time and never again until the job finishes, so on its own it can't
+    tell a legitimately slow job from a crashed one. heartbeat_at is touched every
+    _JOB_HEARTBEAT_INTERVAL_SECONDS by _JobHeartbeat while a handler is actually running
+    (see issue #215), so a still-alive job's heartbeat stays fresh well past 30 minutes."""
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -210,6 +224,7 @@ def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
                 updated_at = NOW()
             WHERE status = 'processing'
               AND updated_at < NOW() - make_interval(mins => %(timeout_minutes)s)
+              AND (heartbeat_at IS NULL OR heartbeat_at < NOW() - make_interval(mins => %(timeout_minutes)s))
             RETURNING id, status
             """,
             {
@@ -222,6 +237,47 @@ def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
     conn.commit()
     for job_id, status in reclaimed:
         log.warning("reclaimed stale job %d -> %s", job_id, status)
+
+
+def _touch_job_heartbeat(job_id: int) -> None:
+    """Runs on its own DB connection, separate from the one process_job uses on the main
+    thread -- psycopg connections aren't safe to share across threads."""
+    try:
+        with psycopg.connect(_DB_URL) as hb_conn:
+            with hb_conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE jobs SET heartbeat_at = NOW() WHERE id = %s AND status = 'processing'",
+                    (job_id,),
+                )
+            hb_conn.commit()
+    except Exception as exc:
+        # Non-fatal -- worst case the reclaim sweep sees a stale heartbeat and reclaims a
+        # job that's actually still running, the same failure mode as before this existed.
+        log.warning("could not touch heartbeat for job %d: %s", job_id, exc)
+
+
+class _JobHeartbeat:
+    """Context manager: touches jobs.heartbeat_at for `job_id` every
+    _JOB_HEARTBEAT_INTERVAL_SECONDS on a background thread for as long as the `with` block
+    runs, so _reclaim_stale_jobs can tell this job apart from a crashed one. See issue #215."""
+
+    def __init__(self, job_id: int):
+        self._job_id = job_id
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        while not self._stop.wait(_JOB_HEARTBEAT_INTERVAL_SECONDS):
+            _touch_job_heartbeat(self._job_id)
+
+    def __enter__(self) -> "_JobHeartbeat":
+        _touch_job_heartbeat(self._job_id)  # immediate first tick, don't wait a full interval
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=_JOB_HEARTBEAT_INTERVAL_SECONDS)
 
 
 def _touch_heartbeat() -> None:
@@ -260,7 +316,8 @@ def run() -> None:
 
                 if row:
                     conn.commit()
-                    process_job(conn, *row)
+                    with _JobHeartbeat(row[0]):
+                        process_job(conn, *row)
         except psycopg.OperationalError:
             log.error("database connection failed, retrying in %ds", poll_seconds)
         except Exception as error:

--- a/apps/worker/tests/test_job_heartbeat.py
+++ b/apps/worker/tests/test_job_heartbeat.py
@@ -3,6 +3,7 @@
 import time
 from datetime import datetime, timedelta, timezone
 
+import psycopg
 import worker
 from worker import _JobHeartbeat, _touch_job_heartbeat
 
@@ -49,6 +50,23 @@ def test_touch_job_heartbeat_is_a_noop_for_a_job_that_is_no_longer_processing(wo
     _touch_job_heartbeat(job_id)
 
     assert _heartbeat_at(conn, job_id) is None
+
+
+def test_touch_job_heartbeat_swallows_a_db_connection_failure(monkeypatch, tmp_path):
+    # The DB heartbeat write is non-fatal by design (see the comment in
+    # _touch_job_heartbeat) -- a DB hiccup mid-job must not crash the job handler. Also
+    # verifies the container-level file heartbeat still gets touched even when the DB
+    # write fails, since it sits outside the try/except.
+    def boom(*args, **kwargs):
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr(psycopg, "connect", boom)
+    heartbeat_file = tmp_path / "worker_heartbeat"
+    monkeypatch.setattr(worker, "HEARTBEAT_FILE", heartbeat_file)
+
+    _touch_job_heartbeat(999)  # must not raise
+
+    assert heartbeat_file.exists()
 
 
 def test_touch_job_heartbeat_also_refreshes_the_container_heartbeat_file(worker_db, tmp_path, monkeypatch):

--- a/apps/worker/tests/test_job_heartbeat.py
+++ b/apps/worker/tests/test_job_heartbeat.py
@@ -51,6 +51,20 @@ def test_touch_job_heartbeat_is_a_noop_for_a_job_that_is_no_longer_processing(wo
     assert _heartbeat_at(conn, job_id) is None
 
 
+def test_touch_job_heartbeat_also_refreshes_the_container_heartbeat_file(worker_db, tmp_path, monkeypatch):
+    # Regression test: run()'s poll loop only touches HEARTBEAT_FILE once per iteration,
+    # before a job is even claimed -- without this, a job handler running past the
+    # healthcheck's 60s staleness threshold gets the worker marked unhealthy mid-job.
+    heartbeat_file = tmp_path / "worker_heartbeat"
+    monkeypatch.setattr(worker, "HEARTBEAT_FILE", heartbeat_file)
+    conn, created_ids = worker_db
+    job_id = _insert_processing_job(conn, created_ids)
+
+    _touch_job_heartbeat(job_id)
+
+    assert heartbeat_file.exists()
+
+
 def test_job_heartbeat_ticks_repeatedly_while_the_context_is_open(worker_db, monkeypatch):
     # Short interval so the test doesn't take _JOB_HEARTBEAT_INTERVAL_SECONDS' real 10s.
     monkeypatch.setattr(worker, "_JOB_HEARTBEAT_INTERVAL_SECONDS", 0.05)

--- a/apps/worker/tests/test_job_heartbeat.py
+++ b/apps/worker/tests/test_job_heartbeat.py
@@ -1,0 +1,78 @@
+"""Tests for _JobHeartbeat / _touch_job_heartbeat (issue #215)."""
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import worker
+from worker import _JobHeartbeat, _touch_job_heartbeat
+
+
+def _insert_processing_job(conn, created_ids) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO jobs (job_type, payload, status, updated_at)
+            VALUES ('github.clear_actions_cache', '{}', 'processing', NOW())
+            RETURNING id
+            """
+        )
+        job_id = cur.fetchone()[0]
+    conn.commit()
+    created_ids.append(job_id)
+    return job_id
+
+
+def _heartbeat_at(conn, job_id):
+    with conn.cursor() as cur:
+        cur.execute("SELECT heartbeat_at FROM jobs WHERE id = %s", (job_id,))
+        return cur.fetchone()[0]
+
+
+def test_touch_job_heartbeat_sets_heartbeat_at_on_a_processing_job(worker_db):
+    conn, created_ids = worker_db
+    job_id = _insert_processing_job(conn, created_ids)
+
+    _touch_job_heartbeat(job_id)
+
+    heartbeat = _heartbeat_at(conn, job_id)
+    assert heartbeat is not None
+    assert heartbeat > datetime.now(timezone.utc) - timedelta(seconds=10)
+
+
+def test_touch_job_heartbeat_is_a_noop_for_a_job_that_is_no_longer_processing(worker_db):
+    conn, created_ids = worker_db
+    job_id = _insert_processing_job(conn, created_ids)
+    with conn.cursor() as cur:
+        cur.execute("UPDATE jobs SET status = 'done' WHERE id = %s", (job_id,))
+    conn.commit()
+
+    _touch_job_heartbeat(job_id)
+
+    assert _heartbeat_at(conn, job_id) is None
+
+
+def test_job_heartbeat_ticks_repeatedly_while_the_context_is_open(worker_db, monkeypatch):
+    # Short interval so the test doesn't take _JOB_HEARTBEAT_INTERVAL_SECONDS' real 10s.
+    monkeypatch.setattr(worker, "_JOB_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+    conn, created_ids = worker_db
+    job_id = _insert_processing_job(conn, created_ids)
+
+    with _JobHeartbeat(job_id):
+        first_tick = _heartbeat_at(conn, job_id)
+        assert first_tick is not None  # touched immediately on __enter__, no wait
+        time.sleep(0.2)
+        second_tick = _heartbeat_at(conn, job_id)
+
+    assert second_tick > first_tick
+
+
+def test_job_heartbeat_stops_ticking_after_the_context_exits(worker_db, monkeypatch):
+    monkeypatch.setattr(worker, "_JOB_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+    conn, created_ids = worker_db
+    job_id = _insert_processing_job(conn, created_ids)
+
+    with _JobHeartbeat(job_id):
+        time.sleep(0.1)
+    after_exit = _heartbeat_at(conn, job_id)
+    time.sleep(0.2)
+    assert _heartbeat_at(conn, job_id) == after_exit

--- a/apps/worker/tests/test_reclaim.py
+++ b/apps/worker/tests/test_reclaim.py
@@ -6,15 +6,15 @@ from datetime import datetime, timedelta, timezone
 from worker import MAX_RETRIES, RECLAIM_TIMEOUT_MINUTES, _reclaim_stale_jobs
 
 
-def _insert_job(conn, created_ids, *, status: str, updated_at, retry_count: int = 0) -> int:
+def _insert_job(conn, created_ids, *, status: str, updated_at, retry_count: int = 0, heartbeat_at=None) -> int:
     with conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO jobs (job_type, payload, status, retry_count, updated_at)
-            VALUES ('github.clear_actions_cache', '{}', %s, %s, %s)
+            INSERT INTO jobs (job_type, payload, status, retry_count, updated_at, heartbeat_at)
+            VALUES ('github.clear_actions_cache', '{}', %s, %s, %s, %s)
             RETURNING id
             """,
-            (status, retry_count, updated_at),
+            (status, retry_count, updated_at, heartbeat_at),
         )
         job_id = cur.fetchone()[0]
     conn.commit()
@@ -50,6 +50,55 @@ def test_leaves_recently_updated_processing_job_alone(worker_db):
     status, retry_count, _result = _fetch(conn, job_id)
     assert status == "processing"
     assert retry_count == 0
+
+
+def test_leaves_a_stale_updated_at_job_alone_if_its_heartbeat_is_still_fresh(worker_db):
+    # Regression test for issue #215: a legitimately slow (not crashed) job's updated_at
+    # goes stale past RECLAIM_TIMEOUT_MINUTES since it's only set at claim time, but its
+    # heartbeat_at is touched every _JOB_HEARTBEAT_INTERVAL_SECONDS by _JobHeartbeat while
+    # the handler is actually running -- the reclaim sweep must check heartbeat_at too.
+    conn, created_ids = worker_db
+    stale_updated_at = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    fresh_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=5)
+    job_id = _insert_job(
+        conn, created_ids, status="processing", updated_at=stale_updated_at, retry_count=0,
+        heartbeat_at=fresh_heartbeat,
+    )
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, _result = _fetch(conn, job_id)
+    assert status == "processing"
+    assert retry_count == 0
+
+
+def test_reclaims_a_stale_updated_at_job_with_a_stale_heartbeat_too(worker_db):
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    job_id = _insert_job(
+        conn, created_ids, status="processing", updated_at=stale, retry_count=0, heartbeat_at=stale,
+    )
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, _result = _fetch(conn, job_id)
+    assert status == "queued"
+    assert retry_count == 1
+
+
+def test_reclaims_a_stale_updated_at_job_with_a_null_heartbeat(worker_db):
+    # A job claimed before the heartbeat column existed, or whose handler hasn't ticked
+    # yet, has heartbeat_at IS NULL -- must still be reclaimed on updated_at staleness
+    # alone, same as before this feature existed.
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    job_id = _insert_job(conn, created_ids, status="processing", updated_at=stale, retry_count=0, heartbeat_at=None)
+
+    _reclaim_stale_jobs(conn)
+
+    status, retry_count, _result = _fetch(conn, job_id)
+    assert status == "queued"
+    assert retry_count == 1
 
 
 def test_leaves_queued_and_done_jobs_alone(worker_db):

--- a/apps/worker/tests/test_run_loop.py
+++ b/apps/worker/tests/test_run_loop.py
@@ -1,0 +1,71 @@
+"""Covers run()'s single-iteration behavior end to end against a real Postgres instance,
+in particular that a claimed job gets wrapped in _JobHeartbeat (issue #215) -- run() itself
+is a `while True:` loop, so these tests break out after exactly one iteration by making
+time.sleep raise a sentinel exception."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import worker
+from _crypto import encrypt_job_token
+from config import settings
+
+
+class _StopLoop(Exception):
+    pass
+
+
+def _insert_queued_job(conn, created_ids) -> int:
+    enc = encrypt_job_token("secret", settings.job_secret_key.get_secret_value())
+    payload = json.dumps({"owner": "acme", "repo": "demo", "token": enc})
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO jobs (job_type, payload, status, updated_at)
+            VALUES ('github.clear_actions_cache', %s, 'queued', NOW())
+            RETURNING id
+            """,
+            (payload,),
+        )
+        job_id = cur.fetchone()[0]
+    conn.commit()
+    created_ids.append(job_id)
+    return job_id
+
+
+def _fetch(conn, job_id):
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, heartbeat_at FROM jobs WHERE id = %s", (job_id,))
+        return cur.fetchone()
+
+
+def test_run_wraps_a_claimed_job_in_a_job_heartbeat(worker_db, monkeypatch):
+    conn, created_ids = worker_db
+    job_id = _insert_queued_job(conn, created_ids)
+
+    monkeypatch.setattr(worker, "_read_poll_seconds", lambda: 1)
+    monkeypatch.setattr(worker.time, "sleep", MagicMock(side_effect=_StopLoop))
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.text = ""
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        try:
+            worker.run()
+        except _StopLoop:
+            pass
+
+    status, heartbeat_at = _fetch(conn, job_id)
+    assert status == "done"
+    # _JobHeartbeat.__enter__ ticks immediately, before process_job even starts -- proves
+    # run() actually wrapped the claimed job rather than calling process_job bare.
+    assert heartbeat_at is not None
+    assert heartbeat_at > datetime.now(timezone.utc) - timedelta(seconds=10)


### PR DESCRIPTION
## ⚠️ This PR includes a schema change — flagging per AGENTS.md

Fixes #215. `apps/worker/src/worker.py`'s `_reclaim_stale_jobs()` resets any job stuck in `processing` for longer than `RECLAIM_TIMEOUT_MINUTES` (30 min) back to `queued`, assuming the original worker crashed. There is no heartbeat/lease-renewal for jobs that are simply slow (e.g. a sluggish GitHub API response) rather than crashed — `updated_at` is only set once, at claim time, so on its own it can't tell a legitimately slow job apart from a crashed one once that window elapses.

## Migration — why it was necessary

`0017_add_jobs_heartbeat_at.py` adds `jobs.heartbeat_at` (nullable timestamptz, no backfill needed, additive-only). There's no existing column that can represent "still alive as of N seconds ago" for a running job. **Note**: main only had migrations through `0016` when this branch was created — if another in-flight PR's migration lands as `0017` first, this one will need renumbering to `0018` and rebasing at merge time.

## Failure scenario this closes

1. Worker A claims job N and starts a legitimately slow call.
2. The reclaim sweep (running in any worker's poll loop) resets job N to `queued` since `updated_at` looks stale.
3. Worker B's `SELECT ... FOR UPDATE SKIP LOCKED` picks up job N and starts the same external side effect again — a duplicate GitHub API call.
4. If B finishes first and marks the job `failed` (e.g. exceeding `MAX_RETRIES` via the reclaim's own `retry_count` bump) before A's original call completes, the job is permanently recorded `failed` in the audit trail even though A's call actually succeeded.

**Honesty about current impact**: the one existing job handler (`_handle_clear_actions_cache`, a single `httpx` call with a 20s timeout) realistically finishes in ~20-30s — nowhere near the 30-minute reclaim window, so this isn't an active bug against it today. It's a real latent gap for any future longer-running handler, and the fix matches the issue's own suggested approach, so I implemented it now per the explicit request rather than waiting for a handler that actually triggers it.

## Fix

A new `_JobHeartbeat` context manager runs on a background thread (its own DB connection, separate from the one `process_job` uses on the main thread — psycopg connections aren't safe to share across threads) and touches `jobs.heartbeat_at` every 10s for as long as a handler is running, wrapping `process_job`'s call in `run()`. The reclaim sweep's SQL now also requires `heartbeat_at` to be stale (or `NULL`, for a job claimed before this column existed) before reclaiming, so a genuinely-still-running job's fresh heartbeat protects it past 30 minutes.

## Test plan

- [x] `apps/worker/tests/test_reclaim.py` — new tests: a stale-`updated_at` job with a fresh `heartbeat_at` is left alone; one with a stale `heartbeat_at` (or `NULL`, for pre-existing jobs) is still reclaimed as before.
- [x] `apps/worker/tests/test_job_heartbeat.py` — new: `_touch_job_heartbeat` sets the column on a `processing` job and no-ops for a job that's no longer processing; `_JobHeartbeat` ticks repeatedly while its context is open (short interval override so the test doesn't take the real 10s) and stops ticking after it exits.
- [x] `pytest -q` — 503 passed.
- [x] `alembic upgrade head` applied cleanly; `alembic revision --autogenerate` afterward confirmed zero model/migration drift.