### PR TITLE
fix(ui): don't require saved-token resolve to succeed for my-items/releases

### DIFF
--- a/apps/ui/app/my/issues/page.tsx
+++ b/apps/ui/app/my/issues/page.tsx
@@ -28,11 +28,9 @@ export default function MyIssuesPage() {
   const myIssuesQuery = useQuery({
     queryKey: ["analytics.my-issues", org, page],
     queryFn: () => api.analytics.myIssues(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
     retry: false,
   })
-
-  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -52,14 +50,12 @@ export default function MyIssuesPage() {
         <MyItemsList
           items={myIssuesQuery.data?.items ?? []}
           isLoading={myIssuesQuery.isLoading || resolveQuery.isLoading}
-          isError={tokenFailed || myIssuesQuery.isError}
+          isError={myIssuesQuery.isError}
           errorMessage={
-            tokenFailed
-              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
-              : (myIssuesQuery.error instanceof Error ? myIssuesQuery.error.message : "Failed to load your assigned issues.")
+            myIssuesQuery.error instanceof Error ? myIssuesQuery.error.message : "Failed to load your assigned issues."
           }
-          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myIssuesQuery.refetch())}
-          retrying={tokenFailed ? resolveQuery.isFetching : myIssuesQuery.isFetching}
+          onRetry={() => myIssuesQuery.refetch()}
+          retrying={myIssuesQuery.isFetching}
           emptyNoun="assigned issues"
           totalCount={myIssuesQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/my/prs/page.tsx
+++ b/apps/ui/app/my/prs/page.tsx
@@ -28,11 +28,9 @@ export default function MyPRsPage() {
   const myPrsQuery = useQuery({
     queryKey: ["analytics.my-prs", org, page],
     queryFn: () => api.analytics.myPrs(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
     retry: false,
   })
-
-  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -52,14 +50,12 @@ export default function MyPRsPage() {
         <MyItemsList
           items={myPrsQuery.data?.items ?? []}
           isLoading={myPrsQuery.isLoading || resolveQuery.isLoading}
-          isError={tokenFailed || myPrsQuery.isError}
+          isError={myPrsQuery.isError}
           errorMessage={
-            tokenFailed
-              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
-              : (myPrsQuery.error instanceof Error ? myPrsQuery.error.message : "Failed to load your pull requests.")
+            myPrsQuery.error instanceof Error ? myPrsQuery.error.message : "Failed to load your pull requests."
           }
-          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myPrsQuery.refetch())}
-          retrying={tokenFailed ? resolveQuery.isFetching : myPrsQuery.isFetching}
+          onRetry={() => myPrsQuery.refetch()}
+          retrying={myPrsQuery.isFetching}
           emptyNoun="open pull requests"
           totalCount={myPrsQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/my/reviews/page.tsx
+++ b/apps/ui/app/my/reviews/page.tsx
@@ -28,11 +28,9 @@ export default function MyReviewsPage() {
   const myReviewsQuery = useQuery({
     queryKey: ["analytics.my-reviews", org, page],
     queryFn: () => api.analytics.myReviews(org, page, PER_PAGE, resolveQuery.data?.token),
-    enabled: org.trim().length > 2 && resolveQuery.isSuccess,
+    enabled: org.trim().length > 2 && !resolveQuery.isLoading,
     retry: false,
   })
-
-  const tokenFailed = resolveQuery.isError
 
   return (
     <>
@@ -52,14 +50,12 @@ export default function MyReviewsPage() {
         <MyItemsList
           items={myReviewsQuery.data?.items ?? []}
           isLoading={myReviewsQuery.isLoading || resolveQuery.isLoading}
-          isError={tokenFailed || myReviewsQuery.isError}
+          isError={myReviewsQuery.isError}
           errorMessage={
-            tokenFailed
-              ? (resolveQuery.error instanceof Error ? resolveQuery.error.message : "Failed to resolve GitHub access.")
-              : (myReviewsQuery.error instanceof Error ? myReviewsQuery.error.message : "Failed to load your review queue.")
+            myReviewsQuery.error instanceof Error ? myReviewsQuery.error.message : "Failed to load your review queue."
           }
-          onRetry={() => (tokenFailed ? resolveQuery.refetch() : myReviewsQuery.refetch())}
-          retrying={tokenFailed ? resolveQuery.isFetching : myReviewsQuery.isFetching}
+          onRetry={() => myReviewsQuery.refetch()}
+          retrying={myReviewsQuery.isFetching}
           emptyNoun="pull requests awaiting your review"
           totalCount={myReviewsQuery.data?.total_count ?? 0}
           page={page}

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -28,7 +28,7 @@ export default function ReleasesPage() {
   })
 
   const token = resolveQuery.data?.token ?? ""
-  const queriesEnabled = org.trim().length > 2 && resolveQuery.isSuccess
+  const queriesEnabled = org.trim().length > 2 && !resolveQuery.isLoading
 
   const releaseTimelineQuery = useQuery({
     queryKey: ["github.release-timeline", org, days],
@@ -69,17 +69,7 @@ export default function ReleasesPage() {
             </select>
           </div>
 
-          {resolveQuery.isError ? (
-            <SectionError
-              message={
-                resolveQuery.error instanceof Error
-                  ? resolveQuery.error.message
-                  : "Failed to resolve GitHub access."
-              }
-              onRetry={() => resolveQuery.refetch()}
-              retrying={resolveQuery.isFetching}
-            />
-          ) : releaseTimelineQuery.isLoading || resolveQuery.isLoading ? (
+          {releaseTimelineQuery.isLoading || resolveQuery.isLoading ? (
             <div className="px-4 py-8">
               <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
             </div>

--- a/apps/ui/tests/components/my-issues-page.test.tsx
+++ b/apps/ui/tests/components/my-issues-page.test.tsx
@@ -100,20 +100,31 @@ describe("MyIssuesPage", () => {
     await waitFor(() => expect(screen.getByText(/No assigned issues/)).toBeInTheDocument());
   });
 
-  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+  it("still queries via a connected GitHub App installation when there's no saved PAT to resolve", async () => {
     localStorage.setItem("default_org", "acme");
-    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myIssuesMock.mockResolvedValue({ items: [ISSUE_ITEM], total_count: 1, page: 1, per_page: 25 });
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
-    expect(myIssuesMock).not.toHaveBeenCalled();
-
-    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
-    myIssuesMock.mockResolvedValueOnce({ items: [ISSUE_ITEM], total_count: 1, page: 1, per_page: 25 });
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
     await waitFor(() => expect(screen.getByText("Investigate flake")).toBeInTheDocument());
+    expect(myIssuesMock).toHaveBeenCalledWith("acme", 1, 25, undefined);
+  });
+
+  it("shows the analytics endpoint's own error when neither a saved token nor an installation is available", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myIssuesMock.mockRejectedValue(
+      new Error("No GitHub App installation found for 'acme' and no token was provided."),
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No GitHub App installation found for 'acme' and no token was provided."),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("advances to page 2 and re-queries when Next is clicked", async () => {

--- a/apps/ui/tests/components/my-prs-page.test.tsx
+++ b/apps/ui/tests/components/my-prs-page.test.tsx
@@ -100,20 +100,34 @@ describe("MyPRsPage", () => {
     await waitFor(() => expect(screen.getByText(/No open pull requests/)).toBeInTheDocument());
   });
 
-  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+  it("still queries via a connected GitHub App installation when there's no saved PAT to resolve", async () => {
+    // /tokens/resolve only bridges the legacy saved-PAT path -- a GitHub App installation is
+    // resolved server-side independent of it (see resolve_owner_token), so a 404/"no saved
+    // token" here must not block the page from loading real data.
     localStorage.setItem("default_org", "acme");
-    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myPrsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
-    expect(myPrsMock).not.toHaveBeenCalled();
-
-    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
-    myPrsMock.mockResolvedValueOnce({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
     await waitFor(() => expect(screen.getByText("Fix bug")).toBeInTheDocument());
+    expect(myPrsMock).toHaveBeenCalledWith("acme", 1, 25, undefined);
+  });
+
+  it("shows the analytics endpoint's own error when neither a saved token nor an installation is available", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myPrsMock.mockRejectedValue(
+      new Error("No GitHub App installation found for 'acme' and no token was provided."),
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No GitHub App installation found for 'acme' and no token was provided."),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("advances to page 2 and re-queries when Next is clicked", async () => {

--- a/apps/ui/tests/components/my-reviews-page.test.tsx
+++ b/apps/ui/tests/components/my-reviews-page.test.tsx
@@ -100,20 +100,31 @@ describe("MyReviewsPage", () => {
     await waitFor(() => expect(screen.getByText(/No pull requests awaiting your review/)).toBeInTheDocument());
   });
 
-  it("surfaces a token-resolve failure with retry instead of firing the analytics query", async () => {
+  it("still queries via a connected GitHub App installation when there's no saved PAT to resolve", async () => {
     localStorage.setItem("default_org", "acme");
-    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myReviewsMock.mockResolvedValue({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
-    expect(myReviewsMock).not.toHaveBeenCalled();
-
-    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
-    myReviewsMock.mockResolvedValueOnce({ items: [PR_ITEM], total_count: 1, page: 1, per_page: 25 });
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
     await waitFor(() => expect(screen.getByText("Add feature flag")).toBeInTheDocument());
+    expect(myReviewsMock).toHaveBeenCalledWith("acme", 1, 25, undefined);
+  });
+
+  it("shows the analytics endpoint's own error when neither a saved token nor an installation is available", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    myReviewsMock.mockRejectedValue(
+      new Error("No GitHub App installation found for 'acme' and no token was provided."),
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No GitHub App installation found for 'acme' and no token was provided."),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("advances to page 2 and re-queries when Next is clicked", async () => {

--- a/apps/ui/tests/components/releases-page.test.tsx
+++ b/apps/ui/tests/components/releases-page.test.tsx
@@ -116,20 +116,31 @@ describe("ReleasesPage", () => {
     await waitFor(() => expect(screen.getByText("Failed to load releases.")).toBeInTheDocument());
   });
 
-  it("surfaces a token-resolve failure with retry instead of firing the release-timeline query", async () => {
+  it("still queries via a connected GitHub App installation when there's no saved PAT to resolve", async () => {
     localStorage.setItem("default_org", "acme");
-    tokensResolveMock.mockRejectedValue(new Error("No GitHub App installation found"));
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    releaseTimelineMock.mockResolvedValue({ org: "acme", releases: [RELEASE] });
 
     renderPage();
 
-    await waitFor(() => expect(screen.getByText("No GitHub App installation found")).toBeInTheDocument());
-    expect(releaseTimelineMock).not.toHaveBeenCalled();
-
-    tokensResolveMock.mockResolvedValueOnce({ token: "ghp_test" });
-    releaseTimelineMock.mockResolvedValueOnce({ org: "acme", releases: [RELEASE] });
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
     await waitFor(() => expect(screen.getAllByText(/v1\.2\.0/).length).toBeGreaterThan(0));
+    expect(releaseTimelineMock).toHaveBeenCalledWith("acme", "", 90);
+  });
+
+  it("shows the release-timeline endpoint's own error when neither a saved token nor an installation is available", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockRejectedValue(new Error("No saved token for this org"));
+    releaseTimelineMock.mockRejectedValue(
+      new Error("No GitHub App installation found for 'acme' and no token was provided."),
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No GitHub App installation found for 'acme' and no token was provided."),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("shows the empty state only when the query genuinely succeeds with no rows", async () => {


### PR DESCRIPTION
## Summary

A CodeRabbit-driven fix applied during PR #267's review gated the My PRs/My Reviews/My Issues/Releases pages' data queries on `resolveQuery.isSuccess` — requiring `POST /tokens/resolve` to succeed before loading any data. That endpoint only bridges the **legacy saved-PAT path** (`apps/api/src/routers/tokens.py:83`): it's `require_workspace_admin`-gated and does a direct `saved_tokens` table lookup with **no fallback to a GitHub App installation**, so it 404s if no PAT was ever saved for the org.

This broke the primary intended auth path. The actual data endpoints (`resolve_owner_token`/`resolve_org_token` in `apps/api/src/services/token_resolution.py`) already try a connected GitHub App installation first and only need a client-supplied token as a fallback, raising a clean actionable error only when neither is available. Gating on the resolve step meant:

- A workspace admin with a GitHub App installation connected but no saved PAT got "No saved token for this org" and could never load any data on these 4 pages.
- Any non-workspace-admin org member was excluded outright, since `/tokens/resolve` itself requires workspace-admin while the data endpoints only require org membership.

## What changed

- `apps/ui/app/my/prs/page.tsx`, `my/reviews/page.tsx`, `my/issues/page.tsx`, `releases/page.tsx`: reverted the query `enabled` gate back to firing once `resolveQuery` has *settled* (loading finished), not requiring it to *succeed* — matching the existing pattern already used by Overview (`app/page.tsx`), Activity, and Repos. Removed the dedicated "token resolve failed" error branch; the data query's own error message (from the backend's clean `NoGitHubTokenAvailable` text, or a real GitHub API failure) is now the single, authoritative error source shown to the user.
- Test files updated to assert the corrected behavior: a token-resolve failure no longer blocks the data query from firing, and if the data query itself succeeds (e.g. via a connected GitHub App installation), the page renders normally.

No backend changes — `resolve_owner_token`/`resolve_org_token` already behaved correctly; this was purely a frontend gating bug.

## Test plan

- [x] `bun run typecheck` / `bun run lint` — clean
- [x] `bun run test` — full suite passing
- [x] `diff-cover` against `origin/main` — 100% on the 4 changed page files
- [ ] Manual smoke test: an org with only a GitHub App installation (no saved PAT) loads My PRs/Reviews/Issues/Releases successfully as both a workspace admin and a regular org member

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “My Issues,” “My PRs,” “My Reviews,” and “Releases” pages now load data when no saved personal access token is available, using a connected GitHub App installation when possible.
  - Error messages now reflect the underlying data request, including when no GitHub App installation is available.
  - Retry actions and loading states are more consistent across these pages.

- **Tests**
  - Added coverage for GitHub App-based loading and installation-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->