### PR TITLE
docs(readme): drop stale note that a legacy token is still required

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ Once the instance is running, here's how to go from a fresh deploy to a connecte
 
 1. **Create the first account.** The first visit lands on `/setup`, which creates the initial admin. After that, sign in with a password or the "Sign in with GitHub" button.
 2. **Connect a GitHub org or account.** Go to **Settings → Connected orgs** and click **Install GitHub App** — this sends you to GitHub to authorize Clevis for that org/account, which is what grants read access to its repos. GitHub redirects you back into the app once you approve it, and the org/account shows up under "Connected orgs" a few seconds later. (The App itself is a one-time setup step for whoever deployed the instance — see [`docs/self-hosting.md`](docs/self-hosting.md) if that hasn't been done yet.) If you install into a brand-new org and the connection doesn't complete, sign out and back in with **"Sign in with GitHub"** once (this is what verifies your admin access on that org) and retry the install.
-3. **(Temporary) Add a personal access token only if needed.** Health & Security and Cache still accept a legacy PAT via **Settings → Personal access tokens (legacy)** as a fallback when no GitHub App installation is available for that org. Tracking removal of that requirement: [#189](https://github.com/nazarli-shabnam/clevis/issues/189).
 
-That's it — Overview, Activity, Repositories, Collaborators, and (when the App is connected) Health & Security / Cache work off the connected org from step 2.
+That's it — Overview, Activity, Repositories, Collaborators, Health & Security, and Cache all work off the connected org from step 2. A legacy personal access token (**Settings → Personal access tokens (legacy)**) is only ever needed as a manual fallback for an org that has no GitHub App installation — it is not a required step.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #189.

#189 claimed "Every user still has to manually create and paste a GitHub PAT into Settings to use the two most security-relevant pages" (Health & Security, Cache). Investigating this turned up that it's already false on `main`:

- `apps/ui/app/security/page.tsx` and `apps/ui/components/repo/cache-panel.tsx` both auto-resolve a saved PAT via `/tokens/resolve` but treat it as fully optional (`token || undefined` sent to the API either way), already labeled "optional if the GitHub App is connected for this org" in the UI.
- The API-side installation-token fallback (`token_resolution.resolve_org_token`/`resolve_personal_token`) that makes this work was wired into these endpoints back in `dc889ae` (`fix(api): wire GitHub App installation tokens into analytics and cache endpoints`), well before this issue was filed.

So the only thing actually stale was this README line, which still framed adding a PAT as a required numbered setup step with a "temporary" caveat and a link tracking its removal.

## What changed

- `README.md`: removed the numbered "(Temporary) Add a personal access token only if needed" step and its `#189` tracking link; folded the PAT note into the closing sentence as what it actually is — an optional fallback for orgs without a GitHub App installation, not a setup action.

## Why not adopt PR #205 instead

There's an existing open PR (#205) also targeting #189 that goes further: it removes the manual PAT input field from these pages entirely, making them GitHub-App-only. I did not adopt that approach here, because it would be a behavior regression, not just a docs fix — `resolve_org_token`/`resolve_personal_token` only fall back to a legacy PAT when the **UI itself** supplies one in the request body; there's no server-side auto-lookup of `saved_tokens`. Removing the input field would silently break Security/Cache for any org connected via a legacy-PAT-only setup with no GitHub App installed (a still-supported configuration per this project's docs). That's a larger, separate decision than what #189 as filed actually needed.

No RBAC/auth/token-encryption/migration changes — README only, no code changes.

## Test plan
- [x] N/A — documentation-only change
- [ ] CI