### PR TITLE
fix(api,ui): audit-log gap for GitHub App connects, silent errors on Audit/Jobs

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import UserOut, require_auth
 from src.core.db import Org, OrgMembership, User, get_db
 from src.core.rbac import OrgContext, require_org_role
-from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo
 from src.schemas.installation import (
     InstallationLookupOut,
     InstallationOut,
@@ -179,6 +179,13 @@ def sync_org_installation(
         installation_id=payload.installation_id,
         org_id=org.id,
     )
+    audit_repo.write(
+        db,
+        actor=user.email,
+        action="installation.connected",
+        target=org_login,
+        payload={"account_type": payload.account_type, "installation_id": payload.installation_id},
+    )
     return {"synced": True, "token_ref": row.token_ref}
 
 
@@ -220,5 +227,12 @@ def sync_personal_installation(
         auth_mode=payload.auth_mode,
         installation_id=payload.installation_id,
         owner_user_id=user.id,
+    )
+    audit_repo.write(
+        db,
+        actor=user.email,
+        action="installation.connected.personal",
+        target=payload.account_login,
+        payload={"account_type": payload.account_type, "installation_id": payload.installation_id},
     )
     return {"synced": True, "token_ref": row.token_ref}

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -1,5 +1,6 @@
 """Tests for org-scoped and personal installation endpoints."""
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -115,6 +116,8 @@ def test_sync_org_installation_writes_audit_log(db, acme_org):
     assert len(logs) == 1
     assert logs[0].target == "acme"
     assert logs[0].actor == acme_org["admin"].email
+    payload = json.loads(logs[0].payload)
+    assert payload == {"account_type": "Organization", "installation_id": 7}
 
 
 def test_personal_installations_scoped_to_self(db):
@@ -160,6 +163,8 @@ def test_sync_personal_installation_writes_audit_log(db):
     assert len(logs) == 1
     assert logs[0].target == "shabnam"
     assert logs[0].actor == me.email
+    payload = json.loads(logs[0].payload)
+    assert payload == {"account_type": "User", "installation_id": 3}
 
 
 def test_sync_personal_installation_requires_linked_github_account(db):

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import User, get_db
+from src.core.db import AuditLog, User, get_db
 from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.installations import router as inst_router
 from src.services import github_app
@@ -102,6 +102,21 @@ def test_sync_org_installation_admin_ok(db, acme_org):
     assert resp.json()["synced"] is True
 
 
+def test_sync_org_installation_writes_audit_log(db, acme_org):
+    # Regression test: connecting a GitHub App installation used to write no audit
+    # entry at all, so the Audit page stayed empty even for a workspace admin who'd
+    # genuinely connected an org.
+    with _mock_installation("acme", "Organization"):
+        _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    logs = db.query(AuditLog).filter(AuditLog.action == "installation.connected").all()
+    assert len(logs) == 1
+    assert logs[0].target == "acme"
+    assert logs[0].actor == acme_org["admin"].email
+
+
 def test_personal_installations_scoped_to_self(db):
     me = _make_user(db, "shabnam@e.com")
     someone_else = _make_user(db, "someoneelse@e.com")
@@ -132,6 +147,19 @@ def test_sync_personal_installation(db):
         )
     assert resp.status_code == 200
     assert resp.json()["synced"] is True
