### PR TITLE
refactor(ui): extract shared no-account-selected empty state

### DIFF
--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { ActivityList } from "@/components/activity-list"
 import { EventFeed } from "@/components/event-feed"
 import { HeatmapCalendar } from "@/components/charts/heatmap-calendar"
 import { SectionError } from "@/components/section-error"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
 import { api } from "@/lib/api/client"
@@ -178,14 +178,7 @@ export default function ActivityPage() {
             {feedTab === "feed" && hasOrg && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
           </div>
           {!hasOrg ? (
-            <div className="px-4 py-8">
-              <p className="text-sm text-muted-foreground">
-                No account selected yet. Pick one from the profile menu, or{" "}
-                <Link href="/security" className="text-primary hover:underline">
-                  configure →
-                </Link>
-              </p>
-            </div>
+            <EmptyStateNoAccount bare />
           ) : feedTab === "feed" && eventsQuery.isError ? (
             <SectionError
               message={eventsQuery.error instanceof Error ? eventsQuery.error.message : "Failed to load events."}

--- a/apps/ui/app/my/issues/page.tsx
+++ b/apps/ui/app/my/issues/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { MyItemsList } from "@/components/my-items-list"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
@@ -42,16 +42,7 @@ export default function MyIssuesPage() {
     <>
       <PageHeader title="My Issues" description="Issues assigned to you." />
 
-      {orgChecked && !org && (
-        <div className="card mb-6">
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            No account selected yet — this page has nothing to query. Pick an organization or your personal
-            account from the profile menu, or connect one in{" "}
-            <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-            haven&rsquo;t already.
-          </p>
-        </div>
-      )}
+      {orgChecked && !org && <EmptyStateNoAccount />}
 
       {org && (
         <MyItemsList

--- a/apps/ui/app/my/prs/page.tsx
+++ b/apps/ui/app/my/prs/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { MyItemsList } from "@/components/my-items-list"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
@@ -42,16 +42,7 @@ export default function MyPRsPage() {
     <>
       <PageHeader title="My PRs" description="Pull requests you've authored." />
 
-      {orgChecked && !org && (
-        <div className="card mb-6">
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            No account selected yet — this page has nothing to query. Pick an organization or your personal
-            account from the profile menu, or connect one in{" "}
-            <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-            haven&rsquo;t already.
-          </p>
-        </div>
-      )}
+      {orgChecked && !org && <EmptyStateNoAccount />}
 
       {org && (
         <MyItemsList

--- a/apps/ui/app/my/reviews/page.tsx
+++ b/apps/ui/app/my/reviews/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { MyItemsList } from "@/components/my-items-list"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
@@ -42,16 +42,7 @@ export default function MyReviewsPage() {
     <>
       <PageHeader title="My Reviews" description="PRs awaiting your review." />
 
-      {orgChecked && !org && (
-        <div className="card mb-6">
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            No account selected yet — this page has nothing to query. Pick an organization or your personal
-            account from the profile menu, or connect one in{" "}
-            <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-            haven&rsquo;t already.
-          </p>
-        </div>
-      )}
+      {orgChecked && !org && <EmptyStateNoAccount />}
 
       {org && (
         <MyItemsList

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -14,6 +14,7 @@ import { useActiveScope } from "@/lib/active-scope"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
 import { SectionError } from "@/components/section-error"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import type { MyViewIssueSummary, MyViewPRSummary } from "@/lib/api/types"
 
 const MY_VIEW_TABS = [
@@ -152,16 +153,7 @@ export default function OverviewPage() {
     <>
       <PageHeader title="Overview" description="Your GitHub organization at a glance." />
 
-      {orgChecked && !org && (
-        <div className="card mb-6">
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            No account selected yet — this page has nothing to query. Pick an organization or your personal
-            account from the profile menu, or connect one in{" "}
-            <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-            haven&rsquo;t already.
-          </p>
-        </div>
-      )}
+      {orgChecked && !org && <EmptyStateNoAccount />}
 
       {org && orgQueryIsError && (
         <div className="card mb-6">

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStateInline } from "@/components/empty-state"
+import { EmptyStateInline, EmptyStateNoAccount } from "@/components/empty-state"
 import { SectionError } from "@/components/section-error"
 import { relativeTime } from "@/lib/format"
 import { api } from "@/lib/api/client"
@@ -44,16 +43,7 @@ export default function ReleasesPage() {
     <>
       <PageHeader title="Releases" description="Release history across your organization." />
 
-      {orgChecked && !org && (
-        <div className="card mb-6">
-          <p className="px-4 py-6 text-sm text-muted-foreground">
-            No account selected yet — this page has nothing to query. Pick an organization or your personal
-            account from the profile menu, or connect one in{" "}
-            <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-            haven&rsquo;t already.
-          </p>
-        </div>
-      )}
+      {orgChecked && !org && <EmptyStateNoAccount />}
 
       {org && (
         <div className="card">

--- a/apps/ui/components/empty-state.tsx
+++ b/apps/ui/components/empty-state.tsx
@@ -1,8 +1,11 @@
+import Link from "next/link"
+
 /**
- * Two empty state variants — no icons, no centered layouts, just text.
+ * Empty state variants — no icons, no centered layouts, just text.
  *
- * <EmptyStateInline>  — inside a card/table where data would be
- * <EmptyStatePage>    — when a whole feature section has no data yet
+ * <EmptyStateInline>    — inside a card/table where data would be
+ * <EmptyStatePage>      — when a whole feature section has no data yet
+ * <EmptyStateNoAccount> — no org/personal account selected in the profile menu
  */
 
 interface EmptyStateInlineProps {
@@ -44,6 +47,23 @@ export function EmptyStatePage({ message, action }: EmptyStatePageProps) {
       </p>
     </div>
   )
+}
+
+interface EmptyStateNoAccountProps {
+  /** Skip the outer card wrapper -- for use inside a panel that's already a card. */
+  bare?: boolean
+}
+
+export function EmptyStateNoAccount({ bare = false }: EmptyStateNoAccountProps) {
+  const message = (
+    <p className="px-4 py-6 text-sm text-muted-foreground">
+      No account selected yet — this page has nothing to query. Pick an organization or your personal
+      account from the profile menu, or connect one in{" "}
+      <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
+      haven&rsquo;t already.
+    </p>
+  )
+  return bare ? message : <div className="card mb-6">{message}</div>
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #278. The same ~9-line "no account selected" card+paragraph+`Settings`-link block was copy-pasted across `apps/ui/app/releases/page.tsx`, `apps/ui/app/my/issues/page.tsx`, `apps/ui/app/my/prs/page.tsx`, `apps/ui/app/my/reviews/page.tsx`, and the home page (`apps/ui/app/page.tsx`), instead of using a shared component. `apps/ui/app/activity/page.tsx` already had its own copy that had drifted (different wording, no card wrapper, links to `/security` instead of `/settings`) — exactly the kind of drift the issue calls out as having already happened once before.

## Change

- Added `EmptyStateNoAccount` to `apps/ui/components/empty-state.tsx`, alongside the existing `EmptyStateInline`/`EmptyStatePage` variants. It supports a `bare` prop to skip the outer card wrapper, since Activity's usage sits inside a panel that's already a card.
- Swapped all 6 sites (the 5 identical ones + Activity) to use it, which also reconciles Activity's copy/link back in line with the rest rather than leaving it diverged.
- Removed now-unused `Link` imports from the pages that no longer reference it directly.

No backend changes. No new dependencies.

## Test plan
- [x] `bun run check` (typecheck + lint + build) — passes
- [x] `bun run test` — 353 passed (existing empty-state assertions in `releases-page.test.tsx`, `overview-page.test.tsx`, `my-issues-page.test.tsx`, `my-prs-page.test.tsx`, `my-reviews-page.test.tsx`, `activity-page.test.tsx` all use loose text-regex matches like `/No account selected/`, so they continue to pass unchanged against the shared component's markup)
- [x] Manually confirmed all 6 test files that assert on this empty state still pass in isolation