### PR TITLE
fix(api): case-sensitive installation lookup can break token resolution

### DIFF
--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -1,3 +1,4 @@
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -84,9 +85,16 @@ def create(
 
 
 def get_for_org(db: Session, org_id: int, account_login: str) -> GitHubInstallation | None:
+    # Case-insensitive: account_login is stored verbatim from GitHub's install payload,
+    # but RBAC/ownership checks elsewhere (assert_owner_matches_org, _verify_installation)
+    # already compare logins case-insensitively -- an exact match here could pass those
+    # checks yet fail to find an installation that's actually there (#246).
     return (
         db.query(GitHubInstallation)
-        .filter(GitHubInstallation.org_id == org_id, GitHubInstallation.account_login == account_login)
+        .filter(
+            GitHubInstallation.org_id == org_id,
+            func.lower(GitHubInstallation.account_login) == account_login.lower(),
+        )
         .first()
     )
 
@@ -96,7 +104,7 @@ def get_for_user(db: Session, owner_user_id: int, account_login: str) -> GitHubI
         db.query(GitHubInstallation)
         .filter(
             GitHubInstallation.owner_user_id == owner_user_id,
-            GitHubInstallation.account_login == account_login,
+            func.lower(GitHubInstallation.account_login) == account_login.lower(),
         )
         .first()
     )

--- a/apps/api/tests/test_installation_repo.py
+++ b/apps/api/tests/test_installation_repo.py
@@ -77,3 +77,42 @@ def test_upsert_reraises_when_the_integrity_error_was_not_actually_a_race(db):
             installation_id=1,
             org_id=999999,
         )
+
+
+def test_get_for_org_matches_regardless_of_login_casing(db):
+    # account_login is stored verbatim from GitHub's install payload; RBAC/ownership checks
+    # elsewhere (assert_owner_matches_org, _verify_installation) already compare logins
+    # case-insensitively, so this lookup must too -- otherwise a case mismatch (e.g. a
+    # renamed org, or a caller passing different casing) passes those checks but fails to
+    # find an installation that's actually there (#246).
+    org_id = _acme_org_id(db)
+    installation_repo.upsert(
+        db, account_login="Acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+
+    found = installation_repo.get_for_org(db, org_id=org_id, account_login="acme")
+
+    assert found is not None
+    assert found.installation_id == 1
+
+
+def test_get_for_user_matches_regardless_of_login_casing(db):
+    from src.core.db import User
+
+    user = User(email="dev@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    installation_repo.upsert(
+        db,
+        account_login="Octocat",
+        account_type="User",
+        auth_mode="app",
+        installation_id=7,
+        owner_user_id=user.id,
+    )
+
+    found = installation_repo.get_for_user(db, owner_user_id=user.id, account_login="octocat")
+
+    assert found is not None
+    assert found.installation_id == 7


### PR DESCRIPTION
## Summary

Closes #246.

`installation_repo.get_for_org`/`get_for_user` matched `account_login` with an exact `==` comparison. `account_login` is stored verbatim from GitHub's install payload (`installations.py`), but RBAC/ownership checks elsewhere in the same request path already compare logins case-insensitively (`assert_owner_matches_org` in `core/rbac.py`, `_verify_installation` in `installations.py`).

## Failure scenario

If a caller reaches a repo/analytics/automation endpoint with an `owner`/`org_login` path parameter whose casing differs from what's stored (a GitHub org renamed casing, or a client simply sending different case), the RBAC/ownership check passes (it's case-insensitive) but `token_resolution.resolve_org_token`/`resolve_personal_token`'s installation lookup fails to find a row that's actually there — silently falling back to a client-supplied PAT, or raising `NoGitHubTokenAvailable` even though a valid installation exists.

## What changed

- `get_for_org` and `get_for_user` now compare `account_login` via `func.lower(...) == account_login.lower()`, matching the case-insensitive comparisons used elsewhere in this same request path.
- `upsert`'s own lookup (used at install-sync time) is intentionally left as an exact match — that's a narrower, separate question about how install-sync dedupes rows on casing drift, not what this issue is about; changing it wasn't needed to close the gap between RBAC checks and token resolution.
- Added `test_get_for_org_matches_regardless_of_login_casing` and `test_get_for_user_matches_regardless_of_login_casing` to `apps/api/tests/test_installation_repo.py`.

## Why

Directly relevant to the just-closed "GitHub org not connecting" bug class on this branch — this is a related edge case the recent fix didn't cover, and the RBAC/token-resolution mismatch it produces (installation exists in the DB but token resolution can't see it) is exactly the "silently falls back or fails oddly" pattern that class of bug was about.

**This PR touches token-resolution code**, flagging per this repo's guardrails: the change is a comparison-only fix (case-insensitive match instead of exact match) to an existing, already-tested lookup function — no change to what gets returned once a row is found, no change to encryption/minting logic.

No migrations, no RBAC bypass — purely a lookup-matching fix.

## Test plan
- [x] `pytest tests/test_installation_repo.py -v` — all 6 tests pass (2 new)
- [x] `pytest tests/test_token_resolution.py tests/test_installations.py -v` — all 42 tests pass, no regressions
- [ ] CI