### PR TITLE
fix(auth): apply rate limiting to /auth/setup

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -182,7 +182,7 @@ def setup_required(db: Session = Depends(get_db)):
     return {"setup_required": count == 0}
 
 
-@router.post("/setup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/setup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(rate_limit())])
 def setup(body: SetupRequest, db: Session = Depends(get_db)):
     """First-run only. Returns 409 if any user already exists."""
     # Two concurrent /auth/setup calls with *different* emails can both pass the

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -91,6 +91,20 @@ def test_setup_rejects_duplicate(auth_client):
     assert resp.status_code == 409
 
 
+def test_setup_applies_a_per_ip_rate_limit(auth_client):
+    # Regression test for issue #279: /auth/setup was missing the rate_limit() dependency
+    # applied to every sibling auth endpoint (register/login/verify-email/resend-verification).
+    _setup_owner(auth_client)  # call 1 (201)
+    for _ in range(9):  # calls 2-10 (409, setup already complete) -- still count toward the limit
+        auth_client.post(
+            "/auth/setup", json={"email": "other@example.com", "password": "supersecret1234"}
+        )
+    resp = auth_client.post(  # call 11 -- exceeds the default max_requests=10
+        "/auth/setup", json={"email": "another@example.com", "password": "supersecret1234"}
+    )
+    assert resp.status_code == 429
+
+
 def test_setup_advisory_lock_serializes_concurrent_holders(_engine):
     # Regression test for issue #218: two concurrent /auth/setup calls with *different*
     # emails both pass the count()==0 check before either commits, and (unlike the


### PR DESCRIPTION
## Summary

Fixes #279. `/auth/setup` (`apps/api/src/routers/auth.py:185`) was missing `dependencies=[Depends(rate_limit())]`, unlike every sibling auth endpoint (`register`, `login`, `verify-email`, `resend-verification`).

## Why this matters

`/auth/setup` is guarded by a Postgres advisory lock (`pg_advisory_xact_lock`) plus a `count() > 0` check, but that only protects against two *concurrent* setup calls racing to create the first admin (a correctness/race safeguard) -- it does nothing to throttle a single caller hitting the unauthenticated endpoint repeatedly before first-run setup completes. Since setup becomes a no-op 409 after the first admin exists, real-world severity is low, but it's an unauthenticated POST that runs password-validation logic on every call, with no rate limit unlike its siblings.

## Change

One-line addition: `dependencies=[Depends(rate_limit())]` on the `/setup` route decorator, matching the existing pattern used by `register`/`login`/`verify-email`/`resend-verification`. No change to the advisory-lock logic itself -- the two mechanisms address different problems (race safety vs. abuse throttling) and both are needed.

## Test plan
- [x] Added `test_setup_applies_a_per_ip_rate_limit`, mirroring the existing `test_rate_limit.py` pattern: exceeds the default `max_requests=10` and asserts a 429 on the 11th call.
- [x] Full backend suite: `pytest -q` -- 599 passed.

No migration, no other sensitive-file changes beyond the auth router itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-IP rate limiting to the authentication setup endpoint.
  * Excessive setup requests now return a rate-limit response, helping protect the endpoint from abuse.

* **Tests**
  * Added coverage to verify rate limits are enforced consistently, including after unsuccessful setup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->