### PR TITLE
fix(ui,worker): support per-cache-key clear and surface GitHub's error body

### DIFF
--- a/apps/ui/components/repo/cache-panel.tsx
+++ b/apps/ui/components/repo/cache-panel.tsx
@@ -32,6 +32,9 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
   const [tokenSaved, setTokenSaved] = useState(false)
   const [actor, setActor] = useState("")
   const [clearArmed, setClearArmed] = useState(false)
+  // null = clearing every cache for this repo (the existing global buttons); set to a
+  // specific { key, ref } when the user clicks a row's own "Clear" action instead.
+  const [clearTarget, setClearTarget] = useState<{ key: string; ref: string } | null>(null)
 
   // Auto-resolve saved token for this owner
   const resolveMutation = useMutation({
@@ -74,6 +77,7 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
     listMutation.reset()
     clearMutation.reset()
     setClearArmed(false)
+    setClearTarget(null)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner, repo])
 
@@ -97,7 +101,13 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
 
   const clearMutation = useMutation({
     mutationFn: (dryRun: boolean) =>
-      api.cache.clear(owner, repo, { token, actor, dry_run: dryRun }),
+      api.cache.clear(owner, repo, {
+        token,
+        actor,
+        dry_run: dryRun,
+        key: clearTarget?.key,
+        ref: clearTarget?.ref,
+      }),
   })
 
   const isLoading = listMutation.isPending || clearMutation.isPending
@@ -188,7 +198,7 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
           <div className="grid grid-cols-2 gap-2">
             <Button
               variant="outline"
-              onClick={() => { setClearArmed(false); clearMutation.mutate(true) }}
+              onClick={() => { setClearArmed(false); setClearTarget(null); clearMutation.mutate(true) }}
               disabled={isLoading || !actor}
             >
               <Eye className="size-3.5" />
