### PR TITLE
fix(api): close a check-then-insert race in org-admin bootstrap

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -23,6 +23,7 @@
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
@@ -107,7 +108,17 @@ def _bootstrap_org_admin_from_installation(db: Session, db_user: User, org_login
     then get-or-create the Org/OrgMembership rows. Callers must already have confirmed
     db_user.github_login is set and installation_id is not None. Raises HTTPException on
     any failure to verify (GitHub API error, or the live check saying the caller isn't an
-    admin)."""
+    admin).
+
+    Serialized per org_login via pg_advisory_xact_lock (transaction-scoped, released at
+    the end of this request) -- without it, two concurrent installation syncs for the
+    same org_login (e.g. two admins racing to connect the same brand-new org with
+    different installation_id's) could both pass the live-admin check before either
+    commits, then race to attach to (or duplicate) the same Org row. Matches the pattern
+    /auth/setup uses for its own check-then-insert race (see auth.py's _SETUP_LOCK_KEY).
+    hashtext() maps the arbitrary org_login string to the int4 key pg_advisory_xact_lock
+    expects."""
+    db.execute(text("SELECT pg_advisory_xact_lock(hashtext(:org_login))"), {"org_login": org_login})
     try:
         installation_token = github_app.get_installation_token(installation_id)
         role = github_app.get_org_membership_role(installation_token, org_login, db_user.github_login)

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -253,6 +253,38 @@ def test_sync_org_installation_bootstraps_new_org_for_live_github_admin(db):
     assert membership.role == "admin"
 
 
+def test_bootstrap_org_admin_advisory_lock_serializes_concurrent_holders(_engine):
+    # Regression test for #249: two concurrent installation syncs for the same org_login
+    # (different installation_id's) both live-verify the caller as admin before either
+    # commits its Org/OrgMembership rows -- only a lock closes that window, same pattern
+    # as auth.py's /auth/setup lock (test_setup_advisory_lock_serializes_concurrent_holders).
+    # Verifies the lock primitive itself: a second connection can't acquire the same
+    # hashtext(org_login) key while the first transaction holds it, and can once released.
+    from sqlalchemy import text
+
+    with _engine.connect() as conn1, _engine.connect() as conn2:
+        conn1.begin()
+        conn2.begin()
+        try:
+            got1 = conn1.execute(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:org_login))"), {"org_login": "acme"}
+            ).scalar()
+            got2 = conn2.execute(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:org_login))"), {"org_login": "acme"}
+            ).scalar()
+            assert got1 is True
+            assert got2 is False
+
+            conn1.commit()  # releases conn1's advisory lock
+
+            got2_retry = conn2.execute(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:org_login))"), {"org_login": "acme"}
+            ).scalar()
+            assert got2_retry is True
+        finally:
+            conn2.rollback()
+
+
 def test_sync_org_installation_rejects_live_non_admin(db):
     """The org already exists in Clevis (someone else connected it), the caller has no
     local membership, and the live GitHub check says they're a "member" not "admin" --


### PR DESCRIPTION
## Summary

Closes #249.

`_bootstrap_org_admin_from_installation` (`apps/api/src/routers/installations.py`) live-verifies the caller is a GitHub admin of `org_login` via the App's own installation token, then separately calls `org_repo.get_or_create(db, github_login=org_login)` and `org_membership_repo.get_or_create(...)`. Unlike `/auth/setup`'s explicit `pg_advisory_xact_lock` for its own check-then-insert race (issue #218), there was no locking here — two concurrent installation syncs for the same `org_login` (different `installation_id`s) could both pass the live-admin check before either commits.

## What changed

- Added `db.execute(text("SELECT pg_advisory_xact_lock(hashtext(:org_login))"), ...)` at the top of `_bootstrap_org_admin_from_installation`, serializing this critical section per `org_login` — same pattern `auth.py`'s `_SETUP_LOCK_KEY` uses, but keyed per-org via `hashtext()` instead of one fixed global constant (an org_login is an arbitrary string, not a fixed key).
- Added `test_bootstrap_org_admin_advisory_lock_serializes_concurrent_holders`, mirroring `test_auth.py`'s existing `test_setup_advisory_lock_serializes_concurrent_holders` — verifies the lock primitive itself (a second connection can't acquire the same `hashtext(org_login)` key while the first transaction holds it, and can once released), the same style this repo already uses for testing advisory locks (real Postgres behavior isn't mockable).

## A caveat worth flagging explicitly

`org_repo.get_or_create` and `org_membership_repo.get_or_create` each call `db.commit()` internally, which ends the *Postgres* transaction the advisory lock is scoped to — so the lock doesn't literally span the entire org-then-membership sequence, only the first commit boundary. This matters less than it might look: both repo functions are already independently race-safe via a unique-constraint + `IntegrityError`-rollback-and-refetch fallback, so no data corruption was possible even before this fix — the practical effect of this fix is narrowing the window before that fallback path, reducing wasted live GitHub API calls and `IntegrityError` churn under concurrency, matching the codebase's established locking convention. Fully closing the window across both commits would require restructuring the shared `get_or_create` helpers to not commit internally, which is out of scope for what this issue asked for.

**This PR touches org-admin-bootstrap code** (RBAC-adjacent) — flagging per this repo's guardrails: the change adds a lock acquisition only, no change to what gets verified or written.

No migrations, no RBAC bypass.

## Test plan
- [x] `pytest tests/test_installations.py -v` — all 35 tests pass (1 new)
- [ ] CI