### PR TITLE
fix(auth): reject passwords over 72 bytes instead of silently truncating

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -47,6 +47,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MIN_PASSWORD_LEN = 12
+# bcrypt's hard limit -- bcrypt.hashpw/checkpw raise ValueError on any input over 72 bytes
+# rather than truncating, so this must be validated before either is ever called.
+_MAX_PASSWORD_LEN = 72
 _VERIFY_TOKEN_TTL = timedelta(hours=24)
 
 
@@ -83,10 +86,19 @@ def _hash_password(password: str) -> str:
 
 
 def _verify_password(password: str, password_hash: str | None) -> bool:
-    if not password_hash:
-        bcrypt.checkpw(password.encode(), _DUMMY_PASSWORD_HASH.encode())
+    password_bytes = password.encode()
+    # No account's real password can be over _MAX_PASSWORD_LEN bytes -- setup()/register()
+    # reject it before hashing -- so an oversized guess is always wrong. Still run a real
+    # (truncated) bcrypt call rather than short-circuiting, so response timing doesn't
+    # reveal the oversized-password case any more than it reveals a nonexistent email below.
+    if len(password_bytes) > _MAX_PASSWORD_LEN:
+        password_bytes = password_bytes[:_MAX_PASSWORD_LEN]
+        bcrypt.checkpw(password_bytes, (password_hash or _DUMMY_PASSWORD_HASH).encode())
         return False
-    return bcrypt.checkpw(password.encode(), password_hash.encode())
+    if not password_hash:
+        bcrypt.checkpw(password_bytes, _DUMMY_PASSWORD_HASH.encode())
+        return False
+    return bcrypt.checkpw(password_bytes, password_hash.encode())
 
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
@@ -201,6 +213,11 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
             status_code=422,
             detail=f"Password must be at least {_MIN_PASSWORD_LEN} characters",
         )
+    if len(body.password.encode()) > _MAX_PASSWORD_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Password must be at most {_MAX_PASSWORD_LEN} bytes",
+        )
     user = User(
         email=body.email,
         name=body.name,
@@ -232,6 +249,11 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=422,
             detail=f"Password must be at least {_MIN_PASSWORD_LEN} characters",
+        )
+    if len(body.password.encode()) > _MAX_PASSWORD_LEN:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Password must be at most {_MAX_PASSWORD_LEN} bytes",
         )
     if db.query(User).filter(User.email == body.email).first():
         raise HTTPException(status_code=409, detail="An account with this email already exists")

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -47,8 +47,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MIN_PASSWORD_LEN = 12
-# bcrypt's hard limit -- bcrypt.hashpw/checkpw raise ValueError on any input over 72 bytes
-# rather than truncating, so this must be validated before either is ever called.
+# bcrypt's hard limit -- input past this point is silently ignored (bcrypt==4.2.1 pinned
+# here truncates rather than raising; only bcrypt>=5.0 raises ValueError). Left unchecked,
+# two different passwords that share the same first 72 bytes hash identically and are
+# accepted as the same password, so this must be validated (rejected, not truncated)
+# before hashing.
 _MAX_PASSWORD_LEN = 72
 _VERIFY_TOKEN_TTL = timedelta(hours=24)
 

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -83,6 +83,13 @@ def test_setup_rejects_short_password(auth_client):
     assert resp.status_code == 422
 
 
