### PR TITLE
fix(worker): fence terminal job writes against a reclaim-and-reclaim race

### DIFF
--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -84,43 +84,53 @@ class ClearActionsCachePayload(BaseModel):
     ref: str | None = None
 
 
-def _mark_done(conn: psycopg.Connection, job_id: int, result: dict) -> None:
-    # WHERE status='processing' guards against a lost update if the reclaim sweep
-    # already reset this job (e.g. this worker stalled past RECLAIM_TIMEOUT_MINUTES)
-    # out from under us — the write becomes a safe no-op instead of clobbering
-    # whatever state/retry_count the reclaim (or another worker) since wrote.
+def _mark_done(conn: psycopg.Connection, job_id: int, result: dict, expected_retry_count: int) -> None:
+    # WHERE status='processing' AND retry_count=expected_retry_count fences this update
+    # against not just a lost update (reclaim already reset this job out from under us --
+    # status no longer 'processing') but also the narrower race where a *second* worker
+    # has since re-claimed the same job: reclaim bumps retry_count when it resets a stale
+    # job back to 'queued', so if that happened and another worker's SELECT ... FOR UPDATE
+    # picked it up again, status is back to 'processing' but retry_count no longer matches
+    # what *this* worker observed when it originally claimed the job. Without the
+    # retry_count check, this stale completion would silently clobber the second worker's
+    # in-flight row (issue #253).
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE jobs SET status='done', result=%s, updated_at=NOW() WHERE id=%s AND status='processing'",
-            (json.dumps(result), job_id),
+            "UPDATE jobs SET status='done', result=%s, updated_at=NOW() "
+            "WHERE id=%s AND status='processing' AND retry_count=%s",
+            (json.dumps(result), job_id, expected_retry_count),
         )
     conn.commit()
 
 
-def _mark_failed(conn: psycopg.Connection, job_id: int, error_text: str) -> None:
+def _mark_failed(conn: psycopg.Connection, job_id: int, error_text: str, expected_retry_count: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s AND status='processing'",
-            (error_text, job_id),
+            "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() "
+            "WHERE id=%s AND status='processing' AND retry_count=%s",
+            (error_text, job_id, expected_retry_count),
         )
     conn.commit()
 
 
 def _requeue_for_retry(conn: psycopg.Connection, job_id: int, retry_count: int, error_text: str) -> None:
+    # `retry_count` here is the value this worker observed at claim time -- same fencing
+    # reasoning as _mark_done/_mark_failed above, checked against the ORIGINAL value
+    # before it's incremented into new_count below.
     new_count = retry_count + 1
     if new_count > MAX_RETRIES:
         with conn.cursor() as cur:
             cur.execute(
                 "UPDATE jobs SET status='failed', retry_count=%s, result=%s, updated_at=NOW() "
-                "WHERE id=%s AND status='processing'",
-                (new_count, f"exceeded max retry attempts ({MAX_RETRIES}): {error_text}", job_id),
+                "WHERE id=%s AND status='processing' AND retry_count=%s",
+                (new_count, f"exceeded max retry attempts ({MAX_RETRIES}): {error_text}", job_id, retry_count),
             )
     else:
         with conn.cursor() as cur:
             cur.execute(
                 "UPDATE jobs SET status='queued', retry_count=%s, result=%s, updated_at=NOW() "
-                "WHERE id=%s AND status='processing'",
-                (new_count, error_text, job_id),
+                "WHERE id=%s AND status='processing' AND retry_count=%s",
+                (new_count, error_text, job_id, retry_count),
             )
     conn.commit()
 
