### PR TITLE
fix(ui): Activity page required a legacy PAT despite GitHub App auth

### DIFF
--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "@/components/page-header"
 import { ActivityList } from "@/components/activity-list"
 import { EventFeed } from "@/components/event-feed"
 import { HeatmapCalendar } from "@/components/charts/heatmap-calendar"
+import { SectionError } from "@/components/section-error"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
 import { api } from "@/lib/api/client"
@@ -64,16 +65,20 @@ export default function ActivityPage() {
     retry: false,
   })
 
-  const configured = !!resolveQuery.data?.token
   const token = resolveQuery.data?.token ?? ""
+  // Queries fire once an org is set and token resolution has settled, regardless of
+  // whether a saved PAT was found -- an org connected purely via GitHub App
+  // installation (no PAT ever saved, a fully supported flow) has no `token` here, but
+  // the API resolves an installation token server-side the same way Overview's queries
+  // already rely on (see app/page.tsx). Gating on a resolved PAT specifically made this
+  // page permanently blank for App-only orgs (#251).
+  const hasOrg = org.trim().length > 0
+  const queriesEnabled = hasOrg && !resolveQuery.isLoading
 
   const eventsQuery = useQuery({
     queryKey: ["github.events", org],
-    queryFn: () => {
-      if (!token) throw new Error("No GitHub token available for this organization")
-      return api.github.events(org, token)
-    },
-    enabled: configured,
+    queryFn: () => api.github.events(org, token),
+    enabled: queriesEnabled,
     retry: false,
     refetchInterval: EVENTS_REFRESH_SECONDS * 1000,
   })
@@ -89,28 +94,28 @@ export default function ActivityPage() {
   const cockpitQuery = useQuery({
     queryKey: ["analytics.cockpit-heatmap", org],
     queryFn: () => api.analytics.cockpit(org, token),
-    enabled: configured,
+    enabled: queriesEnabled,
     retry: false,
   })
 
   const failedRunsQuery = useQuery({
     queryKey: ["github.failed-runs", org],
     queryFn: () => api.github.failedRuns(org, token),
-    enabled: configured,
+    enabled: queriesEnabled,
     retry: false,
   })
 
   const releaseTimelineQuery = useQuery({
     queryKey: ["github.release-timeline", org],
     queryFn: () => api.github.releaseTimeline(org, token),
-    enabled: configured,
+    enabled: queriesEnabled,
     retry: false,
   })
 
   const reposQuery = useQuery({
     queryKey: ["repos.list", org],
     queryFn: () => api.repos.list(org, token),
-    enabled: configured && feedTab === "board",
+    enabled: queriesEnabled && feedTab === "board",
     retry: false,
   })
 
@@ -125,7 +130,7 @@ export default function ActivityPage() {
       )
       return results.flatMap((r) => r.pulls)
     },
-    enabled: configured && feedTab === "board" && !!reposQuery.data,
+    enabled: queriesEnabled && feedTab === "board" && !!reposQuery.data,
     retry: false,
   })
 