+def test_setup_rejects_password_over_72_bytes(auth_client):
+    # Regression test for issue: bcrypt.hashpw raises ValueError (unhandled 500) for any
+    # password over 72 bytes -- must be a clean 422 instead.
+    resp = auth_client.post("/auth/setup", json={"email": "a@b.com", "password": "x" * 73})
+    assert resp.status_code == 422
+
+
 def test_setup_rejects_duplicate(auth_client):
     _setup_owner(auth_client)
     resp = auth_client.post(
@@ -167,6 +174,12 @@ def test_register_before_setup_rejected(auth_client):
 def test_register_rejects_short_password(auth_client):
     _setup_owner(auth_client)
     resp = auth_client.post("/auth/register", json={"email": "a@b.com", "password": "tooshort"})
+    assert resp.status_code == 422
+
+
+def test_register_rejects_password_over_72_bytes(auth_client):
+    _setup_owner(auth_client)
+    resp = auth_client.post("/auth/register", json={"email": "a@b.com", "password": "x" * 73})
     assert resp.status_code == 422
 
 
@@ -346,6 +359,17 @@ def test_login_wrong_password(auth_client):
     _setup_owner(auth_client)
     resp = auth_client.post(
         "/auth/login", json={"email": "owner@example.com", "password": "wrongpassword12"}
+    )
+    assert resp.status_code == 401
+
+
+def test_login_password_over_72_bytes_returns_401_not_500(auth_client):
+    # Regression test for issue: bcrypt.checkpw raises ValueError (unhandled 500) for any
+    # password over 72 bytes -- an oversized login attempt must cleanly fail with 401,
+    # not crash, even though it can never match a real (<=72 byte) stored password.
+    _setup_owner(auth_client)
+    resp = auth_client.post(
+        "/auth/login", json={"email": "owner@example.com", "password": "x" * 200}
     )
     assert resp.status_code == 401
 

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -84,8 +84,9 @@ def test_setup_rejects_short_password(auth_client):
 
 
 def test_setup_rejects_password_over_72_bytes(auth_client):
-    # Regression test for issue: bcrypt.hashpw raises ValueError (unhandled 500) for any
-    # password over 72 bytes -- must be a clean 422 instead.
+    # Regression test: bcrypt silently truncates input past 72 bytes rather than raising
+    # (bcrypt==4.2.1 pinned here) -- unvalidated, two different passwords sharing the same
+    # first 72 bytes would hash identically. Must be a clean 422, not silent truncation.
     resp = auth_client.post("/auth/setup", json={"email": "a@b.com", "password": "x" * 73})
     assert resp.status_code == 422
 
@@ -363,10 +364,11 @@ def test_login_wrong_password(auth_client):
     assert resp.status_code == 401
 
 
-def test_login_password_over_72_bytes_returns_401_not_500(auth_client):
-    # Regression test for issue: bcrypt.checkpw raises ValueError (unhandled 500) for any
-    # password over 72 bytes -- an oversized login attempt must cleanly fail with 401,
-    # not crash, even though it can never match a real (<=72 byte) stored password.
+def test_login_rejects_password_over_72_bytes(auth_client):
+    # Regression test: since setup()/register() now reject any password over 72 bytes,
+    # no real stored password can be that long -- an oversized login guess must always
+    # fail with 401. Without this, bcrypt's silent truncation (bcrypt==4.2.1 pinned here)
+    # would let an oversized guess match on nothing more than a shared 72-byte prefix.
     _setup_owner(auth_client)
     resp = auth_client.post(
         "/auth/login", json={"email": "owner@example.com", "password": "x" * 200}


### PR DESCRIPTION
## Summary

Fixes #269. `_hash_password`/`_verify_password` in `apps/api/src/routers/auth.py` call `bcrypt.hashpw`/`bcrypt.checkpw` directly on raw password bytes, with only a lower-bound length check (`_MIN_PASSWORD_LEN = 12`) and no upper bound.

**Correction from the issue's original framing** (caught during code review, verified directly against the pinned dependency): `bcrypt==4.2.1` — the version actually pinned in `apps/api/requirements.txt` — does **not** raise `ValueError` for passwords over 72 bytes. That behavior was only added in `bcrypt>=5.0`. Verified with `bcrypt.checkpw()` directly: two different passwords sharing the same first 72 bytes hash and verify identically under 4.2.1 today. So the real bug on this pinned version is **silent password-collision via truncation**, not an unhandled 500 — the issue itself flagged this as a secondary concern ("bcrypt truncates at 72 bytes internally with no user-facing error today... should be replaced with an explicit 'password too long' validation error"), and that's the actual live bug here.

The fix itself doesn't change: reject oversized passwords with a clean validation error before hashing, rather than letting bcrypt silently truncate them.

## Why this approach

- **`setup()`/`register()`**: added an explicit `_MAX_PASSWORD_LEN = 72`-byte check (mirroring the existing `_MIN_PASSWORD_LEN` 422 pattern) *before* hashing, so oversized passwords get a clean validation error and can never produce a hash derived from silently-truncated input.
- **`login()`**: can't reject with 422 (unauthenticated clients shouldn't get a different status code that reveals anything), and must preserve the existing timing-safety property (`_verify_password` always runs a real bcrypt call so response timing doesn't reveal whether an email exists). Since `setup()`/`register()` now guarantee no real stored password can exceed 72 bytes, an oversized login attempt is always a wrong guess — `_verify_password` truncates the input to 72 bytes for a bounded bcrypt call (still pays the real cost against the actual stored hash) and unconditionally returns `False`, rather than relying on bcrypt's implicit truncation behavior to (coincidentally) reject it.

## Test plan
- [x] Added regression tests: `test_setup_rejects_password_over_72_bytes`, `test_register_rejects_password_over_72_bytes`, `test_login_rejects_password_over_72_bytes`
- [x] Full backend suite: `pytest -q` — 599 passed
- [x] Manually verified against the pinned `bcrypt==4.2.1`: `bcrypt.checkpw(b"a"*72+b"AAAA", hash_of(b"a"*72+b"BBBB"))` returns `True` on unpatched behavior, confirming the real collision bug
- [x] `apps/ui` unaffected (backend-only change); pre-commit `tsc --noEmit` passed

No migration, no other sensitive-file changes beyond the auth router itself.