### PR TITLE
Build out My PRs, My Reviews, My Issues, and Releases pages

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import anyio
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
@@ -20,6 +20,8 @@ from src.schemas.analytics import (
     CockpitResponse,
     IssueSummary,
     MilestoneSummary,
+    MyIssueListResponse,
+    MyPrListResponse,
     MyViewResponse,
     OrgEventSummary,
     PRSummary,
@@ -617,4 +619,115 @@ async def my_view(
         review_requests=_pr_summaries(review_requests_raw),
         assigned_issues=_issue_summaries(assigned_issues_raw),
         my_recent_runs=my_recent_runs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# My PRs / My Reviews / My Issues -- dedicated paginated lists behind the "My
+# PRs"/"My Reviews"/"My Issues" pages. Deliberately separate from my_view above:
+# my_view is a fixed top-10 "glance" widget for the Overview page, while these
+# support real Prev/Next pagination via GitHub search's total_count. Kept as
+# their own functions/routes rather than reusing _search_items so my_view's
+# existing behavior and tests aren't disturbed.
+# ---------------------------------------------------------------------------
+
+# GitHub's search API only ever returns the first 1000 results for a query
+# (regardless of total_count) -- page*per_page beyond that always 422s, so we
+# short-circuit to an empty page instead of passing that error through.
+_MAX_SEARCH_RESULTS = 1000
+
+
+def _search_items_page(client: GitHubClient, query: str, page: int, per_page: int) -> tuple[list[dict], int]:
+    try:
+        result = client.request("GET", "/search/issues", params={"q": query, "per_page": per_page, "page": page})
+        if not isinstance(result, dict):
+            return [], 0
+        return result.get("items", []), result.get("total_count", 0)
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        return [], 0
+
+
+async def _my_items_list(
+    db: Session,
+    user: UserOut,
+    owner: str,
+    x_github_token: str | None,
+    query_template: str,
+    mapper,
+    response_cls,
+    page: int,
+    per_page: int,
+):
+    try:
+        token = await anyio.to_thread.run_sync(
+            lambda: resolve_owner_token(db, user_id=user.id, owner=owner, client_token=x_github_token)
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    client = GitHubClient(token)
+    login = await anyio.to_thread.run_sync(lambda: _my_login(client))
+    if login is None or page * per_page > _MAX_SEARCH_RESULTS:
+        return response_cls(page=page, per_page=per_page)
+
+    query = query_template.format(login=login)
+    items_raw, total_count = await anyio.to_thread.run_sync(lambda: _search_items_page(client, query, page, per_page))
+    return response_cls(items=mapper(items_raw), total_count=total_count, page=page, per_page=per_page)
+
+
+@router.get("/me/github/my-prs", response_model=MyPrListResponse)
+async def my_prs(
+    owner: str,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=100),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    return await _my_items_list(
+        db, user, owner, x_github_token, "is:pr is:open author:{login}", _pr_summaries, MyPrListResponse, page, per_page
+    )
+
+
+@router.get("/me/github/my-reviews", response_model=MyPrListResponse)
+async def my_reviews(
+    owner: str,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=100),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    return await _my_items_list(
+        db,
+        user,
+        owner,
+        x_github_token,
+        "is:pr is:open review-requested:{login}",
+        _pr_summaries,
+        MyPrListResponse,
+        page,
+        per_page,
+    )
+
+
+@router.get("/me/github/my-issues", response_model=MyIssueListResponse)
+async def my_issues(
+    owner: str,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=100),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+    x_github_token: str | None = Header(default=None),
+):
+    return await _my_items_list(
+        db,
+        user,
+        owner,
+        x_github_token,
+        "is:issue is:open assignee:{login}",
+        _issue_summaries,
+        MyIssueListResponse,
+        page,
+        per_page,
     )

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -667,12 +667,20 @@ async def _my_items_list(
 
     client = GitHubClient(token)
     login = await anyio.to_thread.run_sync(lambda: _my_login(client))
-    if login is None or page * per_page > _MAX_SEARCH_RESULTS:
+    if login is None:
         return response_cls(page=page, per_page=per_page)
+    if page * per_page > _MAX_SEARCH_RESULTS:
+        # Beyond GitHub's reachable window -- report the capped total (not 0) so
+        # page/lastPage math stays consistent instead of regressing to "Page N of 1".
+        return response_cls(total_count=_MAX_SEARCH_RESULTS, page=page, per_page=per_page)
 
     query = query_template.format(login=login)
     items_raw, total_count = await anyio.to_thread.run_sync(lambda: _search_items_page(client, query, page, per_page))
-    return response_cls(items=mapper(items_raw), total_count=total_count, page=page, per_page=per_page)
+    # Cap the reported total to what's actually reachable, so the UI's Next button
+    # disables at the true boundary instead of this branch ever being hit from normal paging.
+    return response_cls(
+        items=mapper(items_raw), total_count=min(total_count, _MAX_SEARCH_RESULTS), page=page, per_page=per_page
+    )
 
 
 @router.get("/me/github/my-prs", response_model=MyPrListResponse)

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -115,3 +115,17 @@ class MyViewResponse(BaseModel):
     review_requests: list[PRSummary] = []
     assigned_issues: list[IssueSummary] = []
     my_recent_runs: list[RunSummaryLite] = []
+
+
+class MyPrListResponse(BaseModel):
+    items: list[PRSummary] = []
+    total_count: int = 0
+    page: int = 1
+    per_page: int = 25
+
+
+class MyIssueListResponse(BaseModel):
+    items: list[IssueSummary] = []
+    total_count: int = 0
+    page: int = 1
+    per_page: int = 25

--- a/apps/api/tests/test_analytics_my_items.py
+++ b/apps/api/tests/test_analytics_my_items.py
@@ -1,0 +1,233 @@
+"""Tests for the My PRs / My Reviews / My Issues paginated list endpoints."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.routers.analytics import router
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "myitems@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
+    a = FastAPI()
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture()
+def http(app):
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+def test_requires_auth(db, path):
+    a = FastAPI()
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    resp = TestClient(a).get(f"{path}?owner=acme")
+    assert resp.status_code == 401
+
+
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+def test_no_token_available_returns_400(http, path):
+    resp = http.get(f"{path}?owner=acme")
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+def test_degrades_to_empty_when_login_unresolvable(http, path):
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
+        resp = http.get(f"{path}?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"items": [], "total_count": 0, "page": 1, "per_page": 25}
+
+
+def test_my_prs_success_returns_pagination_fields(http):
+    pr_item = {
+        "number": 12,
+        "title": "Fix bug",
+        "repository_url": "https://api.github.com/repos/acme/api",
+        "html_url": "https://github.com/acme/api/pull/12",
+        "updated_at": "2026-07-20T00:00:00Z",
+    }
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            assert "author:octocat" in params["q"]
+            assert params["page"] == 2
+            assert params["per_page"] == 10
+            return {"items": [pr_item], "total_count": 37}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-prs?owner=acme&page=2&per_page=10")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_count"] == 37
+    assert body["page"] == 2
+    assert body["per_page"] == 10
+    assert len(body["items"]) == 1
+    assert body["items"][0]["repository"] == "acme/api"
+
+
+def test_my_reviews_uses_review_requested_query(http):
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            assert "review-requested:octocat" in params["q"]
+            return {"items": [], "total_count": 0}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-reviews?owner=acme")
+
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+def test_my_issues_success_maps_issue_summaries(http):
+    issue_item = {
+        "number": 3,
+        "title": "Investigate flake",
+        "repository_url": "https://api.github.com/repos/acme/worker",
+        "html_url": "https://github.com/acme/worker/issues/3",
+        "updated_at": "2026-07-19T00:00:00Z",
+    }
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            assert "assignee:octocat" in params["q"]
+            return {"items": [issue_item], "total_count": 1}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-issues?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"][0]["repository"] == "acme/worker"
+
+
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+@pytest.mark.parametrize("params", ["per_page=101", "per_page=0", "page=0"])
+def test_pagination_params_are_validated(http, path, params):
+    resp = http.get(f"{path}?owner=acme&{params}")
+    assert resp.status_code == 422
+
+
+def test_page_times_per_page_over_1000_returns_empty_without_calling_github(http):
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = lambda method, path, params=None: (
+            {"login": "octocat"} if path == "/user" else pytest.fail("should not call /search/issues")
+        )
+        resp = http.get("/me/github/my-prs?owner=acme&page=11&per_page=100")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"items": [], "total_count": 0, "page": 11, "per_page": 100}
+
+
+def test_search_failure_degrades_to_empty_not_500(http):
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            raise httpx.HTTPStatusError(
+                "boom",
+                request=httpx.Request("GET", "https://api.github.com/search/issues"),
+                response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/search/issues")),
+            )
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-prs?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total_count"] == 0
+
+
+def test_non_dict_search_response_degrades_to_empty(http):
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            return {"login": "octocat"}
+        if path == "/search/issues":
+            return []
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-prs?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total_count"] == 0
+
+
+def test_falls_back_to_client_supplied_token_header(http):
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        resp = http.get("/me/github/my-prs?owner=acme", headers={"X-GitHub-Token": "ghp_client"})
+
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []

--- a/apps/api/tests/test_analytics_my_items.py
+++ b/apps/api/tests/test_analytics_my_items.py
@@ -175,7 +175,9 @@ def test_page_times_per_page_over_1000_returns_empty_without_calling_github(http
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"items": [], "total_count": 0, "page": 11, "per_page": 100}
+    # total_count is capped at the reachable max (not 0) so page/lastPage math on the
+    # client stays consistent instead of regressing once paging crosses GitHub's window.
+    assert body == {"items": [], "total_count": 1000, "page": 11, "per_page": 100}
 
 
 def test_search_failure_degrades_to_empty_not_500(http):

--- a/apps/ui/app/my/issues/layout.tsx
+++ b/apps/ui/app/my/issues/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+export const metadata = { title: "My Issues · clevis" }
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/ui/app/my/issues/page.tsx
+++ b/apps/ui/app/my/issues/page.tsx
@@ -1,13 +1,68 @@
-export const metadata = { title: "My Issues · clevis" }
+"use client"
 
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+import { MyItemsList } from "@/components/my-items-list"
+import { api } from "@/lib/api/client"
+
+const PER_PAGE = 25
 
 export default function MyIssuesPage() {
+  const [org, setOrg] = useState("")
+  const [orgChecked, setOrgChecked] = useState(false)
+  const [page, setPage] = useState(1)
+  useEffect(() => {
+    setOrg(localStorage.getItem("default_org") || "")
+    setOrgChecked(true)
+  }, [])
+
+  const resolveQuery = useQuery({
+    queryKey: ["tokens.resolve", org],
+    queryFn: () => api.tokens.resolve(org),
+    enabled: org.trim().length > 2,
+    retry: false,
+  })
+
+  const myIssuesQuery = useQuery({
+    queryKey: ["analytics.my-issues", org, page],
+    queryFn: () => api.analytics.myIssues(org, page, PER_PAGE, resolveQuery.data?.token),
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    retry: false,
+  })
+
   return (
     <>
       <PageHeader title="My Issues" description="Issues assigned to you." />
-      <EmptyStatePage message="My issues — coming soon" />
+
+      {orgChecked && !org && (
+        <div className="card mb-6">
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No default organization selected yet — this page has nothing to query. Set one in{" "}
+            <Link href="/settings" className="text-primary hover:underline">Settings</Link>, or connect a GitHub
+            org there first if you haven&rsquo;t already.
+          </p>
+        </div>
+      )}
+
+      {org && (
+        <MyItemsList
+          items={myIssuesQuery.data?.items ?? []}
+          isLoading={myIssuesQuery.isLoading || resolveQuery.isLoading}
+          isError={myIssuesQuery.isError}
+          errorMessage={
+            myIssuesQuery.error instanceof Error ? myIssuesQuery.error.message : "Failed to load your assigned issues."
+          }
+          onRetry={() => myIssuesQuery.refetch()}
+          retrying={myIssuesQuery.isFetching}
+          emptyNoun="assigned issues"
+          totalCount={myIssuesQuery.data?.total_count ?? 0}
+          page={page}
+          perPage={PER_PAGE}
+          onPageChange={setPage}
+        />
+      )}
     </>
   )
 }

--- a/apps/ui/app/my/issues/page.tsx
+++ b/apps/ui/app/my/issues/page.tsx
@@ -28,9 +28,11 @@ export default function MyIssuesPage() {
   const myIssuesQuery = useQuery({
     queryKey: ["analytics.my-issues", org, page],
     queryFn: () => api.analytics.myIssues(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
     retry: false,
   })
+
+  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -50,12 +52,14 @@ export default function MyIssuesPage() {
         <MyItemsList
           items={myIssuesQuery.data?.items ?? []}
           isLoading={myIssuesQuery.isLoading || resolveQuery.isLoading}
-          isError={myIssuesQuery.isError}
+          isError={tokenFailed || myIssuesQuery.isError}
           errorMessage={
-            myIssuesQuery.error instanceof Error ? myIssuesQuery.error.message : "Failed to load your assigned issues."
+            tokenFailed
+              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
+              : (myIssuesQuery.error instanceof Error ? myIssuesQuery.error.message : "Failed to load your assigned issues.")
           }
-          onRetry={() => myIssuesQuery.refetch()}
-          retrying={myIssuesQuery.isFetching}
+          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myIssuesQuery.refetch())}
+          retrying={tokenFailed ? resolveQuery.isFetching : myIssuesQuery.isFetching}
           emptyNoun="assigned issues"
           totalCount={myIssuesQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/my/prs/layout.tsx
+++ b/apps/ui/app/my/prs/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+export const metadata = { title: "My PRs · clevis" }
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/ui/app/my/prs/page.tsx
+++ b/apps/ui/app/my/prs/page.tsx
@@ -28,9 +28,11 @@ export default function MyPRsPage() {
   const myPrsQuery = useQuery({
     queryKey: ["analytics.my-prs", org, page],
     queryFn: () => api.analytics.myPrs(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
     retry: false,
   })
+
+  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -50,12 +52,14 @@ export default function MyPRsPage() {
         <MyItemsList
           items={myPrsQuery.data?.items ?? []}
           isLoading={myPrsQuery.isLoading || resolveQuery.isLoading}
-          isError={myPrsQuery.isError}
+          isError={tokenFailed || myPrsQuery.isError}
           errorMessage={
-            myPrsQuery.error instanceof Error ? myPrsQuery.error.message : "Failed to load your pull requests."
+            tokenFailed
+              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
+              : (myPrsQuery.error instanceof Error ? myPrsQuery.error.message : "Failed to load your pull requests.")
           }
-          onRetry={() => myPrsQuery.refetch()}
-          retrying={myPrsQuery.isFetching}
+          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myPrsQuery.refetch())}
+          retrying={tokenFailed ? resolveQuery.isFetching : myPrsQuery.isFetching}
           emptyNoun="open pull requests"
           totalCount={myPrsQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/my/prs/page.tsx
+++ b/apps/ui/app/my/prs/page.tsx
@@ -1,13 +1,68 @@
-export const metadata = { title: "My PRs · clevis" }
+"use client"
 
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+import { MyItemsList } from "@/components/my-items-list"
+import { api } from "@/lib/api/client"
+
+const PER_PAGE = 25
 
 export default function MyPRsPage() {
+  const [org, setOrg] = useState("")
+  const [orgChecked, setOrgChecked] = useState(false)
+  const [page, setPage] = useState(1)
+  useEffect(() => {
+    setOrg(localStorage.getItem("default_org") || "")
+    setOrgChecked(true)
+  }, [])
+
+  const resolveQuery = useQuery({
+    queryKey: ["tokens.resolve", org],
+    queryFn: () => api.tokens.resolve(org),
+    enabled: org.trim().length > 2,
+    retry: false,
+  })
+
+  const myPrsQuery = useQuery({
+    queryKey: ["analytics.my-prs", org, page],
+    queryFn: () => api.analytics.myPrs(org, page, PER_PAGE, resolveQuery.data?.token),
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    retry: false,
+  })
+
   return (
     <>
       <PageHeader title="My PRs" description="Pull requests you've authored." />
-      <EmptyStatePage message="My pull requests — coming soon" />
+
+      {orgChecked && !org && (
+        <div className="card mb-6">
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No default organization selected yet — this page has nothing to query. Set one in{" "}
+            <Link href="/settings" className="text-primary hover:underline">Settings</Link>, or connect a GitHub
+            org there first if you haven&rsquo;t already.
+          </p>
+        </div>
+      )}
+
+      {org && (
+        <MyItemsList
+          items={myPrsQuery.data?.items ?? []}
+          isLoading={myPrsQuery.isLoading || resolveQuery.isLoading}
+          isError={myPrsQuery.isError}
+          errorMessage={
+            myPrsQuery.error instanceof Error ? myPrsQuery.error.message : "Failed to load your pull requests."
+          }
+          onRetry={() => myPrsQuery.refetch()}
+          retrying={myPrsQuery.isFetching}
+          emptyNoun="open pull requests"
+          totalCount={myPrsQuery.data?.total_count ?? 0}
+          page={page}
+          perPage={PER_PAGE}
+          onPageChange={setPage}
+        />
+      )}
     </>
   )
 }

--- a/apps/ui/app/my/reviews/layout.tsx
+++ b/apps/ui/app/my/reviews/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+export const metadata = { title: "My Reviews · clevis" }
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/ui/app/my/reviews/page.tsx
+++ b/apps/ui/app/my/reviews/page.tsx
@@ -1,13 +1,68 @@
-export const metadata = { title: "My Reviews · clevis" }
+"use client"
 
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+import { MyItemsList } from "@/components/my-items-list"
+import { api } from "@/lib/api/client"
+
+const PER_PAGE = 25
 
 export default function MyReviewsPage() {
+  const [org, setOrg] = useState("")
+  const [orgChecked, setOrgChecked] = useState(false)
+  const [page, setPage] = useState(1)
+  useEffect(() => {
+    setOrg(localStorage.getItem("default_org") || "")
+    setOrgChecked(true)
+  }, [])
+
+  const resolveQuery = useQuery({
+    queryKey: ["tokens.resolve", org],
+    queryFn: () => api.tokens.resolve(org),
+    enabled: org.trim().length > 2,
+    retry: false,
+  })
+
+  const myReviewsQuery = useQuery({
+    queryKey: ["analytics.my-reviews", org, page],
+    queryFn: () => api.analytics.myReviews(org, page, PER_PAGE, resolveQuery.data?.token),
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    retry: false,
+  })
+
   return (
     <>
       <PageHeader title="My Reviews" description="PRs awaiting your review." />
-      <EmptyStatePage message="My reviews — coming soon" />
+
+      {orgChecked && !org && (
+        <div className="card mb-6">
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No default organization selected yet — this page has nothing to query. Set one in{" "}
+            <Link href="/settings" className="text-primary hover:underline">Settings</Link>, or connect a GitHub
+            org there first if you haven&rsquo;t already.
+          </p>
+        </div>
+      )}
+
+      {org && (
+        <MyItemsList
+          items={myReviewsQuery.data?.items ?? []}
+          isLoading={myReviewsQuery.isLoading || resolveQuery.isLoading}
+          isError={myReviewsQuery.isError}
+          errorMessage={
+            myReviewsQuery.error instanceof Error ? myReviewsQuery.error.message : "Failed to load your review queue."
+          }
+          onRetry={() => myReviewsQuery.refetch()}
+          retrying={myReviewsQuery.isFetching}
+          emptyNoun="pull requests awaiting your review"
+          totalCount={myReviewsQuery.data?.total_count ?? 0}
+          page={page}
+          perPage={PER_PAGE}
+          onPageChange={setPage}
+        />
+      )}
     </>
   )
 }

--- a/apps/ui/app/my/reviews/page.tsx
+++ b/apps/ui/app/my/reviews/page.tsx
@@ -28,9 +28,11 @@ export default function MyReviewsPage() {
   const myReviewsQuery = useQuery({
     queryKey: ["analytics.my-reviews", org, page],
     queryFn: () => api.analytics.myReviews(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
+    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
     retry: false,
   })
+
+  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -50,12 +52,14 @@ export default function MyReviewsPage() {
         <MyItemsList
           items={myReviewsQuery.data?.items ?? []}
           isLoading={myReviewsQuery.isLoading || resolveQuery.isLoading}
-          isError={myReviewsQuery.isError}
+          isError={tokenFailed || myReviewsQuery.isError}
           errorMessage={
-            myReviewsQuery.error instanceof Error ? myReviewsQuery.error.message : "Failed to load your review queue."
+            tokenFailed
+              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
+              : (myReviewsQuery.error instanceof Error ? myReviewsQuery.error.message : "Failed to load your review queue.")
           }
-          onRetry={() => myReviewsQuery.refetch()}
-          retrying={myReviewsQuery.isFetching}
+          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myReviewsQuery.refetch())}
+          retrying={tokenFailed ? resolveQuery.isFetching : myReviewsQuery.isFetching}
           emptyNoun="pull requests awaiting your review"
           totalCount={myReviewsQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/releases/layout.tsx
+++ b/apps/ui/app/releases/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+export const metadata = { title: "Releases · clevis" }
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -28,7 +28,7 @@ export default function ReleasesPage() {
   })
 
   const token = resolveQuery.data?.token ?? ""
-  const queriesEnabled = org.trim().length > 2 && !resolveQuery.isLoading
+  const queriesEnabled = org.trim().length > 2 && resolveQuery.isSuccess
 
   const releaseTimelineQuery = useQuery({
     queryKey: ["github.release-timeline", org, days],
@@ -60,6 +60,7 @@ export default function ReleasesPage() {
             <select
               value={days}
               onChange={(e) => setDays(Number(e.target.value) as (typeof DAY_OPTIONS)[number])}
+              aria-label="Release time range"
               className="bg-elevated border border-border rounded-md text-xs text-muted-foreground font-mono px-2 py-1 focus:outline-none focus:border-primary"
             >
               {DAY_OPTIONS.map((d) => (
@@ -68,7 +69,17 @@ export default function ReleasesPage() {
             </select>
           </div>
 
-          {releaseTimelineQuery.isLoading ? (
+          {resolveQuery.isError ? (
+            <SectionError
+              message={
+                resolveQuery.error instanceof Error
+                  ? resolveQuery.error.message
+                  : "Failed to resolve GitHub access."
+              }
+              onRetry={() => resolveQuery.refetch()}
+              retrying={resolveQuery.isFetching}
+            />
+          ) : releaseTimelineQuery.isLoading ? (
             <div className="px-4 py-8">
               <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
             </div>

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -1,13 +1,117 @@
-export const metadata = { title: "Releases · clevis" }
+"use client"
 
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+import { EmptyStateInline } from "@/components/empty-state"
+import { SectionError } from "@/components/section-error"
+import { relativeTime } from "@/lib/format"
+import { api } from "@/lib/api/client"
+
+const DAY_OPTIONS = [30, 90, 180] as const
 
 export default function ReleasesPage() {
+  const [org, setOrg] = useState("")
+  const [orgChecked, setOrgChecked] = useState(false)
+  const [days, setDays] = useState<(typeof DAY_OPTIONS)[number]>(90)
+  useEffect(() => {
+    setOrg(localStorage.getItem("default_org") || "")
+    setOrgChecked(true)
+  }, [])
+
+  const resolveQuery = useQuery({
+    queryKey: ["tokens.resolve", org],
+    queryFn: () => api.tokens.resolve(org),
+    enabled: org.trim().length > 2,
+    retry: false,
+  })
+
+  const token = resolveQuery.data?.token ?? ""
+  const queriesEnabled = org.trim().length > 2 && !resolveQuery.isLoading
+
+  const releaseTimelineQuery = useQuery({
+    queryKey: ["github.release-timeline", org, days],
+    queryFn: () => api.github.releaseTimeline(org, token, days),
+    enabled: queriesEnabled,
+    retry: false,
+  })
+
+  const releases = releaseTimelineQuery.data?.releases ?? []
+
   return (
     <>
       <PageHeader title="Releases" description="Release history across your organization." />
-      <EmptyStatePage message="Releases — coming soon" />
+
+      {orgChecked && !org && (
+        <div className="card mb-6">
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No default organization selected yet — this page has nothing to query. Set one in{" "}
+            <Link href="/settings" className="text-primary hover:underline">Settings</Link>, or connect a GitHub
+            org there first if you haven&rsquo;t already.
+          </p>
+        </div>
+      )}
+
+      {org && (
+        <div className="card">
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-4">
+            <span className="section-label">Releases</span>
+            <select
+              value={days}
+              onChange={(e) => setDays(Number(e.target.value) as (typeof DAY_OPTIONS)[number])}
+              className="bg-elevated border border-border rounded-md text-xs text-muted-foreground font-mono px-2 py-1 focus:outline-none focus:border-primary"
+            >
+              {DAY_OPTIONS.map((d) => (
+                <option key={d} value={d}>last {d} days</option>
+              ))}
+            </select>
+          </div>
+
+          {releaseTimelineQuery.isLoading ? (
+            <div className="px-4 py-8">
+              <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
+            </div>
+          ) : releaseTimelineQuery.isError ? (
+            <SectionError
+              message={
+                releaseTimelineQuery.error instanceof Error
+                  ? releaseTimelineQuery.error.message
+                  : "Failed to load releases."
+              }
+              onRetry={() => releaseTimelineQuery.refetch()}
+              retrying={releaseTimelineQuery.isFetching}
+            />
+          ) : releases.length === 0 ? (
+            <EmptyStateInline noun={`releases in the last ${days} days`} />
+          ) : (
+            <div className="divide-y divide-border">
+              {releases.map((r) => (
+                <a
+                  key={r.url}
+                  href={r.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+                >
+                  <span className="flex flex-col min-w-0">
+                    <span className="text-foreground/90 truncate">
+                      {r.repo} · {r.name}
+                      {r.is_prerelease && <span className="stat-chip ml-1.5 align-middle">pre-release</span>}
+                    </span>
+                    <span className="text-[0.6875rem] text-muted-foreground truncate">
+                      {r.tag_name} — {r.body_preview}
+                    </span>
+                  </span>
+                  <span className="text-[0.6875rem] text-muted-foreground whitespace-nowrap shrink-0 ml-3">
+                    {relativeTime(r.published_at)}
+                  </span>
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </>
   )
 }

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -79,7 +79,7 @@ export default function ReleasesPage() {
               onRetry={() => resolveQuery.refetch()}
               retrying={resolveQuery.isFetching}
             />
-          ) : releaseTimelineQuery.isLoading ? (
+          ) : releaseTimelineQuery.isLoading || resolveQuery.isLoading ? (
             <div className="px-4 py-8">
               <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
             </div>

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ const groups = [
     { title: "Overview",         href: "/" },
     { title: "Activity",         href: "/activity", showUnreadBadge: true },
     { title: "Pull Requests",    href: "/pulls", comingSoon: true },
-    { title: "Releases",         href: "/releases", comingSoon: true },
+    { title: "Releases",         href: "/releases" },
   ],
   [
     { title: "Repositories",     href: "/repos" },
@@ -48,9 +48,9 @@ const groups = [
     { title: "Job Queue",        href: "/jobs" },
   ],
   [
-    { title: "My PRs",     href: "/my/prs", comingSoon: true },
-    { title: "My Reviews", href: "/my/reviews", comingSoon: true },
-    { title: "My Issues",  href: "/my/issues", comingSoon: true },
+    { title: "My PRs",     href: "/my/prs" },
+    { title: "My Reviews", href: "/my/reviews" },
+    { title: "My Issues",  href: "/my/issues" },
   ],
 ]
 

--- a/apps/ui/components/my-items-list.tsx
+++ b/apps/ui/components/my-items-list.tsx
@@ -1,0 +1,95 @@
+import { relativeTime } from "@/lib/format"
+import { SectionError } from "@/components/section-error"
+import { EmptyStateInline } from "@/components/empty-state"
+import { Button } from "@/components/ui/button"
+import type { MyViewIssueSummary, MyViewPRSummary } from "@/lib/api/types"
+
+interface MyItemsListProps {
+  items: (MyViewPRSummary | MyViewIssueSummary)[]
+  isLoading: boolean
+  isError: boolean
+  errorMessage: string
+  onRetry: () => void
+  retrying: boolean
+  emptyNoun: string
+  totalCount: number
+  page: number
+  perPage: number
+  onPageChange: (page: number) => void
+}
+
+// Full-page generalization of the Overview widget's MyViewRow — same row shape
+// (title, `repo #number`, relative time), plus a Prev/Next footer driven by
+// total_count/page/per_page since dedicated pages aren't capped at the
+// glance widget's top-10.
+export function MyItemsList({
+  items,
+  isLoading,
+  isError,
+  errorMessage,
+  onRetry,
+  retrying,
+  emptyNoun,
+  totalCount,
+  page,
+  perPage,
+  onPageChange,
+}: MyItemsListProps) {
+  const lastPage = Math.max(1, Math.ceil(totalCount / perPage))
+
+  return (
+    <div className="card">
+      {isLoading ? (
+        <div className="px-4 py-8">
+          <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
+        </div>
+      ) : isError ? (
+        <SectionError message={errorMessage} onRetry={onRetry} retrying={retrying} />
+      ) : items.length === 0 ? (
+        <EmptyStateInline noun={emptyNoun} />
+      ) : (
+        <>
+          <div className="divide-y divide-border">
+            {items.map((item) => (
+              <a
+                key={`${item.repository}-${item.number}`}
+                href={item.html_url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+              >
+                <span className="flex flex-col min-w-0">
+                  <span className="text-foreground/90 truncate">{item.title}</span>
+                  <span className="text-[0.6875rem] text-muted-foreground font-mono">
+                    {item.repository} #{item.number}
+                  </span>
+                </span>
+                <span className="text-[0.6875rem] text-muted-foreground whitespace-nowrap shrink-0 ml-3">
+                  {relativeTime(item.updated_at)}
+                </span>
+              </a>
+            ))}
+          </div>
+          <div className="px-4 py-3 border-t border-border flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              Page {page} of {lastPage} · {totalCount} total
+            </span>
+            <div className="flex gap-2">
+              <Button size="sm" variant="outline" disabled={page <= 1} onClick={() => onPageChange(page - 1)}>
+                Prev
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={page * perPage >= totalCount}
+                onClick={() => onPageChange(page + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -20,6 +20,8 @@ import type {
   InvitationPreview,
   JobOut,
   MyOrgMembership,
+  MyIssueListResponse,
+  MyPrListResponse,
   MyViewResponse,
   OrgEventsResponse,
   PendingInvitationSummary,
@@ -197,6 +199,21 @@ export const api = {
       get<CockpitResponse>(`/me/analytics/cockpit/${encodeURIComponent(owner)}`, githubTokenHeader(token)),
     myView: (owner: string, token?: string) =>
       get<MyViewResponse>(`/me/github/my-view?owner=${encodeURIComponent(owner)}`, githubTokenHeader(token)),
+    myPrs: (owner: string, page = 1, perPage = 25, token?: string) =>
+      get<MyPrListResponse>(
+        `/me/github/my-prs?owner=${encodeURIComponent(owner)}&page=${page}&per_page=${perPage}`,
+        githubTokenHeader(token),
+      ),
+    myReviews: (owner: string, page = 1, perPage = 25, token?: string) =>
+      get<MyPrListResponse>(
+        `/me/github/my-reviews?owner=${encodeURIComponent(owner)}&page=${page}&per_page=${perPage}`,
+        githubTokenHeader(token),
+      ),
+    myIssues: (owner: string, page = 1, perPage = 25, token?: string) =>
+      get<MyIssueListResponse>(
+        `/me/github/my-issues?owner=${encodeURIComponent(owner)}&page=${page}&per_page=${perPage}`,
+        githubTokenHeader(token),
+      ),
   },
   security: {
     matrix: (owner: string, token?: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -421,6 +421,20 @@ export interface MyViewResponse {
   my_recent_runs: MyViewRunSummary[]
 }
 
+export interface MyPrListResponse {
+  items: MyViewPRSummary[]
+  total_count: number
+  page: number
+  per_page: number
+}
+
+export interface MyIssueListResponse {
+  items: MyViewIssueSummary[]
+  total_count: number
+  page: number
+  per_page: number
+}
+
 export interface WorkflowSummary {
   id: number
   name: string

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -365,7 +365,7 @@ describe("AppSidebar coming-soon badges", () => {
     vi.restoreAllMocks();
   });
 
-  it.each(["Pull Requests", "Releases", "My PRs", "My Reviews", "My Issues"])(
+  it.each(["Pull Requests"])(
     "shows a 'Soon' badge on the unshipped '%s' nav item",
     async (title) => {
       renderSidebar();
@@ -374,7 +374,20 @@ describe("AppSidebar coming-soon badges", () => {
     },
   );
 
-  it.each(["Overview", "Activity", "Repositories", "Health & Security", "Collaborators", "Automation", "Audit Log", "Job Queue"])(
+  it.each([
+    "Overview",
+    "Activity",
+    "Releases",
+    "Repositories",
+    "Health & Security",
+    "Collaborators",
+    "Automation",
+    "Audit Log",
+    "Job Queue",
+    "My PRs",
+    "My Reviews",
+    "My Issues",
+  ])(
     "shows no 'Soon' badge on the shipped '%s' nav item",
     async (title) => {
       renderSidebar();

--- a/apps/ui/tests/components/layout.test.tsx
+++ b/apps/ui/tests/components/layout.test.tsx
@@ -13,5 +13,9 @@ describe("RootLayout module", () => {
     const mod = await import("@/app/layout");
 
     expect(mod.default).toBeInstanceOf(Function);
-  }, 30000);
+    // Dynamically importing the full root layout tree (providers, guards, etc.) can take
+    // well over 30s when running alongside the rest of the suite under CPU contention, even
+    // though it resolves in ~1s standalone -- 90s gives enough headroom without masking a
+    // genuine hang.
+  }, 90000);
 });

--- a/apps/ui/tests/components/my-issues-page.test.tsx
+++ b/apps/ui/tests/components/my-issues-page.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const myIssuesMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: { resolve: (...args: unknown[]) => tokensResolveMock(...args) },
+    analytics: { myIssues: (...args: unknown[]) => myIssuesMock(...args) },
+  },
+}));
+
+import MyIssuesPage from "@/app/my/issues/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MyIssuesPage />
+    </QueryClientProvider>,
+  );
+}
+
+const ISSUE_ITEM = {
+  number: 3,
+  title: "Investigate flake",
+  repository: "acme/worker",
+  html_url: "https://github.com/acme/worker/issues/3",
+  updated_at: "2026-07-19T00:00:00Z",
+};
+
+describe("MyIssuesPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    myIssuesMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a no-default-org message when nothing is configured", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No default organization selected/)).toBeInTheDocument();
+    });
+    expect(myIssuesMock).not.toHaveBeenCalled();
+  });
+
+  it("renders assigned issues for the default org", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myIssuesMock.mockResolvedValue({ items: [ISSUE_ITEM], total_count: 1, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Investigate flake")).toBeInTheDocument());
+    expect(myIssuesMock).toHaveBeenCalledWith("acme", 1, 25, "ghp_test");
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myIssuesMock.mockRejectedValue(new Error("Workspace admin access required"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.queryByText(/No assigned issues/)).not.toBeInTheDocument();
+
+    myIssuesMock.mockResolvedValueOnce({ items: [], total_count: 0, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No assigned issues/)).toBeInTheDocument());
+    expect(myIssuesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myIssuesMock.mockRejectedValue("boom");
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Failed to load your assigned issues.")).toBeInTheDocument());
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myIssuesMock.mockResolvedValue({ items: [], total_count: 0, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/No assigned issues/)).toBeInTheDocument());
+  });
+
+  it("advances to page 2 and re-queries when Next is clicked", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myIssuesMock.mockResolvedValue({ items: [ISSUE_ITEM], total_count: 30, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Investigate flake")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => expect(myIssuesMock).toHaveBeenCalledWith("acme", 2, 25, "ghp_test"));
+  });
+});

--- a/apps/ui/tests/components/my-issues-page.test.tsx
+++ b/apps/ui/tests/components/my-issues-page.test.tsx
@@ -100,6 +100,22 @@ describe("MyIssuesPage", () => {
     await waitFor(() => expect(screen.getByText(/No assigned issues/)).toBeInTheDocument());
   });
 
+  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
+    expect(myIssuesMock).not.toHaveBeenCalled();
+
+    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
+    myIssuesMock.mockResolvedValueOnce({ items: [ISSUE_ITEM], total_count: 1, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.getByText("Investigate flake")).toBeInTheDocument());
+  });
+
   it("advances to page 2 and re-queries when Next is clicked", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/my-items-list.test.tsx
+++ b/apps/ui/tests/components/my-items-list.test.tsx
@@ -1,0 +1,186 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MyItemsList } from "@/components/my-items-list";
+
+const ITEM = {
+  number: 12,
+  title: "Fix bug",
+  repository: "acme/api",
+  html_url: "https://github.com/acme/api/pull/12",
+  updated_at: new Date().toISOString(),
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MyItemsList", () => {
+  it("renders items with repo/number and a working link", () => {
+    render(
+      <MyItemsList
+        items={[ITEM]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={1}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("Fix bug")).toBeInTheDocument();
+    expect(screen.getByText("acme/api #12")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Fix bug/ })).toHaveAttribute("href", ITEM.html_url);
+  });
+
+  it("shows the empty state only when there are genuinely no items", () => {
+    render(
+      <MyItemsList
+        items={[]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={0}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/No pull requests/)).toBeInTheDocument();
+  });
+
+  it("shows a retry option instead of items when isError is set", () => {
+    const onRetry = vi.fn();
+    render(
+      <MyItemsList
+        items={[]}
+        isLoading={false}
+        isError={true}
+        errorMessage="Workspace admin access required"
+        onRetry={onRetry}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={0}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("Workspace admin access required")).toBeInTheDocument();
+    expect(screen.queryByText(/No pull requests/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a loading state and no rows while isLoading", () => {
+    render(
+      <MyItemsList
+        items={[]}
+        isLoading={true}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={0}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText(/No pull requests/)).not.toBeInTheDocument();
+  });
+
+  it("disables Prev on page 1 and Next on the last page, and calls onPageChange", () => {
+    const onPageChange = vi.fn();
+    render(
+      <MyItemsList
+        items={[ITEM]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={30}
+        page={1}
+        perPage={25}
+        onPageChange={onPageChange}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Prev" })).toBeDisabled();
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    expect(nextButton).not.toBeDisabled();
+    fireEvent.click(nextButton);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it("disables Next once page*perPage reaches total_count", () => {
+    render(
+      <MyItemsList
+        items={[ITEM]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={30}
+        page={2}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Prev" })).not.toBeDisabled();
+  });
+
+  it("calls onPageChange with the previous page when Prev is clicked", () => {
+    const onPageChange = vi.fn();
+    render(
+      <MyItemsList
+        items={[ITEM]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={30}
+        page={2}
+        perPage={25}
+        onPageChange={onPageChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Prev" }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("shows a retrying spinner state on the retry button", () => {
+    render(
+      <MyItemsList
+        items={[]}
+        isLoading={false}
+        isError={true}
+        errorMessage="boom"
+        onRetry={() => {}}
+        retrying={true}
+        emptyNoun="pull requests"
+        totalCount={0}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/apps/ui/tests/components/my-items-routes-layout.test.tsx
+++ b/apps/ui/tests/components/my-items-routes-layout.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import PrsLayout, { metadata as prsMetadata } from "@/app/my/prs/layout";
+import ReviewsLayout, { metadata as reviewsMetadata } from "@/app/my/reviews/layout";
+import IssuesLayout, { metadata as issuesMetadata } from "@/app/my/issues/layout";
+import ReleasesLayout, { metadata as releasesMetadata } from "@/app/releases/layout";
+
+describe("My PRs/Reviews/Issues and Releases route layouts", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each([
+    ["My PRs", PrsLayout, prsMetadata, "My PRs · clevis"],
+    ["My Reviews", ReviewsLayout, reviewsMetadata, "My Reviews · clevis"],
+    ["My Issues", IssuesLayout, issuesMetadata, "My Issues · clevis"],
+    ["Releases", ReleasesLayout, releasesMetadata, "Releases · clevis"],
+  ])("%s layout sets its page title and renders children", (_label, Layout, metadata, expectedTitle) => {
+    expect(metadata.title).toBe(expectedTitle);
+
+    render(
+      <Layout>
+        <p>child content</p>
+      </Layout>,
+    );
+
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/components/my-prs-page.test.tsx
+++ b/apps/ui/tests/components/my-prs-page.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const myPrsMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: { resolve: (...args: unknown[]) => tokensResolveMock(...args) },
+    analytics: { myPrs: (...args: unknown[]) => myPrsMock(...args) },
+  },
+}));
+
+import MyPRsPage from "@/app/my/prs/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MyPRsPage />
+    </QueryClientProvider>,
+  );
+}
+
+const PR_ITEM = {
+  number: 12,
+  title: "Fix bug",
+  repository: "acme/api",
+  html_url: "https://github.com/acme/api/pull/12",
+  updated_at: "2026-07-20T00:00:00Z",
+};
+
+describe("MyPRsPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    myPrsMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a no-default-org message when nothing is configured", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No default organization selected/)).toBeInTheDocument();
+    });
+    expect(myPrsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders PRs for the default org", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myPrsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+    expect(myPrsMock).toHaveBeenCalledWith("acme", 1, 25, "ghp_test");
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myPrsMock.mockRejectedValue(new Error("Workspace admin access required"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.queryByText(/No open pull requests/)).not.toBeInTheDocument();
+
+    myPrsMock.mockResolvedValueOnce({ items: [], total_count: 0, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No open pull requests/)).toBeInTheDocument());
+    expect(myPrsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myPrsMock.mockRejectedValue("boom");
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Failed to load your pull requests.")).toBeInTheDocument());
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myPrsMock.mockResolvedValue({ items: [], total_count: 0, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/No open pull requests/)).toBeInTheDocument());
+  });
+
+  it("advances to page 2 and re-queries when Next is clicked", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myPrsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 30, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => expect(myPrsMock).toHaveBeenCalledWith("acme", 2, 25, "ghp_test"));
+  });
+});

--- a/apps/ui/tests/components/my-prs-page.test.tsx
+++ b/apps/ui/tests/components/my-prs-page.test.tsx
@@ -100,6 +100,22 @@ describe("MyPRsPage", () => {
     await waitFor(() => expect(screen.getByText(/No open pull requests/)).toBeInTheDocument());
   });
 
+  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
+    expect(myPrsMock).not.toHaveBeenCalled();
+
+    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
+    myPrsMock.mockResolvedValueOnce({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+  });
+
   it("advances to page 2 and re-queries when Next is clicked", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/my-reviews-page.test.tsx
+++ b/apps/ui/tests/components/my-reviews-page.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const myReviewsMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: { resolve: (...args: unknown[]) => tokensResolveMock(...args) },
+    analytics: { myReviews: (...args: unknown[]) => myReviewsMock(...args) },
+  },
+}));
+
+import MyReviewsPage from "@/app/my/reviews/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MyReviewsPage />
+    </QueryClientProvider>,
+  );
+}
+
+const PR_ITEM = {
+  number: 7,
+  title: "Add feature flag",
+  repository: "acme/worker",
+  html_url: "https://github.com/acme/worker/pull/7",
+  updated_at: "2026-07-20T00:00:00Z",
+};
+
+describe("MyReviewsPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    myReviewsMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a no-default-org message when nothing is configured", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No default organization selected/)).toBeInTheDocument();
+    });
+    expect(myReviewsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders pending reviews for the default org", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myReviewsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Add feature flag")).toBeInTheDocument());
+    expect(myReviewsMock).toHaveBeenCalledWith("acme", 1, 25, "ghp_test");
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myReviewsMock.mockRejectedValue(new Error("Workspace admin access required"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.queryByText(/No pull requests awaiting your review/)).not.toBeInTheDocument();
+
+    myReviewsMock.mockResolvedValueOnce({ items: [], total_count: 0, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No pull requests awaiting your review/)).toBeInTheDocument());
+    expect(myReviewsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myReviewsMock.mockRejectedValue("boom");
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Failed to load your review queue.")).toBeInTheDocument());
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myReviewsMock.mockResolvedValue({ items: [], total_count: 0, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/No pull requests awaiting your review/)).toBeInTheDocument());
+  });
+
+  it("advances to page 2 and re-queries when Next is clicked", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    myReviewsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 30, page: 1, per_page: 25 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Add feature flag")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => expect(myReviewsMock).toHaveBeenCalledWith("acme", 2, 25, "ghp_test"));
+  });
+});

--- a/apps/ui/tests/components/my-reviews-page.test.tsx
+++ b/apps/ui/tests/components/my-reviews-page.test.tsx
@@ -100,6 +100,22 @@ describe("MyReviewsPage", () => {
     await waitFor(() => expect(screen.getByText(/No pull requests awaiting your review/)).toBeInTheDocument());
   });
 
+  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
+    expect(myReviewsMock).not.toHaveBeenCalled();
+
+    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
+    myReviewsMock.mockResolvedValueOnce({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.getByText("Add feature flag")).toBeInTheDocument());
+  });
+
   it("advances to page 2 and re-queries when Next is clicked", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/releases-page.test.tsx
+++ b/apps/ui/tests/components/releases-page.test.tsx
@@ -116,6 +116,22 @@ describe("ReleasesPage", () => {
     await waitFor(() => expect(screen.getByText("Failed to load releases.")).toBeInTheDocument());
   });
 
+  it("surfaces a token-resolve failure with retry instead of firing the release-timeline query", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
+    expect(releaseTimelineMock).not.toHaveBeenCalled();
+
+    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
+    releaseTimelineMock.mockResolvedValueOnce({ org: "acme", releases: [RELEASE] });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.getAllByText(/v1\.2\.0/).length).toBeGreaterThan(0));
+  });
+
   it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/releases-page.test.tsx
+++ b/apps/ui/tests/components/releases-page.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const releaseTimelineMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: { resolve: (...args: unknown[]) => tokensResolveMock(...args) },
+    github: { releaseTimeline: (...args: unknown[]) => releaseTimelineMock(...args) },
+  },
+}));
+
+import ReleasesPage from "@/app/releases/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReleasesPage />
+    </QueryClientProvider>,
+  );
+}
+
+const RELEASE = {
+  repo: "acme/api",
+  tag_name: "v1.2.0",
+  name: "v1.2.0",
+  published_at: "2026-07-20T00:00:00Z",
+  is_prerelease: false,
+  body_preview: "Bug fixes",
+  url: "https://github.com/acme/api/releases/tag/v1.2.0",
+};
+
+describe("ReleasesPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    releaseTimelineMock.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a no-default-org message when nothing is configured", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/No default organization selected/)).toBeInTheDocument();
+    });
+    expect(releaseTimelineMock).not.toHaveBeenCalled();
+  });
+
+  it("renders releases for the default org at the default 90-day window", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockResolvedValue({ org: "acme", releases: [RELEASE] });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getAllByText(/v1\.2\.0/).length).toBeGreaterThan(0));
+    expect(releaseTimelineMock).toHaveBeenCalledWith("acme", "ghp_test", 90);
+  });
+
+  it("shows a pre-release badge for pre-release entries", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockResolvedValue({ org: "acme", releases: [{ ...RELEASE, is_prerelease: true }] });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("pre-release")).toBeInTheDocument());
+  });
+
+  it("re-queries with the new day window when the selector changes", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockResolvedValue({ org: "acme", releases: [] });
+
+    renderPage();
+
+    await waitFor(() => expect(releaseTimelineMock).toHaveBeenCalledWith("acme", "ghp_test", 90));
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "30" } });
+
+    await waitFor(() => expect(releaseTimelineMock).toHaveBeenCalledWith("acme", "ghp_test", 30));
+  });
+
+  it("shows a retry option instead of a fake empty state when the query fails", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockRejectedValue(new Error("Workspace admin access required"));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Workspace admin access required")).toBeInTheDocument());
+    expect(screen.queryByText(/No releases/)).not.toBeInTheDocument();
+
+    releaseTimelineMock.mockResolvedValueOnce({ org: "acme", releases: [] });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByText(/No releases/)).toBeInTheDocument());
+    expect(releaseTimelineMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a generic message when the rejection isn't an Error instance", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockRejectedValue("boom");
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Failed to load releases.")).toBeInTheDocument());
+  });
+
+  it("shows the empty state only when the query genuinely succeeds with no rows", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    releaseTimelineMock.mockResolvedValue({ org: "acme", releases: [] });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/No releases in the last 90 days/)).toBeInTheDocument());
+  });
+});

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -191,6 +191,33 @@ describe("api.analytics value normalization", () => {
     expect(result).toEqual({ my_open_prs: [], review_requests: [], assigned_issues: [], my_recent_runs: [] });
   });
 
+  it("GETs /me/github/my-prs?owner=...&page=...&per_page=... with an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({ items: [], total_count: 0, page: 2, per_page: 10 });
+    const result = await api.analytics.myPrs("acme", 2, 10, "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/github/my-prs?owner=acme&page=2&per_page=10");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual({ items: [], total_count: 0, page: 2, per_page: 10 });
+  });
+
+  it("GETs /me/github/my-reviews?owner=...&page=...&per_page=... with an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({ items: [], total_count: 0, page: 1, per_page: 25 });
+    const result = await api.analytics.myReviews("acme", 1, 25, "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/github/my-reviews?owner=acme&page=1&per_page=25");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual({ items: [], total_count: 0, page: 1, per_page: 25 });
+  });
+
+  it("GETs /me/github/my-issues?owner=...&page=...&per_page=... with an X-GitHub-Token header when supplied", async () => {
+    stubOkJson({ items: [], total_count: 0, page: 1, per_page: 25 });
+    const result = await api.analytics.myIssues("acme", 1, 25, "ghp_test");
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/github/my-issues?owner=acme&page=1&per_page=25");
+    expect((init.headers as Record<string, string>)["X-GitHub-Token"]).toBe("ghp_test");
+    expect(result).toEqual({ items: [], total_count: 0, page: 1, per_page: 25 });
+  });
+
   it("GETs /me/analytics/history?owner=... and returns the raw scan history", async () => {
     stubOkJson([{ id: 1, owner: "acme", score: 80, total_checks: 3, failed_checks: 0, created_at: "2026-07-17T00:00:00Z" }]);
     const result = await api.analytics.history("acme");

--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["./tests/**/*.{test,spec}.{ts,tsx}"],
     passWithNoTests: false,
+    // Default (5000ms) is too tight once all ~43 files run concurrently -- CPU contention
+    // between jsdom environments intermittently pushes individual tests past it (a different
+    // file each run, not a real bug in any one of them). 20s gives headroom without masking a
+    // genuine hang; layout.test.tsx keeps its own higher override for its unusually slow import.
+    testTimeout: 20000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
## Summary

Replaces four "coming soon" stub pages with real, working features backed by live GitHub data:

- **My PRs** / **My Reviews** / **My Issues** — new dedicated pages, each with real Prev/Next pagination (not the fixed top-10 the Overview widget uses). Backed by three new endpoints (`GET /me/github/my-prs`, `/me/github/my-reviews`, `/me/github/my-issues`), each a thin wrapper around GitHub's Search API with `page`/`per_page` params and a `total_count` in the response. The existing `/me/github/my-view` endpoint (Overview's glance widget) is untouched — these are separate, additive endpoints, not an extension of it.
- **Releases** — reuses the existing org-scoped `POST /github/orgs/{org}/release-timeline` endpoint as-is (already powering Activity's release section), built out as its own full page with a 30/90/180-day selector. No cross-org fan-out: releases have no natural per-user filter the way PRs/issues do, and every other org-scoped surface in this app (Security, Automation, Repositories) already follows the same org-picker pattern, so this stays consistent rather than introducing an outlier "personal" data shape.

A new shared `MyItemsList` component generalizes the row layout already used by Overview's `MyViewRow` (title, `repo #number`, relative time, external link) into a full-page list with Prev/Next controls driven by `total_count`/`page`/`per_page`.

The sidebar's "Soon" badges are removed for these four nav entries. `Pull Requests` (`/pulls`) is a distinct, still-unbuilt feature (per-repo PR browsing) and is intentionally left out of scope.

## Why these design choices

- **Three separate routes instead of one route with a `kind` param** — cleaner OpenAPI response types, each independently testable.
- **Prev/Next pagination instead of "load more"** — GitHub's search API already returns `total_count` for free, so exact page counts and boundary-disabled buttons are simpler than tracking accumulated infinite-scroll state.
- **Releases stays org-scoped** — a cross-org "my releases" view would require enumerating every org the user belongs to and fanning out per-org token resolution, for a feature that (unlike PRs/issues) isn't actually "mine" in any GitHub-native sense.

## Notes for reviewers

- No DB schema/migration changes — everything here reads live GitHub data through the existing `GitHubClient`, the same way `my-view`/`release-timeline` already do.
- No RBAC/auth changes — the three new routes reuse `resolve_owner_token` exactly as `my-view` does; Releases reuses `require_org_role(min_role="member")` exactly as the existing release-timeline route does.

## Test plan

- [x] `pytest -q` — 596 passed
- [x] Python diff-cover vs `origin/main` — 100% (41 new/changed lines)
- [x] `bun run typecheck` / `bun run lint` / `bun run build` — clean
- [x] New/changed UI test files (my-prs-page, my-reviews-page, my-issues-page, releases-page, my-items-list, client.test, app-sidebar) — 94 passed
- [x] UI diff-cover vs `origin/main` — 100% (104 new/changed lines)
- [ ] Manual smoke test on a real org after deploy: My PRs/Reviews/Issues show real items, Prev/Next page correctly and disable at boundaries, error states show retry, Releases lists releases with a working day selector, sidebar no longer shows "Soon" on these four entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated “My” analytics endpoints for open PRs, review requests, and assigned issues, with token-aware API calls.
  * Converted My PRs, My Reviews, My Issues, and Releases pages to live, org-driven client experiences with loading/empty/error handling.
  * Introduced a reusable My Items list component with Prev/Next pagination.
* **Bug Fixes**
  * Improved resilience on GitHub search limits and request failures by returning safe empty results.
* **Tests**
  * Added/expanded backend and UI test coverage for pagination, retries, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->