### PR TITLE
chore(hooks): add pre-push checks, require setup before commit/push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-cd apps/ui && bun run typecheck
+cd apps/ui && bun run typecheck && bun run lint && bun run build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# pytest hits a real Postgres (see AGENTS.md) — make sure one is reachable
+# (e.g. `docker compose up db`) before pushing.
+(cd apps/ui && bun run test && bun run build) && pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,11 @@ Migration files live in `apps/api/alembic/versions/`. Use zero-padded 4-digit pr
 
 Conventional Commits are enforced via commitlint + husky. Format: `type(scope): subject`. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`. Merge commits are excluded from linting.
 
+**Git hooks (husky, `.husky/`):**
+- `commit-msg` — commitlint against Conventional Commits.
+- `pre-commit` — `cd apps/ui && bun run typecheck && bun run lint && bun run build`.
+- `pre-push` — `cd apps/ui && bun run test && bun run build`, then `pytest -q` from the repo root (needs a reachable Postgres — see Running locally).
+
 ## Guardrails for AI Agents
 
 These apply to every AI tool working in this repo, not just Claude Code.
@@ -184,6 +189,12 @@ No dropping or truncating tables. No bypassing `require_org_role("admin")` on pr
 ### 4. Don't scope-creep
 
 A bug fix doesn't need surrounding cleanup. Don't touch files outside what was asked. Don't add abstractions for hypothetical future requirements. Most damage from AI agents in a mature codebase comes from unrequested "improvements," not from wrong facts — keep changes scoped to the task.
+
+### 5. Complete setup before your first commit or push
+
+**Mandatory:** before touching this repo, run the full One-time setup block (see Development setup above) — `pip install -r apps/api/requirements.txt`, `pip install -r requirements-test.txt`, `pip install -e packages/checks`, `cd apps/ui && bun install`. The `pre-commit` hook shells out to `bun run typecheck && bun run lint && bun run build`; without `bun install` first it fails with confusing "command not found" / missing-`node_modules` errors rather than a real typecheck/lint/build result. Before your first `git push`, also make sure a local Postgres is reachable (`docker compose up db`, with `DB_*`/`DATABASE_URL` set) — `pre-push` runs `pytest -q`, which hits a real database.
+
+Never bypass a failing hook with `--no-verify`, `HUSKY=0`, or by editing/deleting files under `.husky/` — fix the underlying failure (usually a missing dependency or a real lint/type/test error) instead.
 
 ## AI Attribution Policy
 


### PR DESCRIPTION
## Summary

- Adds a `pre-push` husky hook (didn't exist before): `cd apps/ui && bun run test && bun run build`, then `pytest -q` from the repo root. Previously nothing ran locally before a push, so a broken UI test/build or a broken Python test could only be caught by CI.
- Extends the existing `pre-commit` hook from `bun run typecheck` only to `bun run typecheck && bun run lint && bun run build`, so lint and build errors are caught at commit time instead of push/CI time. (`bun run build` intentionally also stays in `pre-push`, since a commit-time build failure and a push-time build failure catch different things — e.g. build issues introduced by commits made with `--no-verify`.)
- Adds a mandatory guardrail (`AGENTS.md`, new "Complete setup before your first commit or push" section) telling every AI agent (and human contributor) to run the existing one-time setup (`bun install`, the `pip install` steps) before their first commit, and to have a local Postgres reachable before their first push — because `pre-commit`/`pre-push` now depend on both, and skipping setup makes hook failures look like broken tooling ("bun: command not found") instead of what they actually are. Also explicitly forbids bypassing a failing hook with `--no-verify`/`HUSKY=0`/editing `.husky/*`.
- Documents the hook contents under "Commit conventions" in `AGENTS.md` so the doc matches what's actually in `.husky/`.

## Why

The repo had a `commit-msg` hook (commitlint) and a `pre-commit` hook (typecheck only), but no pre-push gate at all, and no explicit instruction telling agents to run setup first — so an agent could hit a cryptic `pre-commit` failure from a missing `node_modules` and not know why. This closes both gaps: local hooks now mirror more of what CI checks, and the setup requirement is spelled out so hook failures are actionable rather than confusing.

## Notes for reviewers

- No schema/migration changes.
- No `.env`/RBAC/auth/token-encryption changes — this PR only touches `.husky/*` and `AGENTS.md`.
- Verified locally: `bun run typecheck`, `bun run lint`, and `bun run build` all pass (this is the new `pre-commit` hook, and it ran on the commit in this PR). `bun run test` (388 tests) and `bun run build` also pass standalone (the new UI portion of `pre-push`). I could not verify the `pytest -q` leg of `pre-push` end-to-end in my sandbox because it has no reachable local Postgres — that's expected per the new AGENTS.md guardrail (a real dev machine with `docker compose up db` running would have one).

## Test plan

- [ ] Pull this branch, run `bun install` (apps/ui) and the Python setup, then make a trivial commit — confirm `pre-commit` runs typecheck+lint+build.
- [ ] With `docker compose up db` running locally, `git push` from this branch — confirm `pre-push` runs UI tests, UI build, and `pytest -q`.
- [ ] Confirm CI still passes (unaffected by this change — it doesn't touch CI config, only local hooks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened pre-commit and pre-push checks to validate frontend linting, builds, type safety, and tests before changes are submitted.
  * Added automated backend test verification, including required database connectivity checks.

* **Documentation**
  * Expanded setup and contribution guidance with required installation, migration, and testing steps.
  * Added guidance to resolve failed checks rather than bypassing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->