### PR TITLE
fix(ui): audit tab's error state hides an unrelated, loaded section

### DIFF
--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -161,11 +161,15 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
         )}
       </div>
 
-      {activeQuery.isLoading ? (
+      {/* The audit tab renders two independently-fetched sections (permission audit,
+          inactive members) and gives each its own loading/error state below -- gating the
+          whole tab on permissionAuditQuery alone would hide inactive-members data that
+          loaded fine just because the audit call happened to fail (#252). */}
+      {tab !== "audit" && activeQuery.isLoading ? (
         <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
           <CircleNotch className="size-3.5 animate-spin" /> Loading…
         </div>
-      ) : activeQuery.isError ? (
+      ) : tab !== "audit" && activeQuery.isError ? (
         <div className="px-4 py-6">
           <p className="text-xs text-destructive">{activeQuery.error.message}</p>
         </div>
@@ -312,30 +316,40 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
               )}
             </span>
           </div>
-          <div className="overflow-x-auto max-h-96 overflow-y-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Repo</th>
-                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Collaborator</th>
-                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Affiliation</th>
-                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Permission</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {(permissionAuditQuery.data?.repos ?? []).flatMap((repo) =>
-                  repo.collaborators.map((c) => (
-                    <tr key={`${repo.repo}-${c.login}`} className={c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin") ? "bg-yellow-500/5" : ""}>
-                      <td className="px-4 py-2 font-mono text-muted-foreground truncate max-w-[10rem]">{repo.repo}</td>
-                      <td className="px-4 py-2 text-foreground/80">{c.login}</td>
-                      <td className="px-4 py-2 text-muted-foreground">{c.affiliation}</td>
-                      <td className="px-4 py-2 text-muted-foreground capitalize">{c.permission}</td>
-                    </tr>
-                  )),
-                )}
-              </tbody>
-            </table>
-          </div>
+          {permissionAuditQuery.isLoading ? (
+            <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
+              <CircleNotch className="size-3.5 animate-spin" /> Loading…
+            </div>
+          ) : permissionAuditQuery.isError ? (
+            <div className="px-4 py-6">
+              <p className="text-xs text-destructive">{permissionAuditQuery.error.message}</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto max-h-96 overflow-y-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Repo</th>
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Collaborator</th>
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Affiliation</th>
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Permission</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {(permissionAuditQuery.data?.repos ?? []).flatMap((repo) =>
+                    repo.collaborators.map((c) => (
+                      <tr key={`${repo.repo}-${c.login}`} className={c.is_outside_collaborator && (c.permission === "write" || c.permission === "maintain" || c.permission === "admin") ? "bg-yellow-500/5" : ""}>
+                        <td className="px-4 py-2 font-mono text-muted-foreground truncate max-w-[10rem]">{repo.repo}</td>
+                        <td className="px-4 py-2 text-foreground/80">{c.login}</td>
+                        <td className="px-4 py-2 text-muted-foreground">{c.affiliation}</td>
+                        <td className="px-4 py-2 text-muted-foreground capitalize">{c.permission}</td>
+                      </tr>
+                    )),
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
 
           <div className="px-4 py-2.5 border-b border-t border-border">
             <span className="text-xs font-medium text-foreground">Inactive members (30d+)</span>

--- a/apps/ui/tests/components/github-roster.test.tsx
+++ b/apps/ui/tests/components/github-roster.test.tsx
@@ -385,6 +385,28 @@ describe("GithubRoster (Collaborators page)", () => {
     });
   });
 
+  it("still shows inactive members that loaded fine when the permission audit call fails (#252)", async () => {
+    membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
+    permissionAuditMock.mockRejectedValue(new Error("GitHub rate limit exceeded"));
+    inactiveMembersMock.mockResolvedValue({
+      org: "acme",
+      sampled_repos: ["acme/api"],
+      members: [{ login: "frank", avatar_url: "", role: "member", last_commit_repo: null, last_commit_days_ago: null }],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Audit" }));
+
+    // Previously the whole Audit tab collapsed into a single generic error line whenever
+    // permissionAuditQuery failed, hiding the independently-fetched (and successfully
+    // loaded) inactive-members section entirely -- both must render their own state.
+    await waitFor(() => {
+      expect(screen.getByText("GitHub rate limit exceeded")).toBeInTheDocument();
+    });
+    expect(await screen.findByText("frank")).toBeInTheDocument();
+  });
+
   it("shows how long ago an inactive member's last commit was", async () => {
     membersMock.mockResolvedValue({ org: "acme", members: [], two_factor_overlay_available: true });
     inactiveMembersMock.mockResolvedValue({


### PR DESCRIPTION
## Summary

Closes #252.

`apps/ui/app/settings/org/[login]/members/page.tsx`'s Audit tab renders two independently-fetched sections -- the permission audit table and "Inactive members (30d+)" -- but the top-level loading/error gate (`activeQuery.isLoading` / `activeQuery.isError`) only ever tracked `permissionAuditQuery`. If the permission-audit call failed (e.g. a GitHub rate limit hitting that specific endpoint) while the inactive-members call succeeded, the whole tab collapsed to a single generic error line, and inactive-member data that loaded fine was never shown to the admin.

## What changed

- The top-level `isLoading`/`isError` gate now excludes the `audit` tab (`tab !== "audit" && ...`) -- it was never a good fit for a tab backed by two independent queries.
- The permission-audit table gets its own `isLoading`/`isError` branch, mirroring the handling `inactiveMembersQuery` already had further down in the same tab.
- Added a test (`apps/ui/tests/components/github-roster.test.tsx`) covering the actual failure scenario from the issue: permission audit fails, inactive members succeeds -- both the error message and the successfully-loaded inactive member now render simultaneously.

## Why

An admin using the Audit tab for a real security review shouldn't lose visibility into inactive members just because an unrelated GitHub API call (permission audit) hit a rate limit or transient error.

No RBAC/auth/token-encryption/migration changes -- purely a client-side rendering fix; no backend changes.

## Test plan
- [x] `bun run test -- github-roster` -- all 18 tests pass
- [x] `bun run typecheck` -- passes
- [ ] CI