### PR TITLE
fix(api): distinguish a mint failure from no installation at all

### DIFF
--- a/apps/api/src/services/token_resolution.py
+++ b/apps/api/src/services/token_resolution.py
@@ -49,6 +49,24 @@ def _github_app_configured() -> bool:
     return settings.github_app_id is not None and settings.github_app_private_key is not None
 
 
+def _no_token_error(account_login: str, installation_exists: bool, *, personal: bool) -> NoGitHubTokenAvailable:
+    if installation_exists:
+        # Distinct from "never installed" -- the installation row is there, minting just
+        # failed (stale/uninstalled on GitHub's side, or a transient API error; see the
+        # warning _from_installation already logged). Telling the caller to "install" it
+        # sends them down the wrong path when, per the DB, it's already installed.
+        return NoGitHubTokenAvailable(
+            f"A GitHub App installation exists for '{account_login}' but minting a token for it "
+            "failed. The installation may need to be reinstalled, or the GitHub App may be "
+            "misconfigured -- check server logs for details."
+        )
+    install_hint = "Install the GitHub App" if personal else "Install the GitHub App for this organization"
+    return NoGitHubTokenAvailable(
+        f"No GitHub App installation found for '{account_login}' and no token was provided. "
+        f"{install_hint}, or add a personal access token in Settings."
+    )
+
+
 def resolve_org_token(db: Session, *, org_id: int, account_login: str, client_token: str | None) -> str:
     installation = (
         installation_repo.get_for_org(db, org_id=org_id, account_login=account_login)
@@ -60,10 +78,7 @@ def resolve_org_token(db: Session, *, org_id: int, account_login: str, client_to
         return token
     if client_token:
         return client_token
-    raise NoGitHubTokenAvailable(
-        f"No GitHub App installation found for '{account_login}' and no token was provided. "
-        "Install the GitHub App for this organization, or add a personal access token in Settings."
-    )
+    raise _no_token_error(account_login, installation is not None, personal=False)
 
 
 def resolve_personal_token(db: Session, *, owner_user_id: int, account_login: str, client_token: str | None) -> str:
@@ -77,7 +92,4 @@ def resolve_personal_token(db: Session, *, owner_user_id: int, account_login: st
         return token
     if client_token:
         return client_token
-    raise NoGitHubTokenAvailable(
-        f"No GitHub App installation found for '{account_login}' and no token was provided. "
-        "Install the GitHub App, or add a personal access token in Settings."
-    )
+    raise _no_token_error(account_login, installation is not None, personal=True)

--- a/apps/api/tests/test_token_resolution.py
+++ b/apps/api/tests/test_token_resolution.py
@@ -88,8 +88,30 @@ def test_resolve_org_token_falls_back_when_installation_token_mint_fails(db, app
 
 def test_resolve_org_token_raises_when_nothing_available(db, app_configured):
     org = org_repo.get_or_create(db, github_login="acme")
-    with pytest.raises(NoGitHubTokenAvailable):
+    with pytest.raises(NoGitHubTokenAvailable, match="Install the GitHub App"):
         resolve_org_token(db, org_id=org.id, account_login="acme", client_token=None)
+
+
+def test_resolve_org_token_error_distinguishes_mint_failure_from_no_installation(db, app_configured):
+    # Regression test for #250: an installation row exists (App was installed), but
+    # minting a token for it failed -- the error must say so, not tell the caller to
+    # "install" something that's already installed per the DB.
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    request = httpx.Request("POST", "https://api.github.com/app/installations/42/access_tokens")
+    response = httpx.Response(404, request=request)
+    with patch(
+        "src.services.token_resolution.github_app.get_installation_token",
+        side_effect=httpx.HTTPStatusError("not found", request=request, response=response),
+    ):
+        with pytest.raises(NoGitHubTokenAvailable) as exc_info:
+            resolve_org_token(db, org_id=org.id, account_login="acme", client_token=None)
+    message = str(exc_info.value)
+    assert "installation exists" in message
+    assert "minting a token" in message
+    assert "Install the GitHub App" not in message
 
 
 def test_resolve_personal_token_uses_installation_when_connected(db, app_configured):
@@ -105,5 +127,24 @@ def test_resolve_personal_token_uses_installation_when_connected(db, app_configu
 
 def test_resolve_personal_token_raises_when_nothing_available(db, app_configured):
     user = _make_user(db, "shabnam@e.com")
-    with pytest.raises(NoGitHubTokenAvailable):
+    with pytest.raises(NoGitHubTokenAvailable, match="Install the GitHub App"):
         resolve_personal_token(db, owner_user_id=user.id, account_login="shabnam", client_token=None)
+
+
+def test_resolve_personal_token_error_distinguishes_mint_failure_from_no_installation(db, app_configured):
+    user = _make_user(db, "shabnam@e.com")
+    installation_repo.create(
+        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=7, owner_user_id=user.id
+    )
+    request = httpx.Request("POST", "https://api.github.com/app/installations/7/access_tokens")
+    response = httpx.Response(404, request=request)
+    with patch(
+        "src.services.token_resolution.github_app.get_installation_token",
+        side_effect=httpx.HTTPStatusError("not found", request=request, response=response),
+    ):
+        with pytest.raises(NoGitHubTokenAvailable) as exc_info:
+            resolve_personal_token(db, owner_user_id=user.id, account_login="shabnam", client_token=None)
+    message = str(exc_info.value)
+    assert "installation exists" in message
+    assert "minting a token" in message
+    assert "Install the GitHub App" not in message


### PR DESCRIPTION
## Summary

Closes #250.

`token_resolution._from_installation` silently falls back to `None` (then to a client-supplied token, or `NoGitHubTokenAvailable` if there's none of those either) both when there's genuinely no installation row *and* when an installation exists but minting a token for it failed (stale/uninstalled on GitHub's side, or a transient API error — see the warning it already logs). `resolve_org_token`/`resolve_personal_token` couldn't tell these two cases apart, so whoever hits the final error always saw the same generic "No GitHub App installation found... Install the GitHub App..." message — even when the installation row genuinely exists in the DB and just needs reinstalling or the App needs reconfiguring.

## What changed

- Added `_no_token_error(account_login, installation_exists, *, personal)` in `token_resolution.py`, which builds a distinct message when `installation_exists` is `True`: *"A GitHub App installation exists for '{account_login}' but minting a token for it failed. The installation may need to be reinstalled, or the GitHub App may be misconfigured -- check server logs for details."*
- `resolve_org_token`/`resolve_personal_token` now pass whether an installation row was actually found (not just whether minting succeeded) into the error builder.
- Added tests asserting the mint-failure message is distinct from ("does not contain") the "Install the GitHub App" wording, for both the org and personal resolvers.

## Why

Directly closes the gap the issue describes: someone debugging a broken installation would previously be told to "install" something that, per the DB, is already installed — sending them down the wrong path.

**This PR touches token-resolution code**, flagging per this repo's guardrails: purely an error-message/branching change based on data already being looked up (`installation` was already fetched before this change) — no change to what gets minted, returned, or persisted.

No migrations, no RBAC bypass, no behavior change to the success paths.

## Test plan
- [x] `pytest tests/test_token_resolution.py -v` — all 10 tests pass (2 new)
- [x] `pytest tests/test_analytics_cockpit.py tests/test_analytics_my_view.py tests/test_collab.py tests/test_repos.py tests/test_github_events.py -q` — all 110 pass, no regressions (none of these assert on the exact error text)
- [ ] CI