+
+
+def test_sync_personal_installation_writes_audit_log(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    with _mock_installation("shabnam", "User"):
+        _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
+    logs = db.query(AuditLog).filter(AuditLog.action == "installation.connected.personal").all()
+    assert len(logs) == 1
+    assert logs[0].target == "shabnam"
+    assert logs[0].actor == me.email
 
 
 def test_sync_personal_installation_requires_linked_github_account(db):

--- a/apps/ui/app/audit/page.tsx
+++ b/apps/ui/app/audit/page.tsx
@@ -4,14 +4,21 @@ import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { EmptyStateInline } from "@/components/empty-state"
+import { SectionError } from "@/components/section-error"
 import { api } from "@/lib/api/client"
 
-const ACTION_TYPES = ["", "cache.clear", "cache.clear.dry_run"]
+const ACTION_TYPES = [
+  "",
+  "cache.clear",
+  "cache.clear.dry_run",
+  "installation.connected",
+  "installation.connected.personal",
+]
 
 export default function AuditPage() {
   const [actionFilter, setActionFilter] = useState("")
 
-  const { data: logs = [], isLoading } = useQuery({
+  const { data: logs = [], isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ["audit", actionFilter],
     queryFn: () => api.audit.list(actionFilter || undefined),
     refetchInterval: 30_000,
@@ -43,6 +50,12 @@ export default function AuditPage() {
           <div className="px-4 py-8">
             <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
           </div>
+        ) : isError ? (
+          <SectionError
+            message={error instanceof Error ? error.message : "Failed to load audit events."}
+            onRetry={() => refetch()}
+            retrying={isFetching}
+          />
         ) : logs.length === 0 ? (
           <EmptyStateInline noun="audit events" qualifier={actionFilter || undefined} />
         ) : (

--- a/apps/ui/app/audit/page.tsx
+++ b/apps/ui/app/audit/page.tsx
@@ -42,7 +42,7 @@ export default function AuditPage() {
                 <option key={a} value={a}>{a}</option>
               ))}
             </select>
-            {!isLoading && <span className="stat-chip">{logs.length} entries</span>}
+            {!isLoading && !isError && <span className="stat-chip">{logs.length} entries</span>}
           </div>
         </div>
 

--- a/apps/ui/app/jobs/page.tsx
+++ b/apps/ui/app/jobs/page.tsx
@@ -43,7 +43,7 @@ export default function JobsPage() {
       <div className="card">
         <div className="px-4 py-3 border-b border-border flex items-center justify-between">
           <span className="section-label">Jobs</span>
-          {!isLoading && (
+          {!isLoading && !isError && (
             <span className="stat-chip">{jobs.length} total</span>
           )}
         </div>

--- a/apps/ui/app/jobs/page.tsx
+++ b/apps/ui/app/jobs/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { EmptyStateInline } from "@/components/empty-state"
+import { SectionError } from "@/components/section-error"
 import { api } from "@/lib/api/client"
 import type { JobOut } from "@/lib/api/types"
 
@@ -12,7 +13,7 @@ export default function JobsPage() {
   const searchParams = useSearchParams()
   const highlightId = Number(searchParams.get("id")) || null
 
-  const { data: jobs = [], isLoading } = useQuery({
+  const { data: jobs = [], isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ["jobs"],
     queryFn: api.jobs.list,
     refetchInterval: 10_000,
@@ -51,6 +52,12 @@ export default function JobsPage() {
           <div className="px-4 py-8">
             <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
           </div>
+        ) : isError ? (
+          <SectionError
+            message={error instanceof Error ? error.message : "Failed to load jobs."}
+            onRetry={() => refetch()}
+            retrying={isFetching}
+          />
         ) : jobs.length === 0 ? (
           <EmptyStateInline noun="jobs" />
         ) : (

--- a/apps/ui/tests/components/audit-page.test.tsx
+++ b/apps/ui/tests/components/audit-page.test.tsx
@@ -48,6 +48,9 @@ describe("AuditPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
     expect(screen.queryByText(/No audit events/)).not.toBeInTheDocument();
+    // Regression test (CodeRabbit finding): a misleading "0 entries" chip must not
+    // render alongside the error message.
+    expect(screen.queryByText(/entries$/)).not.toBeInTheDocument();
 
     auditListMock.mockResolvedValueOnce([]);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));

--- a/apps/ui/tests/components/audit-page.test.tsx
+++ b/apps/ui/tests/components/audit-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -47,8 +47,18 @@ describe("AuditPage", () => {
     auditListMock.mockRejectedValue(new Error("Workspace admin access required"));
     renderPage();
     await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(screen.queryByText(/No audit events/)).not.toBeInTheDocument();
+
+    auditListMock.mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No audit events/)).toBeInTheDocument());
+    expect(auditListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    auditListMock.mockRejectedValue("boom");
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Failed to load audit events.")).toBeInTheDocument());
   });
 
   it("shows the empty state only when the query genuinely succeeds with no rows", async () => {

--- a/apps/ui/tests/components/audit-page.test.tsx
+++ b/apps/ui/tests/components/audit-page.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const auditListMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    audit: { list: (...args: unknown[]) => auditListMock(...args) },
+  },
+}));
+
+import AuditPage from "@/app/audit/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuditPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AuditPage", () => {
+  beforeEach(() => {
+    auditListMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders audit log entries", async () => {
+    auditListMock.mockResolvedValue([
+      { id: 1, actor: "u@e.com", action: "installation.connected", target: "acme", payload: "{}", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText("installation.connected")).toBeInTheDocument());
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    // Regression test: this page used to default logs to [] on any query error and never
+    // checked isError, so a real 403/500 rendered identically to "genuinely zero rows".
+    auditListMock.mockRejectedValue(new Error("Workspace admin access required"));
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.queryByText(/No audit events/)).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    auditListMock.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/No audit events/)).toBeInTheDocument());
+  });
+});

--- a/apps/ui/tests/components/jobs-page.test.tsx
+++ b/apps/ui/tests/components/jobs-page.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const jobsListMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    jobs: { list: (...args: unknown[]) => jobsListMock(...args) },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import JobsPage from "@/app/jobs/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <JobsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("JobsPage", () => {
+  beforeEach(() => {
+    jobsListMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders jobs", async () => {
+    jobsListMock.mockResolvedValue([
+      { id: 1, job_type: "github.clear_actions_cache", status: "done", result: "ok", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText("github.clear_actions_cache")).toBeInTheDocument());
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    // Regression test: this page used to default jobs to [] on any query error and never
+    // checked isError, so a real 403/500 rendered identically to "genuinely zero rows".
+    jobsListMock.mockRejectedValue(new Error("Workspace admin access required"));
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.queryByText(/No jobs/)).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    jobsListMock.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/No jobs/)).toBeInTheDocument());
+  });
+});

