### PR TITLE
fix(api): unbounded in-process caches never evict expired entries

### DIFF
--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -124,6 +124,14 @@ def _fetch_events(org_login: str, token: str, per_page: int) -> OrgEventsRespons
     return OrgEventsResponse(org=org_login, events=events)
 
 
+def _evict_expired_events(now: float) -> None:
+    # Same reasoning as repos.py's _evict_expired_stats: token_hash rotates hourly with
+    # each fresh installation token, so stale keys would otherwise accumulate forever.
+    expired = [key for key, (cached_at, _) in _events_cache.items() if now - cached_at >= _EVENTS_CACHE_TTL_SECONDS]
+    for key in expired:
+        del _events_cache[key]
+
+
 def _cached_events(org_login: str, token: str, per_page: int) -> OrgEventsResponse:
     key = (org_login, _token_hash(token), per_page)
     now = time.monotonic()
@@ -132,6 +140,7 @@ def _cached_events(org_login: str, token: str, per_page: int) -> OrgEventsRespon
         return cached[1]
     events = _fetch_events(org_login, token, per_page)
     _events_cache[key] = (now, events)
+    _evict_expired_events(now)
     return events
 
 

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -105,6 +105,15 @@ def _fetch_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
     }
 
 
+def _evict_expired_stats(now: float) -> None:
+    # Installation tokens rotate hourly, so every org x repo x hour of uptime adds a new
+    # key that's never revisited once its token_hash goes stale -- without this sweep the
+    # dict grows without bound for a long-running instance serving many orgs.
+    expired = [key for key, (cached_at, _) in _stats_cache.items() if now - cached_at >= _STATS_CACHE_TTL_SECONDS]
+    for key in expired:
+        del _stats_cache[key]
+
+
 def _cached_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
     key = (owner, repo, _token_hash(token))
     now = time.monotonic()
@@ -113,6 +122,7 @@ def _cached_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
         return cached[1]
     stats = _fetch_stats(owner, repo, token)
     _stats_cache[key] = (now, stats)
+    _evict_expired_stats(now)
     return stats
 
 

--- a/apps/api/tests/test_github_events.py
+++ b/apps/api/tests/test_github_events.py
@@ -197,6 +197,24 @@ def test_events_different_tokens_are_not_served_from_the_same_cache_entry(events
     assert mock_client.return_value.request.call_count == 2
 
 
+def test_events_evicts_expired_entries_from_the_cache(events_client):
+    # Same reasoning as test_repos.py's equivalent test: token_hash rotates hourly with
+    # each fresh installation token, so stale entries would otherwise never be pruned (#247).
+    import time as time_module
+
+    stale_key = ("other-org", "deadbeef", 30)
+    _events_cache[stale_key] = (time_module.monotonic() - 10_000, {"org": "other-org", "events": []})
+
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [_PUSH_EVENT]
+        resp = events_client.post(
+            "/github/orgs/acme/events", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.status_code == 200
+    assert stale_key not in _events_cache
+
+
 def test_events_non_list_response_returns_502(events_client):
     # GitHubClient.request falls back to `{}` on an empty response body -- a non-list
     # response must surface as an error, not silently render as "no events".

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -282,6 +282,29 @@ def test_repo_stats_second_call_is_served_from_cache(repos_client):
     assert mock_client.return_value.request.call_count == 5
 
 
+def test_repo_stats_evicts_expired_entries_from_the_cache(repos_client):
+    # Installation tokens rotate hourly, so a long-running instance would otherwise
+    # accumulate one stale entry per org x repo x hour forever -- a cache miss now sweeps
+    # any entry whose TTL has already elapsed (#247).
+    import time as time_module
+
+    stale_key = ("other-owner", "other-repo", "deadbeef")
+    _stats_cache[stale_key] = (time_module.monotonic() - 10_000, {"repository": "other-owner/other-repo"})
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META,
+            commit_activity=[{"week": 1, "total": 5}],
+            release_error=_not_found(),
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.status_code == 200
+    assert stale_key not in _stats_cache
+
+
 def test_repo_stats_different_tokens_are_not_served_from_the_same_cache_entry(repos_client):
     with patch("src.routers.repos.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = _stats_side_effect(


### PR DESCRIPTION
## Summary

Closes #247.

`apps/api/src/routers/repos.py`'s `_stats_cache` and `apps/api/src/routers/github.py`'s `_events_cache` are module-level dicts keyed by `(owner, repo, token_hash)` / `(org, token_hash, per_page)` with TTL-based staleness checks — but expired entries were only ever *skipped* on a cache-hit check, never actually removed from the dict.

Installation tokens rotate hourly, changing `token_hash`, so every org × repo × hour of uptime added a new entry that was never pruned. A long-running instance serving many orgs sees steady, unbounded memory growth in these two dicts.

## What changed

- `repos.py`: added `_evict_expired_stats(now)`, called right after inserting a fresh entry on every cache miss — sweeps any entry whose TTL has already elapsed.
- `github.py`: same pattern, `_evict_expired_events(now)`.
- Added a test in each file's test suite (`test_repo_stats_evicts_expired_entries_from_the_cache`, `test_events_evicts_expired_entries_from_the_cache`) that seeds a synthetic stale entry, triggers a real cache miss, and asserts the stale entry is gone afterward.

## Why

Both caches are process-lifetime dicts with no other cleanup path — an operator running Clevis for weeks/months against a growing set of orgs would otherwise see these grow forever. The fix piggybacks the sweep on the existing miss path rather than adding a background thread/scheduler, since a miss already happens on roughly the same cadence as new stale entries would accumulate.

No RBAC/auth/token-encryption/migration changes — purely an in-memory cache-hygiene fix, no behavior change to cache hits/misses themselves.

## Test plan
- [x] `pytest tests/test_repos.py tests/test_github_events.py -v` — all 40 tests pass (2 new)
- [ ] CI