@@ -129,7 +139,7 @@ def process_job(conn: psycopg.Connection, job_id: int, job_type: str, payload_ra
     handler = JOB_HANDLERS.get(job_type)
     if handler is None:
         log.error("job %d has no handler registered for job_type %r", job_id, job_type)
-        _mark_failed(conn, job_id, f"no handler registered for job_type {job_type!r}")
+        _mark_failed(conn, job_id, f"no handler registered for job_type {job_type!r}", retry_count)
         return
     try:
         handler(conn, job_id, payload_raw, retry_count)
@@ -139,7 +149,7 @@ def process_job(conn: psycopg.Connection, job_id: int, job_type: str, payload_ra
         # until the reclaim sweep picks it up, up to RECLAIM_TIMEOUT_MINUTES later,
         # instead of failing/retrying immediately.
         log.error("job %d hit an unexpected error: %s", job_id, error)
-        _mark_failed(conn, job_id, sanitize_error(error))
+        _mark_failed(conn, job_id, sanitize_error(error), retry_count)
 
 
 def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_raw: str, retry_count: int) -> None:
@@ -147,14 +157,14 @@ def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_r
         payload = ClearActionsCachePayload.model_validate_json(payload_raw)
     except ValidationError as error:
         log.error("job %d has an invalid payload: %s", job_id, error)
-        _mark_failed(conn, job_id, sanitize_error(error))
+        _mark_failed(conn, job_id, sanitize_error(error), retry_count)
         return
 
     try:
         token = decrypt_job_token(payload.token, settings.job_secret_key.get_secret_value())
     except Exception as error:
         log.error("job %d failed to decrypt its token: %s", job_id, error)
-        _mark_failed(conn, job_id, sanitize_error(error))
+        _mark_failed(conn, job_id, sanitize_error(error), retry_count)
         return
 
     base = settings.github_api_base
@@ -185,10 +195,10 @@ def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_r
 
     if resp.status_code >= 300:
         log.error("job %d failed: GitHub API error %d", job_id, resp.status_code)
-        _mark_failed(conn, job_id, f"GitHub API error: {resp.status_code}")
+        _mark_failed(conn, job_id, f"GitHub API error: {resp.status_code}", retry_count)
         return
 
-    _mark_done(conn, job_id, {"ok": True, "status": resp.status_code})
+    _mark_done(conn, job_id, {"ok": True, "status": resp.status_code}, retry_count)
     log.info("job %d done", job_id)
 
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -101,7 +101,9 @@ def test_process_job_marks_failed_when_token_decryption_fails():
 
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
+    assert "retry_count=%s" in sql
     assert params[1] == 3
+    assert params[2] == 0
     assert conn.committed is True
 
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -110,9 +110,10 @@ def test_process_job_requeues_on_5xx_http_error():
 
     sql, params = conn._cursor.calls[0]
     assert "status='queued'" in sql
-    new_retry_count, result_text, job_id = params
+    new_retry_count, result_text, job_id, expected_retry_count = params
     assert new_retry_count == 1
     assert job_id == 6
+    assert expected_retry_count == 0  # fences against a job reclaimed/re-claimed since this worker started
     assert "GitHub API error" in result_text
     assert conn.committed is True
 
@@ -133,9 +134,10 @@ def test_process_job_requeues_on_httpx_request_error():
 
     sql, params = conn._cursor.calls[0]
     assert "status='queued'" in sql
-    new_retry_count, result_text, job_id = params
+    new_retry_count, result_text, job_id, expected_retry_count = params
     assert new_retry_count == 3  # incremented from the passed-in retry_count=2
     assert job_id == 7
+    assert expected_retry_count == 2
     assert "connection refused" in result_text
     assert conn.committed is True
 
@@ -157,9 +159,10 @@ def test_process_job_fails_once_retry_cap_exceeded():
 
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
-    new_retry_count, result_text, job_id = params
+    new_retry_count, result_text, job_id, expected_retry_count = params
     assert new_retry_count == MAX_RETRIES + 1
     assert job_id == 8
+    assert expected_retry_count == MAX_RETRIES
     assert "exceeded max retry attempts" in result_text
     assert conn.committed is True
 
@@ -294,6 +297,62 @@ def test_process_job_terminal_write_is_a_noop_if_reclaimed_out_from_under_it(wor
         cur.execute("SELECT status, retry_count FROM jobs WHERE id = %s", (job_id,))
         final_status, final_retry_count = cur.fetchone()
     assert final_status == "queued"
+    assert final_retry_count == 1
+
+
+def test_process_job_terminal_write_is_a_noop_if_a_second_worker_reclaimed_and_reprocessed_it(worker_db):
+    """Narrower race than the reclaim-to-'queued' case above (#253): the reclaim sweep
+    resets this job to 'queued' (bumping retry_count) AND a second worker's own
+    SELECT ... FOR UPDATE picks it back up, setting status back to 'processing' before
+    this (first) worker's stale terminal write runs. WHERE status='processing' alone
+    would then incorrectly match again -- the retry_count fence is what actually
+    prevents this worker's stale completion from clobbering the second worker's
+    in-flight row."""
+    conn, created_ids = worker_db
+    stale = datetime.now(timezone.utc) - timedelta(minutes=RECLAIM_TIMEOUT_MINUTES + 5)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO jobs (job_type, payload, status, retry_count, updated_at)
+            VALUES ('github.clear_actions_cache', '{}', 'processing', 0, %s)
+            RETURNING id
+            """,
+            (stale,),
+        )
+        job_id = cur.fetchone()[0]
+    conn.commit()
+    created_ids.append(job_id)
+
+    # Reclaim sweep fires (job -> 'queued', retry_count -> 1), then a second worker's
+    # own claim query picks it back up (job -> 'processing' again, same bumped retry_count).
+    _reclaim_stale_jobs(conn)
+    with conn.cursor() as cur:
+        cur.execute("UPDATE jobs SET status = 'processing', updated_at = NOW() WHERE id = %s", (job_id,))
+    conn.commit()
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, retry_count FROM jobs WHERE id = %s", (job_id,))
+        reprocessed_status, reprocessed_retry_count = cur.fetchone()
+    assert reprocessed_status == "processing"
+    assert reprocessed_retry_count == 1
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.text = ""
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        # This (first) worker's in-memory retry_count is stale (captured before the
+        # reclaim) -- its completion must not touch the row the second worker now owns.
+        process_job(conn, job_id, "github.clear_actions_cache", _payload(), retry_count=0)
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT status, retry_count FROM jobs WHERE id = %s", (job_id,))
+        final_status, final_retry_count = cur.fetchone()
+    assert final_status == "processing"
     assert final_retry_count == 1
 
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -91,6 +91,20 @@ def test_process_job_marks_failed_on_4xx_http_error():
     assert conn.committed is True
 
 
+def test_process_job_marks_failed_when_token_decryption_fails():
+    """A payload with a token that fails to decrypt is a permanent failure, not a retry."""
+    conn = _FakeConn()
+
+    payload = json.dumps({"owner": "acme", "repo": "demo", "token": "not-a-valid-encrypted-token"})
+
+    process_job(conn, 3, "github.clear_actions_cache", payload)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert params[1] == 3
+    assert conn.committed is True
+
+
 def test_process_job_requeues_on_5xx_http_error():
     """5xx is presumed transient (GitHub-side issue) — worth a bounded retry, unlike 4xx."""
     conn = _FakeConn()


### PR DESCRIPTION
## Summary

Closes #253.

`_mark_done`/`_mark_failed` guard their terminal update with `WHERE status='processing'`. This protects the simple case (reclaim sweep reset the job back to `'queued'`/`'failed'` -- status no longer matches, safe no-op). It doesn't protect a narrower race: the reclaim sweep resets a stale job to `'queued'` (bumping `retry_count`) **and** a second worker's own `SELECT ... FOR UPDATE SKIP LOCKED` picks it back up before the first (stale, still in-flight) worker's terminal write runs. By then `status` is `'processing'` again -- from the *second* worker's claim -- so the guard alone incorrectly matches, letting the first worker's stale completion clobber the second worker's actively-processing row (mislabeling it done/failed while the second worker is still mid-flight, or double-hitting GitHub's cache-clear endpoint for the same job).

## What changed

- `_mark_done`, `_mark_failed`, and `_requeue_for_retry` now also require `retry_count` to equal the value this worker observed when it originally claimed the job (already available everywhere via the existing `retry_count` parameter threaded through `process_job`/handlers). The reclaim sweep always increments `retry_count` when it resets a job, so a second worker's re-claim carries a `retry_count` the first worker's stale write no longer matches -- the update becomes a no-op instead of clobbering the second worker's row.
- No schema change: `retry_count` already existed specifically as a fencing/dedup signal, it just wasn't checked on the terminal-write side, only used to compute the next retry count.
- Updated the existing `_requeue_for_retry`-touching tests for the new 4th SQL param, and added `test_process_job_terminal_write_is_a_noop_if_a_second_worker_reclaimed_and_reprocessed_it`, which reproduces the actual scenario the issue describes (reclaim + re-claim, not just reclaim alone) and asserts the second worker's `processing` row is left untouched.

## Why

Directly closes the narrow window the issue flagged as an accepted trade-off in the original heartbeat design (#215) -- worth a tracked, deliberate fix given how sensitive double-processing a privileged job (clearing GitHub Actions caches) is, even though it's low-probability in practice.

No migrations, no RBAC bypass, no behavior change to the normal (non-racing) success/failure/retry paths.

## Test plan
- [x] `pytest apps/worker/tests/ -v` — all 35 tests pass (1 new, 3 updated for the new param)
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale job results from overwriting work reclaimed by another worker.
  * Improved job retry and completion handling by validating the latest retry state.
  * Jobs with invalid tokens or unexpected errors are now marked failed with a sanitized error message.
  * GitHub action failures now correctly record non-success responses and preserve job state integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->