### PR TITLE
fix(ui): stop overview-page milestone burndown test date from going stale

### DIFF
--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -213,7 +213,10 @@ describe("OverviewPage cockpit", () => {
         {
           repo: "acme/api",
           title: "v2",
-          due_on: "2026-08-01T00:00:00Z",
+          // relativeTime() renders anything within 60s (or in the future) as "just now" --
+          // computed relative to test execution time so this doesn't go stale as real time
+          // passes (a hardcoded near-future date drifted into "N days ago" here before).
+          due_on: new Date(Date.now() + 60_000).toISOString(),
           open_issues: 2,
           closed_issues: 8,
           progress_pct: 80,


### PR DESCRIPTION
## Summary

`tests/components/overview-page.test.tsx`'s "renders milestone burndown rows" test hardcoded `due_on: "2026-08-01T00:00:00Z"` and asserted it renders as "due just now". That was true when the test was written (2026-07-25), but `relativeTime()` (`apps/ui/lib/format.ts`) only renders a timestamp as "just now" when it's under 60 seconds old or in the future — as real time passed, the same fixture started rendering "due N days ago" and the assertion started failing.

Found while working on unrelated backend migration work (issue #190) — the pre-push hook's `bun run test` step failed and initially looked like flaky/CPU-contention-related test timeouts (the repo's `vitest.config.ts` already documents that class of issue), but this particular failure reproduced consistently even at reduced test concurrency, which ruled that out. Root cause was a stale, undated test fixture with no clock mocking — a ticking time bomb, unrelated to the branch it was blocking.

## What changed

- `apps/ui/tests/components/overview-page.test.tsx`: `due_on` for the "renders milestone burndown rows" test now computes `new Date(Date.now() + 60_000).toISOString()` instead of a hardcoded calendar date, so it stays "due just now" regardless of when the test runs.

No production code changed — this is a test-only fix. No schema, RBAC, auth, or token-encryption files touched.

## Test plan

- [x] `bunx vitest run tests/components/overview-page.test.tsx` — 13 passed (previously 1 failed on this file).
- [x] `bun run test` (full vitest suite) via the pre-push hook — 388 passed.
- [x] `bun run check` (typecheck + lint + build) via the pre-commit hook — passed.
- [x] `pytest -q` via the pre-push hook — 606 passed (unaffected, included for completeness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated milestone burndown test timing to consistently verify the “due just now” display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->