### PR TITLE
fix(ui): show a 'no account selected' prompt on the Repos page

### DIFF
--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -183,6 +184,14 @@ export default function ReposPage() {
     setOwner(scopeOrgLogin)
   }, [scopeOrgLogin])
 
+  // Same pattern as the other pages that gate on useActiveScope() (see app/page.tsx,
+  // app/my/prs/page.tsx, etc.) -- deferred a tick so this doesn't flash before
+  // useActiveScope's first read of localStorage resolves.
+  const [scopeChecked, setScopeChecked] = useState(false)
+  useEffect(() => {
+    setScopeChecked(true)
+  }, [])
+
   const { data: installs = [] } = useQuery<InstallationMeta[]>({
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
@@ -264,6 +273,8 @@ export default function ReposPage() {
         title="Repositories"
         description="Browse an organization's repositories — activity, open PRs, and cache access."
       />
+
+      {scopeChecked && !scope && <EmptyStateNoAccount />}
 
       <div className="grid gap-4 lg:grid-cols-3">
         {/* Config panel */}

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -274,7 +274,9 @@ export default function ReposPage() {
         description="Browse an organization's repositories — activity, open PRs, and cache access."
       />
 
-      {scopeChecked && !scope && <EmptyStateNoAccount />}
+      {scopeChecked && !scope && (
+        <EmptyStateNoAccount message="No account selected — pick an organization from the profile menu to prefill the search below, or just type one in directly." />
+      )}
 
       <div className="grid gap-4 lg:grid-cols-3">
         {/* Config panel */}

--- a/apps/ui/components/empty-state.tsx
+++ b/apps/ui/components/empty-state.tsx
@@ -52,15 +52,23 @@ export function EmptyStatePage({ message, action }: EmptyStatePageProps) {
 interface EmptyStateNoAccountProps {
   /** Skip the outer card wrapper -- for use inside a panel that's already a card. */
   bare?: boolean
+  /** Override the default "this page has nothing to query" copy -- for pages (like
+   * Repos) where a manual search still works without an active scope, so the default
+   * wording would be misleading. */
+  message?: string
 }
 
-export function EmptyStateNoAccount({ bare = false }: EmptyStateNoAccountProps) {
+export function EmptyStateNoAccount({ bare = false, message: messageOverride }: EmptyStateNoAccountProps) {
   const message = (
     <p className="px-4 py-6 text-sm text-muted-foreground">
-      No account selected yet — this page has nothing to query. Pick an organization or your personal
-      account from the profile menu, or connect one in{" "}
-      <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-      haven&rsquo;t already.
+      {messageOverride ?? (
+        <>
+          No account selected yet — this page has nothing to query. Pick an organization or your personal
+          account from the profile menu, or connect one in{" "}
+          <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
+          haven&rsquo;t already.
+        </>
+      )}
     </p>
   )
   return bare ? message : <div className="card mb-6">{message}</div>

--- a/apps/ui/tests/components/empty-state.test.tsx
+++ b/apps/ui/tests/components/empty-state.test.tsx
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 
-import { EmptyStateInline, EmptyStatePage } from "@/components/empty-state";
+import { EmptyStateInline, EmptyStateNoAccount, EmptyStatePage } from "@/components/empty-state";
+
+afterEach(cleanup);
 
 describe("EmptyStateInline", () => {
   it("renders the noun with no qualifier", () => {
@@ -35,5 +37,18 @@ describe("EmptyStatePage", () => {
 
     const link = screen.getByRole("link", { name: "Configure" });
     expect(link).toHaveAttribute("href", "/security");
+  });
+});
+
+describe("EmptyStateNoAccount", () => {
+  it("renders the default copy when no message override is given", () => {
+    render(<EmptyStateNoAccount />);
+    expect(screen.getByText(/this page has nothing to query/)).toBeInTheDocument();
+  });
+
+  it("renders a custom message when one is provided", () => {
+    render(<EmptyStateNoAccount message="No account selected — type an organization below." />);
+    expect(screen.getByText("No account selected — type an organization below.")).toBeInTheDocument();
+    expect(screen.queryByText(/this page has nothing to query/)).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -85,7 +85,7 @@ describe("ReposPage", () => {
 
   it("shows a 'no account selected' prompt when no active scope is set, without blocking manual org entry", async () => {
     renderPage();
-    expect(await screen.findByText(/No account selected yet/)).toBeInTheDocument();
+    expect(await screen.findByText(/No account selected/)).toBeInTheDocument();
     // Unlike the fully scope-driven pages (My PRs, etc.), this page's org field is a
     // manual search tool that works independent of the active scope -- the prompt is
     // informational only, not a replacement for the form.
@@ -96,7 +96,7 @@ describe("ReposPage", () => {
     localStorage.setItem("active_scope", JSON.stringify({ kind: "org", login: "acme" }));
     renderPage();
     await waitFor(() => expect(screen.getByPlaceholderText("e.g. octocat")).toHaveValue("acme"));
-    expect(screen.queryByText(/No account selected yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/No account selected/)).not.toBeInTheDocument();
   });
 
   it("hides the GitHub Token field when an installation covers the entered org", async () => {

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -83,6 +83,22 @@ describe("ReposPage", () => {
     expect(screen.getByRole("button", { name: /load repositories/i })).toBeDisabled();
   });
 
+  it("shows a 'no account selected' prompt when no active scope is set, without blocking manual org entry", async () => {
+    renderPage();
+    expect(await screen.findByText(/No account selected yet/)).toBeInTheDocument();
+    // Unlike the fully scope-driven pages (My PRs, etc.), this page's org field is a
+    // manual search tool that works independent of the active scope -- the prompt is
+    // informational only, not a replacement for the form.
+    expect(screen.getByPlaceholderText("e.g. octocat")).toBeInTheDocument();
+  });
+
+  it("does not show the 'no account selected' prompt once an org scope is active", async () => {
+    localStorage.setItem("active_scope", JSON.stringify({ kind: "org", login: "acme" }));
+    renderPage();
+    await waitFor(() => expect(screen.getByPlaceholderText("e.g. octocat")).toHaveValue("acme"));
+    expect(screen.queryByText(/No account selected yet/)).not.toBeInTheDocument();
+  });
+
   it("hides the GitHub Token field when an installation covers the entered org", async () => {
     installationsListMock.mockResolvedValue([
       { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },


### PR DESCRIPTION
## Summary

Fixes #277.

The six other pages that render `useActiveScope()`-driven content (Releases, Overview, Activity, My Issues, My PRs, My Reviews) all show the shared `EmptyStateNoAccount` card when nothing is selected in the profile menu. The Repos page had no equivalent — with no active scope, it silently rendered just a blank org/token form and disabled "Load repositories" button, with no explanation.

Unlike those six pages, Repos' org field is a manual search tool that already works independent of the active scope — it only pre-fills the org input when an org-kind scope is active, but stays fully usable for any org the user types regardless of scope. So rather than hard-gating the whole page behind the scope check (which would remove the ability to manually search any org), the `EmptyStateNoAccount` banner renders as an informational addition above the existing form when there's no scope, matching the visual pattern used everywhere else without changing the page's actual (already-correct) behavior.

## Test plan
- [x] `bun run typecheck`, `bun run lint`, full `bunx vitest run` (379 tests) all pass locally
- [x] `diff-cover` locally: 100% on the changed lines in `apps/ui/app/repos/page.tsx`
- [x] New tests in `repos-page.test.tsx`: shows the prompt with no active scope (without blocking the org field); prompt disappears once an org scope is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational message when no account is selected on the repositories page.
  * The message appears after the active account status is checked and does not interfere with manual organization selection.
  * When an account is selected, its organization is displayed and the no-account message remains hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->