@@ -171,9 +176,9 @@ export default function ActivityPage() {
                 PR Board
               </button>
             </div>
-            {feedTab === "feed" && configured && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
+            {feedTab === "feed" && hasOrg && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
           </div>
-          {!configured ? (
+          {!hasOrg ? (
             <div className="px-4 py-8">
               <p className="text-sm text-muted-foreground">
                 No organization configured yet.{" "}
@@ -182,6 +187,12 @@ export default function ActivityPage() {
                 </Link>
               </p>
             </div>
+          ) : feedTab === "feed" && eventsQuery.isError ? (
+            <SectionError
+              message={eventsQuery.error instanceof Error ? eventsQuery.error.message : "Failed to load events."}
+              onRetry={() => eventsQuery.refetch()}
+              retrying={eventsQuery.isFetching}
+            />
           ) : feedTab === "feed" ? (
             <EventFeed events={eventsQuery.data?.events ?? []} isLoading={eventsQuery.isLoading} />
           ) : prBoardQuery.isLoading || reposQuery.isLoading ? (
@@ -222,7 +233,7 @@ export default function ActivityPage() {
         </div>
       </div>
 
-      {configured && (
+      {hasOrg && (
         <div className="grid gap-4 lg:grid-cols-2 mt-4">
           <div className="card lg:col-span-2">
             <div className="px-4 py-3 border-b border-border">

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -118,19 +118,35 @@ describe("ActivityPage", () => {
     renderPage();
 
     await waitFor(() => expect(tokensResolveMock).toHaveBeenCalledWith("hp"));
+    await waitFor(() => expect(githubEventsMock).toHaveBeenCalled());
     expect(await screen.findByText(/no events yet/)).toBeInTheDocument();
   });
 
-  it("shows an error instead of crashing when the events query runs without a resolved token", async () => {
+  it("still queries events when no PAT is saved, relying on the API's installation-token fallback (#251)", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
 
     renderPage();
 
-    // configured is false when token is empty, so the feed never queries and the
-    // configure prompt is shown -- no uncaught exception from a bare `.token` read.
-    expect(await screen.findByText(/No organization configured yet/)).toBeInTheDocument();
-    expect(githubEventsMock).not.toHaveBeenCalled();
+    // An org connected purely via GitHub App installation has no saved PAT, so
+    // resolveQuery resolves to an empty token -- the feed must still query (letting the
+    // API resolve an installation token server-side) instead of showing the "not
+    // configured" prompt, which would be a false negative for App-only orgs.
+    await waitFor(() => expect(githubEventsMock).toHaveBeenCalledWith("acme", ""));
+    expect(screen.queryByText(/No organization configured yet/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/no events yet/)).toBeInTheDocument();
+  });
+
+  it("shows a retryable error when the events query fails with no working token available", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "" });
+    githubEventsMock.mockRejectedValue(new Error("No GitHub token available for this organization"));
+
+    renderPage();
+
+    expect(await screen.findByText("No GitHub token available for this organization")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
   it("renders the CI failure log and release timeline", async () => {

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -146,7 +146,13 @@ describe("ActivityPage", () => {
     renderPage();
 
     expect(await screen.findByText("No GitHub token available for this organization")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: "Retry" });
+
+    githubEventsMock.mockResolvedValueOnce({ org: "acme", events: [] });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(githubEventsMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/no events yet/)).toBeInTheDocument();
   });
 
   it("renders the CI failure log and release timeline", async () => {


### PR DESCRIPTION
## Summary

Closes #251.

The Activity page (`apps/ui/app/activity/page.tsx`) derived a `configured` flag from whether a legacy PAT resolved via `POST /tokens/resolve`, and gated **every** query on the page (event feed, commit heatmap, CI failure log, release timeline, PR board) behind that flag. If no PAT had ever been saved for the org — a fully supported setup when the org is connected purely via GitHub App installation — `configured` stayed `false` forever, and the page showed a permanent "No organization configured yet" prompt even though the org was correctly connected and Overview/Security worked fine for it.

Overview (`apps/ui/app/page.tsx`) already avoids this: its data queries are enabled once an org is known and token resolution has settled, regardless of whether a PAT was actually found, trusting the API's own installation-token fallback (`token_resolution.resolve_org_token`/`resolve_personal_token`). Activity never got that same treatment.

## What changed

- Replaced the `configured` (PAT-resolved) gate with `hasOrg` (an org is set) for every query's `enabled` flag, matching Overview's pattern.
- The "no organization" empty state now reflects whether an org is actually configured, not whether a PAT resolved.
- Added a `SectionError` (with retry) branch for the event feed specifically, since a genuine "no token available at all" failure now surfaces as a real query error instead of being silently swallowed by the old gate.
- Updated/added tests in `apps/ui/tests/components/activity-page.test.tsx`: the old test asserting the buggy behavior (no PAT → events never queried) is replaced with a test asserting the fixed behavior (no PAT → events still queried, relying on the API's installation-token fallback), plus a new test for the genuine-no-token error path.

## Why

An org connected only via GitHub App installation (no PAT ever saved) is meant to be a fully working setup per this project's architecture — Activity being blank for that case undermines the whole point of the GitHub App migration.

No RBAC/auth/token-encryption/migration changes — this is a client-side query-gating fix only; the backend token-resolution fallback it now relies on already existed and is unchanged.

## Test plan
- [x] `bun run test -- activity-page` — all 10 tests pass
- [x] `bun run typecheck` — passes
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Activity page GitHub/analytics loading for organizations without a saved token, ensuring queries run after token resolution completes.
  - Activity feed now handles missing/empty tokens gracefully and shows the “no events yet” state instead of incorrect prompts.
  - Added a clearer error experience on event load failures, including a **Retry** action to recover without refresh.
  - Refined when refresh countdown and right-side activity panels (e.g., heatmap/CI/release timeline) appear, based on org availability.
  - Tightened pull request board querying to avoid incomplete data states.
- **Tests**
  - Updated Activity page coverage for empty-token and error/retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->