### PR TITLE
fix(api): duplicate pending invitations aren't prevented

### DIFF
--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -39,6 +39,19 @@ def list_for_org(db: Session, org_id: int) -> list[Invitation]:
     return db.query(Invitation).filter(Invitation.org_id == org_id).order_by(Invitation.created_at.desc()).all()
 
 
+def get_pending_for_org_and_email(db: Session, org_id: int, email: str) -> Invitation | None:
+    return (
+        db.query(Invitation)
+        .filter(
+            Invitation.org_id == org_id,
+            Invitation.email.ilike(email),
+            Invitation.status == "pending",
+            Invitation.expires_at > datetime.now(timezone.utc),
+        )
+        .first()
+    )
+
+
 def list_pending_for_email(db: Session, email: str) -> list[Invitation]:
     return (
         db.query(Invitation)

--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -56,6 +56,12 @@ def create_invitation(
     user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
+    existing = invitation_repo.get_pending_for_org_and_email(db, org_id=ctx.org.id, email=body.email)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A pending invitation already exists for {body.email} in this organization",
+        )
     invitation = invitation_repo.create(db, org_id=ctx.org.id, email=body.email, invited_by_user_id=user.id)
     return {
         "invitation": invitation,

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -57,6 +57,45 @@ def test_create_invitation_admin_ok(db, acme_org):
     assert "/invite/" in body["invite_link"]
 
 
+def test_create_invitation_rejects_duplicate_pending_invite(db, acme_org):
+    client = _client(db, acme_org["admin"])
+    first = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert first.status_code == 200
+
+    second = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert second.status_code == 409
+
+    # Only the first invite exists -- the rejected attempt didn't create a second row.
+    listing = client.get("/orgs/acme/invitations").json()
+    assert len(listing) == 1
+
+
+def test_create_invitation_duplicate_check_is_case_insensitive(db, acme_org):
+    client = _client(db, acme_org["admin"])
+    client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+
+    resp = client.post("/orgs/acme/invitations", json={"email": "BOB@ACME.COM"})
+    assert resp.status_code == 409
+
+
+def test_create_invitation_allows_new_invite_after_the_pending_one_is_revoked(db, acme_org):
+    client = _client(db, acme_org["admin"])
+    created = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    client.post(f"/orgs/acme/invitations/{created['invitation']['id']}/revoke")
+
+    resp = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 200
+
+
+def test_create_invitation_allows_new_invite_after_the_pending_one_expires(db, acme_org):
+    client = _client(db, acme_org["admin"])
+    created = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    _expire_invitation(db, created["invitation"]["id"])
+
+    resp = client.post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 200
+
+
 def test_list_invitations_admin_only(db, acme_org):
     _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
     resp = _client(db, acme_org["admin"]).get("/orgs/acme/invitations")


### PR DESCRIPTION
## Summary

Closes #248.

`POST /orgs/{org_login}/invitations` had no check for an existing pending invite to the same email within the same org. Inviting the same address twice (by accident, or a retried request) created two independently valid, independently tokened pending invitations.

## Failure scenario

An admin invites `bob@acme.com`, then invites them again later (forgetting the first invite, or after a client-side retry). Two separate `Invitation` rows now exist, each with its own token and its own link. Revoking "the" invite shown in the admin UI (most likely the most recently created one) leaves the older link still valid and able to grant org membership until it separately expires or is separately found and revoked — a stale invite link staying alive longer than the admin believes it does.

## What changed

- Added `invitation_repo.get_pending_for_org_and_email(db, org_id, email)` — same `Invitation.email.ilike(...)` case-insensitive pattern `list_pending_for_email` already uses for the (cross-org) registration-time lookup, but scoped to a single org and filtered to `status == "pending"` and not-yet-expired.
- `create_invitation` now checks this before creating a new row and returns `409 Conflict` if a pending invite already exists for that org/email.
- A new invite can still be sent once the existing one is revoked or naturally expires — this only blocks a duplicate *pending* invite, not re-inviting after the old one is gone.
- Added tests: rejects a duplicate while pending, case-insensitive match, and that a new invite is allowed after the prior one is revoked or expires.

## Why

Directly closes the gap the issue describes — no schema/behavior change beyond adding the pre-create check; existing single-invite flows are unaffected.

No RBAC/auth/token-encryption/migration changes.

## Test plan
- [x] `pytest tests/test_invitations.py -v` — all 18 tests pass (4 new)
- [ ] CI