@@ -197,23 +207,26 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
             <Button
               variant="destructive"
               onClick={() => {
-                if (clearArmed) {
+                if (clearArmed && clearTarget === null) {
                   setClearArmed(false)
                   clearMutation.mutate(false)
                 } else {
+                  setClearTarget(null)
                   setClearArmed(true)
                 }
               }}
               disabled={isLoading || !actor}
             >
               <Trash className="size-3.5" />
-              {clearArmed ? "Confirm clear" : "Clear"}
+              {clearArmed && clearTarget === null ? "Confirm clear" : "Clear"}
             </Button>
           </div>
           {clearArmed && (
             <p className="text-xs text-yellow-400/80 flex items-center gap-1.5">
               <Warning className="size-3 shrink-0" />
-              Click again to permanently delete these caches — this can&rsquo;t be undone.
+              {clearTarget
+                ? <>Click the row&rsquo;s confirm action again to permanently delete <span className="font-mono">{clearTarget.key}</span> — this can&rsquo;t be undone.</>
+                : "Click again to permanently delete these caches — this can’t be undone."}
             </p>
           )}
           {clearMutation.isError && (
@@ -292,12 +305,14 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
                   <th className="text-right text-muted-foreground font-medium px-4 py-2">Size</th>
                   <th className="text-right text-muted-foreground font-medium px-4 py-2">Created</th>
                   <th className="text-right text-muted-foreground font-medium px-4 py-2">Last accessed</th>
+                  <th className="px-4 py-2" />
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
                 {caches.map((c) => {
                   const staleness = classifyStaleness(c.last_accessed_at)
                   const { text: staleText, dot: staleDot } = stalenessColor[staleness]
+                  const isThisRowArmed = clearArmed && clearTarget?.key === c.key && clearTarget?.ref === c.ref
                   return (
                     <tr key={c.id} className="hover:bg-muted/40 transition-colors">
                       <td className="px-4 py-2.5 font-mono text-foreground/80 max-w-[14rem] truncate">{c.key}</td>
@@ -313,6 +328,25 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
                           <span className={`inline-block size-1.5 rounded-full ${staleDot}`} />
                           {relativeTime(c.last_accessed_at)}
                         </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        <Button
+                          variant="outline"
+                          className="h-6 px-2 text-[0.6875rem]"
+                          disabled={isLoading || !actor}
+                          onClick={() => {
+                            if (isThisRowArmed) {
+                              setClearArmed(false)
+                              clearMutation.mutate(false)
+                            } else {
+                              setClearTarget({ key: c.key, ref: c.ref })
+                              setClearArmed(true)
+                            }
+                          }}
+                        >
+                          <Trash className="size-3" />
+                          {isThisRowArmed ? "Confirm clear key" : "Clear key"}
+                        </Button>
                       </td>
                     </tr>
                   )

--- a/apps/ui/tests/components/cache-page.test.tsx
+++ b/apps/ui/tests/components/cache-page.test.tsx
@@ -269,6 +269,49 @@ describe("CachePage", () => {
     expect(await screen.findByText(/could not clear caches/i)).toBeInTheDocument();
   });
 
+  it("clears a single row's cache via its own key-scoped Clear key action, without affecting others", async () => {
+    cacheListMock.mockResolvedValue({
+      actions_caches: [
+        {
+          id: 1,
+          key: "api-cache-key",
+          ref: "refs/heads/main",
+          size_in_bytes: 1024,
+          created_at: "2026-01-01T00:00:00Z",
+          last_accessed_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+    cacheClearMock.mockResolvedValue({ queued: true, dry_run: false, job_id: 9 });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /load caches/i }));
+    await waitFor(() => expect(screen.getByText("api-cache-key")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
+    const clearKeyButton = screen.getByRole("button", { name: /^clear key$/i });
+    await waitFor(() => expect(clearKeyButton).not.toBeDisabled());
+    fireEvent.click(clearKeyButton);
+
+    expect(cacheClearMock).not.toHaveBeenCalled();
+    const confirmButton = await screen.findByRole("button", { name: /confirm clear key/i });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() =>
+      expect(cacheClearMock).toHaveBeenCalledWith("acme", "demo", {
+        token: "",
+        actor: "me@example.com",
+        dry_run: false,
+        key: "api-cache-key",
+        ref: "refs/heads/main",
+      }),
+    );
+
+    // The global "Clear" button, not this row's, must stay unarmed by the row action.
+    expect(screen.getByRole("button", { name: /^clear$/i })).toBeInTheDocument();
+  });
+
   it("clears the stale cache table and clear result when navigating to a different repo under the same owner", async () => {
     cacheListMock.mockResolvedValue({
       actions_caches: [

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -203,12 +203,12 @@ def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_r
     if resp.status_code >= 500:
         # 5xx is presumed transient (GitHub-side issue) — worth retrying, unlike 4xx.
         log.warning("job %d got a %d from GitHub (attempt %d)", job_id, resp.status_code, retry_count + 1)
-        _requeue_for_retry(conn, job_id, retry_count, _github_error_message(resp))
+        _requeue_for_retry(conn, job_id, retry_count, sanitize_error(_github_error_message(resp)))
         return
 
     if resp.status_code >= 300:
         log.error("job %d failed: GitHub API error %d", job_id, resp.status_code)
-        _mark_failed(conn, job_id, _github_error_message(resp), retry_count)
+        _mark_failed(conn, job_id, sanitize_error(_github_error_message(resp)), retry_count)
         return
 
     _mark_done(conn, job_id, {"ok": True, "status": resp.status_code}, retry_count)

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -152,6 +152,19 @@ def process_job(conn: psycopg.Connection, job_id: int, job_type: str, payload_ra
         _mark_failed(conn, job_id, sanitize_error(error), retry_count)
 
 
+def _github_error_message(resp: httpx.Response) -> str:
+    """Prefer GitHub's own error message over a bare status code, so jobs.result
+    tells an operator *why* a clear failed (e.g. "Resource not accessible by
+    integration") instead of just "GitHub API error: 403"."""
+    try:
+        message = resp.json().get("message")
+    except (ValueError, AttributeError):
+        message = None
+    if message:
+        return f"GitHub API error: {resp.status_code} - {message}"
+    return f"GitHub API error: {resp.status_code}"
+
+
 def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_raw: str, retry_count: int) -> None:
     try:
         payload = ClearActionsCachePayload.model_validate_json(payload_raw)
@@ -190,12 +203,12 @@ def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_r
     if resp.status_code >= 500:
         # 5xx is presumed transient (GitHub-side issue) — worth retrying, unlike 4xx.
         log.warning("job %d got a %d from GitHub (attempt %d)", job_id, resp.status_code, retry_count + 1)
-        _requeue_for_retry(conn, job_id, retry_count, f"GitHub API error: {resp.status_code}")
+        _requeue_for_retry(conn, job_id, retry_count, _github_error_message(resp))
         return
 
     if resp.status_code >= 300:
         log.error("job %d failed: GitHub API error %d", job_id, resp.status_code)
-        _mark_failed(conn, job_id, f"GitHub API error: {resp.status_code}", retry_count)
+        _mark_failed(conn, job_id, _github_error_message(resp), retry_count)
         return
 
     _mark_done(conn, job_id, {"ok": True, "status": resp.status_code}, retry_count)

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -91,6 +91,31 @@ def test_process_job_marks_failed_on_4xx_http_error():
     assert conn.committed is True
 
 
+def test_process_job_marks_failed_with_status_code_only_when_error_body_is_not_json():
+    """_github_error_message must fall back to a bare status code (not crash) when
+    GitHub's error body isn't valid JSON."""
+    conn = _FakeConn()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "not found"
+    mock_response.json.side_effect = ValueError("not json")
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 9, "github.clear_actions_cache", _payload())
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert params[0] == "GitHub API error: 404"
+    assert conn.committed is True
+
+
 def test_process_job_marks_failed_when_token_decryption_fails():
     """A payload with a token that fails to decrypt is a permanent failure, not a retry."""
     conn = _FakeConn()


### PR DESCRIPTION
## Summary

Fixes #274.

- **UI**: The Actions Cache panel's "Clear" button always cleared *every* cache for a repo, even though the backend (`CacheClearInput.key`/`.ref`) and the table itself (each row already shows its `key`) fully supported scoping to one entry. Added a per-row "Clear key" action that scopes the same `clearMutation` to that row's `{ key, ref }`, using the same two-click "arm then confirm" pattern as the existing global Clear button. The global button is unchanged and still clears everything when no row is targeted.
- **Worker**: `_mark_failed`/`_requeue_for_retry` only ever recorded the bare HTTP status code in `jobs.result` (e.g. `"GitHub API error: 403"`). Added a `_github_error_message` helper that reads GitHub's JSON error body's `message` field when present, so a failed job's audit trail shows *why* it failed (e.g. `"Resource not accessible by integration"`) instead of just a status code.
- **Nav**: confirmed the standalone `/repos/{repo}/cache` route is already linked from the repos list page's per-row "Cache" link (`apps/ui/app/repos/page.tsx:161`) — not orphaned, no change needed there.

No backend/schema change was required — `CacheClearInput`, `cache_service.clear()`, and the worker's `_handle_clear_actions_cache` already plumbed `key`/`ref` through end-to-end; only the UI never collected them.

## Why

Without a way to clear a single stale cache entry, the only option in the UI was "clear everything for this repo," which is unnecessarily destructive for the common case of wanting to evict one bad/stale cache key. And a failed clear job's error message ("GitHub API error: 403") gave an operator no way to tell *why* it failed without going to GitHub's own UI.

## Test plan
- [x] `bun run typecheck`, `bun run lint`, full `bunx vitest run` (354 tests) all pass locally
- [x] New test: "clears a single row's cache via its own key-scoped Clear key action, without affecting others" in `cache-page.test.tsx`, asserting the row action calls `api.cache.clear` with `key`/`ref` set and doesn't arm the global button
- [x] `apps/worker/tests/test_process_job.py` unit tests (mocked httpx) pass — 13/15 pass; 2 unrelated reclaim/DB-integration tests error locally only because no local Postgres is running (pre-existing environment limitation, not caused by this change)