### PR TITLE
fix(ui): trim owner before matching personal installations

### DIFF
--- a/apps/ui/app/automation/page.tsx
+++ b/apps/ui/app/automation/page.tsx
@@ -60,7 +60,7 @@ export default function AutomationPage() {
     retry: false,
   })
   const hasInstallationForOwner =
-    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
+    installs.some((i) => i.account_login === owner.trim()) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -199,7 +199,7 @@ export default function ReposPage() {
     retry: false,
   })
   const hasInstallationForOwner =
-    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
+    installs.some((i) => i.account_login === owner.trim()) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -118,7 +118,7 @@ export default function SecurityPage() {
     retry: false,
   })
   const hasInstallationForOwner =
-    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
+    installs.some((i) => i.account_login === owner.trim()) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),

--- a/apps/ui/tests/components/automation-page.test.tsx
+++ b/apps/ui/tests/components/automation-page.test.tsx
@@ -84,6 +84,20 @@ describe("AutomationPage", () => {
     });
   });
 
+  it("hides the GitHub Token field when a personal installation covers the entered owner with trailing whitespace", async () => {
+    // Regression test (CodeRabbit finding on PR #299): the personal-installation match
+    // compared account_login against raw owner state, so "acme " (untrimmed) never
+    // matched an "acme" installation and incorrectly left the token field visible.
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme " } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
   it("hides the GitHub Token field when an org-level installation covers the entered owner", async () => {
     // Regression test: api.installations.list() only ever returns the caller's *personal*
     // installations -- an org's App installation must be checked via the separate

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -94,6 +94,20 @@ describe("ReposPage", () => {
     });
   });
 
+  it("hides the GitHub Token field when an installation covers the entered org with trailing whitespace", async () => {
+    // Regression test (CodeRabbit finding on PR #299): the personal-installation match
+    // compared account_login against raw owner state, so "acme " (untrimmed) never
+    // matched an "acme" installation and incorrectly left the token field visible.
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme " } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
   it("hides the GitHub Token field when an org-level installation covers the entered org", async () => {
     // Regression test: api.installations.list() only ever returns the caller's *personal*
     // installations -- an org's App installation must be checked via the separate

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -109,6 +109,20 @@ describe("SecurityPage", () => {
     });
   });
 
+  it("hides the GitHub Token field when an installation covers the entered org with trailing whitespace", async () => {
+    // Regression test (CodeRabbit finding on PR #299): the personal-installation match
+    // compared account_login against raw owner state, so "acme " (untrimmed) never
+    // matched an "acme" installation and incorrectly left the token field visible.
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme " } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
   it("hides the GitHub Token field when an org-level installation covers the entered org", async () => {
     // Regression test: api.installations.list() only ever returns the caller's *personal*
     // installations -- an org's App installation must be checked via the separate


### PR DESCRIPTION
## Summary

CodeRabbit flagged this on PR #299 (\`hasInstallationForOwner\` comparing \`account_login\` against untrimmed owner input on Automation/Security/Repos, so \`"acme "\` never matched an \`"acme"\` installation and incorrectly left the token field visible), and I fixed it there — but PR #299 got merged before that follow-up commit was pushed, so both the fix and its regression tests never actually landed on \`main\`. This PR restores them.

- \`apps/ui/app/automation/page.tsx\`, \`apps/ui/app/security/page.tsx\`, \`apps/ui/app/repos/page.tsx\`: \`installs.some((i) => i.account_login === owner)\` → \`=== owner.trim()\`, matching each page's already-trimmed org-scoped installations query.
- \`apps/ui/components/repo/cache-panel.tsx\` is unaffected — its \`owner\` is a route-derived prop (already clean), not free-text state, and its own installations check already uses \`owner\` consistently throughout.

No backend/schema change.

## Test plan
- [x] \`bun run typecheck\`, \`bun run lint\`, full \`bunx vitest run\` (all pass locally)
- [x] \`diff-cover\` locally: 100% on the three changed lines
- [x] Restored the three regression tests (one per page) asserting the token field still hides when the entered org has trailing whitespace but a matching installation exists