--- a/apps/ui/tests/components/jobs-page.test.tsx
+++ b/apps/ui/tests/components/jobs-page.test.tsx
@@ -52,6 +52,9 @@ describe("JobsPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
     expect(screen.queryByText(/No jobs/)).not.toBeInTheDocument();
+    // Regression test (CodeRabbit finding): a misleading "0 total" chip must not
+    // render alongside the error message.
+    expect(screen.queryByText(/total$/)).not.toBeInTheDocument();
 
     jobsListMock.mockResolvedValueOnce([]);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));

--- a/apps/ui/tests/components/jobs-page.test.tsx
+++ b/apps/ui/tests/components/jobs-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -51,8 +51,18 @@ describe("JobsPage", () => {
     jobsListMock.mockRejectedValue(new Error("Workspace admin access required"));
     renderPage();
     await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(screen.queryByText(/No jobs/)).not.toBeInTheDocument();
+
+    jobsListMock.mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No jobs/)).toBeInTheDocument());
+    expect(jobsListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    jobsListMock.mockRejectedValue("boom");
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Failed to load jobs.")).toBeInTheDocument());
   });
 
   it("shows the empty state only when the query genuinely succeeds with no rows", async () => {


### PR DESCRIPTION
## Summary
Investigated why the Audit log and Job queue pages showed an empty state for a confirmed workspace-admin account (verified via JWT: `is_workspace_admin: true`, `id: 1`) — ruling out a permission bug. The real cause: those tables were legitimately near-empty because:
- Installing/connecting a GitHub App installation never wrote an `audit_logs` row at all (`installations.py` had zero `audit_repo` references).
- No non-dry-run cache clear had been queued yet, so `jobs` was also empty.

## Changes
- **`installations.py`**: `sync_org_installation` and `sync_personal_installation` now write an audit log entry (`installation.connected` / `installation.connected.personal`) on success, matching the existing `cache.clear`/`token.resolve` pattern. Added both to the Audit page's action-type filter dropdown.
- **`audit/page.tsx` / `jobs/page.tsx`**: both previously defaulted their query's `data` to `[]` and never checked `isError` — a real failure (e.g. a genuine 403) would have rendered identically to "genuinely zero rows." This masking is exactly what obscured the initial permission-bug hypothesis during diagnosis. Now surfaces a `SectionError` with retry, matching the pattern already used in Settings' `ConnectedOrgsSection`.

No schema/migration change. No RBAC changes (existing `require_workspace_admin` gate on both endpoints is untouched).

## Test plan
- [x] `pytest -q` — 571 passed, including new regression tests confirming both sync endpoints write the expected `AuditLog` row
- [x] `diff-cover` against `origin/main` — 100% on changed lines
- [x] `bun run check` (typecheck + lint + build)
- [x] New UI tests for Audit/Jobs pages: renders real rows, shows `SectionError`+retry on query failure (not a fake empty state), shows the empty state only on a genuine zero-row success

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installation connections now generate audit log entries for organization and personal installations.
  - Audit history now supports richer action filtering.
  - Audit and Jobs pages now show clear load errors with a Retry action.
- **Bug Fixes**
  - Empty states are displayed only after a successful load that returns no results.
- **Tests**
  - Added/updated coverage for installation audit logging and for Audit/Jobs page loading, error, and retry behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->