### PR TITLE
feat(infra): add Redis + webhook_deliveries table for webhook ingestion (S3 PR 1/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,12 @@ AUTH_SECRET=           # openssl rand -hex 32  (JWT signing secret)
 
 NEXT_PUBLIC_API_BASE=  # e.g. https://api.yourdomain.com
 
-# REDIS_URL: issue #191/S3 -- the webhook ingestion queue (Redis Streams). No safe
-# default (unlike CORS_ORIGINS/GITHUB_API_BASE below): without it the webhook
-# receiver can't queue anything. Docker Compose: redis://redis:6379/0. Local dev
-# outside Docker: redis://localhost:6379/0.
-REDIS_URL=redis://redis:6379/0
+# REDIS_PASSWORD: issue #191/S3 -- auths the webhook ingestion queue (Redis
+# Streams). apps/api/entrypoint.sh builds REDIS_URL from this at container start
+# (same pattern as DB_USER/DB_PASSWORD/DB_NAME -> DATABASE_URL below). No safe
+# default: without it the redis service won't start (--requirepass) and the
+# webhook receiver has no queue to reach.
+REDIS_PASSWORD=  # openssl rand -hex 32
 
 # ── DEPLOY-TIME CONFIG (optional, safe defaults in code) ──────────────────────
 # Set per environment/install. Omit to use the code default.
@@ -75,6 +76,11 @@ SMTP_FROM=
 # DATABASE_URL is only needed when running apps/api or apps/worker outside Docker.
 # Format: postgresql+psycopg://user:pass@localhost:5432/db
 DATABASE_URL=
+#
+# REDIS_URL is only needed when running apps/api outside Docker (inside Docker,
+# entrypoint.sh builds it from REDIS_PASSWORD above). Format for a local Redis with
+# no password: redis://localhost:6379/0 (add :password@ before the host if yours has one).
+REDIS_URL=
 
 # ── CONFIGURED VIA SETTINGS PAGE (not env vars) ───────────────────────────────
 # Lives in the app_config DB table and can be changed in the Settings page

--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ NEXT_PUBLIC_API_BASE=  # e.g. https://api.yourdomain.com
 # Streams). apps/api/entrypoint.sh builds REDIS_URL from this at container start
 # (same pattern as DB_USER/DB_PASSWORD/DB_NAME -> DATABASE_URL below). No safe
 # default: without it the redis service won't start (--requirepass) and the
-# webhook receiver has no queue to reach.
-REDIS_PASSWORD=  # openssl rand -hex 32
+# webhook receiver has no queue to reach. Generate with: openssl rand -hex 32
+REDIS_PASSWORD=
 
 # ── DEPLOY-TIME CONFIG (optional, safe defaults in code) ──────────────────────
 # Set per environment/install. Omit to use the code default.

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ AUTH_SECRET=           # openssl rand -hex 32  (JWT signing secret)
 
 NEXT_PUBLIC_API_BASE=  # e.g. https://api.yourdomain.com
 
+# REDIS_URL: issue #191/S3 -- the webhook ingestion queue (Redis Streams). No safe
+# default (unlike CORS_ORIGINS/GITHUB_API_BASE below): without it the webhook
+# receiver can't queue anything. Docker Compose: redis://redis:6379/0. Local dev
+# outside Docker: redis://localhost:6379/0.
+REDIS_URL=redis://redis:6379/0
+
 # ── DEPLOY-TIME CONFIG (optional, safe defaults in code) ──────────────────────
 # Set per environment/install. Omit to use the code default.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      # Issue #191/S3: webhook ingestion queue. Not used by any test yet in this PR
+      # (infra scaffolding only), but required for Settings() to construct (redis_url
+      # has no default) and wired up now so PR 3's Redis-backed tests don't need a
+      # separate CI change.
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       # Superuser URL: used for migrations and every step except "Run Python tests" below,
       # which overrides DATABASE_URL to the clevis_api role instead (issue #330/#190 --
@@ -127,6 +140,7 @@ jobs:
       API_DB_PASSWORD: ci-dummy-api-db-password-not-for-production-use-0
       JOB_SECRET_KEY: ${{ secrets.JOB_SECRET_KEY || 'ci-dummy-secret-key-not-for-production-use-00' }}
       AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-dummy-auth-secret-not-for-production-use-000' }}
+      REDIS_URL: redis://localhost:6379/0
     steps:
       - name: Checkout (full history for diff coverage)
         uses: actions/checkout@v4
@@ -213,6 +227,7 @@ jobs:
           AUTH_SECRET=ci-e2e-auth-secret-not-for-production-use-00000
           NEXT_PUBLIC_API_BASE=http://localhost:8080
           NEXT_PUBLIC_GITHUB_APP_SLUG=
+          REDIS_URL=redis://redis:6379/0
           EOF
 
       # Full docker-compose stack (not direct processes) so this exercises the real images —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
           AUTH_SECRET=ci-e2e-auth-secret-not-for-production-use-00000
           NEXT_PUBLIC_API_BASE=http://localhost:8080
           NEXT_PUBLIC_GITHUB_APP_SLUG=
-          REDIS_URL=redis://redis:6379/0
+          REDIS_PASSWORD=ci-e2e-redis-password-not-for-production-use-000
           EOF
 
       # Full docker-compose stack (not direct processes) so this exercises the real images —
@@ -313,6 +313,7 @@ jobs:
             -e DATABASE_URL=postgresql+psycopg://smoke:smoke@localhost:5432/smoke \
             -e JOB_SECRET_KEY=ci-smoke-test-key-not-for-production-use-000 \
             -e AUTH_SECRET=ci-smoke-test-secret-not-for-production-use-00 \
+            -e REDIS_URL=redis://smoke:6379/0 \
             clevis-api -c "import src.main"
 
       - name: Smoke-test Worker image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Nine tables managed by Alembic — no runtime DDL:
 - **`jobs`** — job queue; composite index on `(status, job_type)` for efficient worker polling. Status lifecycle: `queued → processing → done/failed`. The `result` column stores JSON on success or a raw exception string on failure. `retry_count` caps both reclaim-after-crash and transient-failure retries at `MAX_RETRIES`; `heartbeat_at` (issue #215) lets a long-running-but-alive job survive the reclaim sweep past `RECLAIM_TIMEOUT_MINUTES`.
 - **`scan_results`** — historical security-scan snapshots (score, checks JSON) powering the score-trend chart; `scanned_by_user_id` scopes personal-endpoint scan history when there's no org membership to gate on.
 - **`app_config`** — DB-backed, Settings-page-editable runtime config (currently just `worker_poll_seconds`; see Development setup below).
+- **`webhook_deliveries`** — issue #191/S3: durable landing spot for verified GitHub webhook payloads (raw `bytea` body, delivery id, event type, resolved `tenant_id` when resolvable) before they're queued onto Redis Streams for later processing. `status` (`queued`/`queue_failed`) lets a future sweep re-enqueue anything the queue write itself failed on. Not deduplicated by `delivery_id` here — GitHub redelivers on retry, and dedupe is the S4 event-processor's job, not this table's.
 
 ### Job queue flow
 
@@ -74,7 +75,7 @@ pip install -e packages/checks
 cd apps/ui && bun install
 ```
 
-**Required env vars (6 total):** `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY`, `AUTH_SECRET`, `NEXT_PUBLIC_API_BASE`. Everything else is optional with a safe default in code (`CORS_ORIGINS`, `GITHUB_API_BASE`, the `GITHUB_APP_*` block for GitHub App auth/OAuth, the `SMTP_*` block for verification emails — see `.env.example`). Everything else lives in the `app_config` DB table (configured via Settings page).
+**Required env vars (7 total):** `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY`, `AUTH_SECRET`, `NEXT_PUBLIC_API_BASE`, `REDIS_URL`. Everything else is optional with a safe default in code (`CORS_ORIGINS`, `GITHUB_API_BASE`, the `GITHUB_APP_*` block for GitHub App auth/OAuth, the `SMTP_*` block for verification emails — see `.env.example`). Everything else lives in the `app_config` DB table (configured via Settings page).
 
 Key variables:
 - `DB_USER`, `DB_PASSWORD`, `DB_NAME` — Postgres credentials. Docker Compose maps these to `POSTGRES_USER/PASSWORD/DB` for the db container; entrypoints construct `DATABASE_URL` from them (host = `db`).
@@ -82,6 +83,7 @@ Key variables:
 - `JOB_SECRET_KEY` — Fernet key for token encryption; generate with `openssl rand -hex 32`
 - `AUTH_SECRET` — JWT signing secret; generate with `openssl rand -hex 32`
 - `NEXT_PUBLIC_API_BASE` — `http://localhost:8080` for local dev
+- `REDIS_URL` — issue #191/S3's webhook ingestion queue (Redis Streams). Docker Compose: `redis://redis:6379/0`. Local dev outside Docker: `redis://localhost:6379/0`. No safe default (unlike `CORS_ORIGINS`/`GITHUB_API_BASE` below) — without it the webhook receiver can't queue anything.
 - `API_PORT` / `UI_PORT` — `8080` / `3000`
 
 **Deploy-time config (env vars, safe defaults in code):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Clevis is a GitHub analytics dashboard with three independently deployable servi
 
 ### Database models (`apps/api/src/core/db.py`)
 
-Nine tables managed by Alembic — no runtime DDL:
+Tables managed by Alembic — no runtime DDL. (Not an exhaustive list of every table in `apps/api/src/core/db.py` — `tenants`/`memberships` predate this list being kept current; see that file for the authoritative schema.)
 - **`users`** — email/password or GitHub-OAuth-linked accounts. `is_workspace_admin` (instance-level, set once at first-run `/auth/setup`), `token_version` (bumped to invalidate all issued JWTs), `email_verified` / `email_verify_token` / `email_verify_token_expires_at` (issue #217 — self-registered accounts start unverified and can't accept org invites until they click the emailed link; GitHub-linked and first-run-setup accounts are verified immediately since their email is already trusted).
 - **`orgs`** / **`org_memberships`** — a GitHub org becomes a Clevis `Org` row once someone connects it; `org_memberships` is the `(org_id, user_id) -> role ("member"|"admin")` join table `require_org_role` checks against.
 - **`invitations`** — pending org invites by email; `accept_invitation` requires the accepting user's email to match and (per #217) `email_verified=True`.
@@ -75,7 +75,7 @@ pip install -e packages/checks
 cd apps/ui && bun install
 ```
 
-**Required env vars (7 total):** `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY`, `AUTH_SECRET`, `NEXT_PUBLIC_API_BASE`, `REDIS_URL`. Everything else is optional with a safe default in code (`CORS_ORIGINS`, `GITHUB_API_BASE`, the `GITHUB_APP_*` block for GitHub App auth/OAuth, the `SMTP_*` block for verification emails — see `.env.example`). Everything else lives in the `app_config` DB table (configured via Settings page).
+**Required env vars (7 total):** `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY`, `AUTH_SECRET`, `NEXT_PUBLIC_API_BASE`, `REDIS_PASSWORD`. Everything else is optional with a safe default in code (`CORS_ORIGINS`, `GITHUB_API_BASE`, the `GITHUB_APP_*` block for GitHub App auth/OAuth, the `SMTP_*` block for verification emails — see `.env.example`). Everything else lives in the `app_config` DB table (configured via Settings page).
 
 Key variables:
 - `DB_USER`, `DB_PASSWORD`, `DB_NAME` — Postgres credentials. Docker Compose maps these to `POSTGRES_USER/PASSWORD/DB` for the db container; entrypoints construct `DATABASE_URL` from them (host = `db`).
@@ -83,7 +83,7 @@ Key variables:
 - `JOB_SECRET_KEY` — Fernet key for token encryption; generate with `openssl rand -hex 32`
 - `AUTH_SECRET` — JWT signing secret; generate with `openssl rand -hex 32`
 - `NEXT_PUBLIC_API_BASE` — `http://localhost:8080` for local dev
-- `REDIS_URL` — issue #191/S3's webhook ingestion queue (Redis Streams). Docker Compose: `redis://redis:6379/0`. Local dev outside Docker: `redis://localhost:6379/0`. No safe default (unlike `CORS_ORIGINS`/`GITHUB_API_BASE` below) — without it the webhook receiver can't queue anything.
+- `REDIS_PASSWORD` — issue #191/S3's webhook ingestion queue (Redis Streams). Auths the `redis` Compose service (`--requirepass`, so any other container on the shared network can't read/inject stream entries); `apps/api/entrypoint.sh` builds `REDIS_URL` from it, same pattern as `DB_USER`/`DB_PASSWORD`/`DB_NAME` → `DATABASE_URL`. `REDIS_URL` itself is local-dev-only (outside Docker), same as `DATABASE_URL`.
 - `API_PORT` / `UI_PORT` — `8080` / `3000`
 
 **Deploy-time config (env vars, safe defaults in code):**

--- a/apps/api/alembic/versions/0034_add_webhook_deliveries.py
+++ b/apps/api/alembic/versions/0034_add_webhook_deliveries.py
@@ -1,0 +1,98 @@
+"""Add webhook_deliveries table (issue #191, S3 webhook ingestion PR 1 of 4).
+
+Pure additive schema change, no existing table touched -- zero data-loss risk.
+Durable landing spot for verified GitHub webhook payloads before they're queued
+onto Redis Streams for later processing (a future S4 event-processor fleet).
+See docs/architecture/clevis-architecture.md's Ingestion pipeline layer for the
+target design; this table is the "raw payload store" half of it. Object storage
+(MinIO) is the architecture doc's eventual answer for that role, but standing up
+a second stateful service for what's typically a few KB of JSON is infra ahead
+of need at this stage -- Postgres is already the trusted durable store this repo
+uses everywhere else. Table bloat from unbounded accumulation is a known,
+deliberately deferred follow-up (a retention/pruning job, once something -- S4 --
+actually consumes these rows), not solved here.
+
+No unique constraint on delivery_id: GitHub redelivers the same delivery id on
+retry, and dedupe is the future S4 consumer's job operating on the queue side,
+not a write-side constraint here -- enforcing uniqueness now would mean deciding
+dedupe semantics (reject vs. upsert vs. which duplicate wins) that belong to
+S4's design.
+
+No Row-Level Security on this table, despite the nullable tenant_id column --
+deliberately structured like `jobs`/`app_config` (see migration 0030's docstring
+for why those two are excluded), not like the Group A/B tenant-scoped tables.
+The webhook receiver writes this table on an unauthenticated connection with no
+app.tenant_id session var set (there's no authenticated tenant context at
+webhook-receive time -- see src/core/rbac.py's _set_tenant_session_context,
+only ever called from require_org_role/require_personal_tenant, neither of
+which runs on this route), so a tenant-matching WITH CHECK would reject every
+insert regardless of whether tenant_id resolution succeeded. And the future S4
+consumer fleet needs to read pending rows across all tenants at once, not one
+tenant's rows at a time -- the same structural reason `jobs` has no RLS. Access
+control here is HMAC-signature verification at the receiver, not row-level
+tenant isolation.
+
+Grants clevis_api access to the new table + its backing sequence inline (see
+migration 0032's docstring: "a future new table requires its own reviewed
+migration to grant clevis_api access, rather than silently inheriting it").
+No-op when the clevis_api role doesn't exist, matching 0032/0033.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-08-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webhook_deliveries",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True),
+        sa.Column("delivery_id", sa.String(), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("installation_id", sa.Integer(), nullable=True),
+        sa.Column("payload", sa.LargeBinary(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="queued"),
+        sa.Column("received_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_webhook_deliveries_tenant_id", "webhook_deliveries", ["tenant_id"])
+    op.create_index("ix_webhook_deliveries_status", "webhook_deliveries", ["status"])
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON webhook_deliveries TO clevis_api;
+                GRANT USAGE, SELECT ON SEQUENCE webhook_deliveries_id_seq TO clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                REVOKE USAGE, SELECT ON SEQUENCE webhook_deliveries_id_seq FROM clevis_api;
+                REVOKE SELECT, INSERT, UPDATE, DELETE ON webhook_deliveries FROM clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.drop_index("ix_webhook_deliveries_status", table_name="webhook_deliveries")
+    op.drop_index("ix_webhook_deliveries_tenant_id", table_name="webhook_deliveries")
+    op.drop_table("webhook_deliveries")

--- a/apps/api/alembic/versions/0034_add_webhook_deliveries.py
+++ b/apps/api/alembic/versions/0034_add_webhook_deliveries.py
@@ -1,6 +1,8 @@
 """Add webhook_deliveries table (issue #191, S3 webhook ingestion PR 1 of 4).
 
-Pure additive schema change, no existing table touched -- zero data-loss risk.
+Upgrade is purely additive and touches no existing table -- zero data-loss risk.
+Downgrade drops this table and permanently deletes any stored payloads; do not
+run it against a real environment without explicit confirmation (AGENTS.md).
 Durable landing spot for verified GitHub webhook payloads before they're queued
 onto Redis Streams for later processing (a future S4 event-processor fleet).
 See docs/architecture/clevis-architecture.md's Ingestion pipeline layer for the

--- a/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
+++ b/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
@@ -60,6 +60,12 @@ def upgrade() -> None:
         $$;
         """
     )
+    # Postgres grants EXECUTE on a new function to PUBLIC by default (unlike tables) --
+    # left alone, the GRANT below wouldn't actually narrow anything, since every role
+    # that can connect could already call this function and read any installation's
+    # tenant_id, defeating the "narrow, deliberately scoped" bypass this migration's
+    # docstring describes (CodeRabbit finding on PR #337).
+    op.execute("REVOKE EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) FROM PUBLIC")
     op.execute(
         """
         DO $$

--- a/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
+++ b/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
@@ -1,0 +1,77 @@
+"""Add resolve_installation_tenant_id() SECURITY DEFINER function (issue #191, S3 PR 2 of 4).
+
+**Fixes a genuine, already-live production bug** -- not a refactor. Migration 0031 put
+`github_installations` under `FORCE ROW LEVEL SECURITY` with policy
+`USING (tenant_id = app.tenant_id OR owner_user_id = app.user_id)`. The GitHub webhook
+receiver (`src/routers/webhooks.py`, `POST /webhooks/github`) is unauthenticated by
+design -- it verifies the request via HMAC signature, not a login session -- so it never
+calls `require_org_role`/`require_personal_tenant` (the only places that set the
+`app.tenant_id`/`app.user_id` session vars this policy reads). Under the real runtime
+`clevis_api` role (non-superuser since #330), that means `_handle_installation_deleted`'s
+lookup against `github_installations` evaluates the policy to `NULL OR NULL` -- every row
+invisible, every time. The uninstall-cleanup delete has been silently no-op'ing in
+production since #330 cut the API over to `clevis_api`: GitHub's `installation.deleted`
+webhook fires, signature verifies, handler runs, `DELETE` affects 0 rows, no error, no
+audit log entry, and the stale `github_installations` row (and its now-invalid
+`token_ref`) is never cleaned up.
+
+This migration adds a narrow SECURITY DEFINER function, owned by whichever role runs
+migrations (the DB_USER bootstrap superuser -- table owner, unconditionally bypasses RLS
+regardless of FORCE), that does exactly one read: resolve a GitHub installation_id to its
+tenant_id. `clevis_api` is granted EXECUTE on it, not BYPASSRLS on the role itself --
+BYPASSRLS is an all-or-nothing role attribute that would neuter RLS for every query the
+API makes, not just this one pre-authentication lookup. The webhook handler (PR 2's other
+half, in installation_repo.py) calls this function first to resolve tenant_id, then sets
+`app.tenant_id` for the rest of the request via the existing plain-SET pattern
+(src/core/db.py's set_session_user, src/core/rbac.py's set_tenant_session_context) so the
+actual DELETE that follows is evaluated under a session that now legitimately satisfies
+the policy's tenant_id-equality branch -- not bypassing RLS for the delete itself, just
+supplying the session context RLS already expects to find.
+
+Upgrade is purely additive (one new function) -- zero data-loss risk. Downgrade drops the
+function; do not run it against a real environment without explicit confirmation
+(AGENTS.md) since it would silently reintroduce the bug this migration fixes.
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-08-16
+"""
+
+from alembic import op
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION resolve_installation_tenant_id(p_installation_id integer)
+        RETURNS integer
+        LANGUAGE sql
+        SECURITY DEFINER
+        SET search_path = pg_catalog, public
+        AS $$
+            SELECT tenant_id FROM github_installations
+            WHERE installation_id = p_installation_id
+            LIMIT 1
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) TO clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS resolve_installation_tenant_id(integer)")

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -16,6 +16,15 @@ _urlenc() {
 _db_user_enc=$(_urlenc "$DB_USER")
 _db_password_enc=$(_urlenc "$DB_PASSWORD")
 _db_name_enc=$(_urlenc "$DB_NAME")
+_redis_password_enc=$(_urlenc "$REDIS_PASSWORD")
+
+# Issue #191/S3: webhook ingestion queue. Built here (not left as a directly-set
+# REDIS_URL) so the raw password only ever needs to be set once, the same shape as
+# DB_USER/DB_PASSWORD/DB_NAME above -- REDIS_URL itself stays a "local dev outside
+# Docker only" var (see .env.example), same as DATABASE_URL. Must be set before
+# `alembic upgrade head` below, since alembic/env.py imports src.core.config, which
+# now requires REDIS_URL (Settings() fails to construct otherwise).
+export REDIS_URL="redis://:${_redis_password_enc}@redis:6379/0"
 
 # Migrations always run under the DB_USER superuser credential -- it owns the tables
 # (see migration 0030's ENABLE-without-FORCE reasoning: table owners bypass RLS unless
@@ -34,12 +43,6 @@ python -m alembic upgrade head
 if [ -n "$API_DB_PASSWORD" ]; then
   export DATABASE_URL="postgresql+psycopg://clevis_api:$(_urlenc "$API_DB_PASSWORD")@db:5432/${_db_name_enc}"
 fi
-
-# Issue #191/S3: webhook ingestion queue. Built here (not left as a directly-set
-# REDIS_URL) so the raw password only ever needs to be set once, the same shape as
-# DB_USER/DB_PASSWORD/DB_NAME above -- REDIS_URL itself stays a "local dev outside
-# Docker only" var (see .env.example), same as DATABASE_URL.
-export REDIS_URL="redis://:$(_urlenc "$REDIS_PASSWORD")@redis:6379/0"
 
 # --proxy-headers/--forwarded-allow-ips: trust X-Forwarded-Proto from Traefik so
 # request.url_for() (used to build the GitHub OAuth callback/redirect_uri) reports the

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-if [ -z "$DB_USER" ] || [ -z "$DB_NAME" ] || [ -z "$DB_PASSWORD" ] || [ -z "$JOB_SECRET_KEY" ] || [ -z "$AUTH_SECRET" ]; then
-  echo "ERROR: DB_USER, DB_NAME, DB_PASSWORD, JOB_SECRET_KEY, and AUTH_SECRET must all be set" >&2
+if [ -z "$DB_USER" ] || [ -z "$DB_NAME" ] || [ -z "$DB_PASSWORD" ] || [ -z "$JOB_SECRET_KEY" ] || [ -z "$AUTH_SECRET" ] || [ -z "$REDIS_PASSWORD" ]; then
+  echo "ERROR: DB_USER, DB_NAME, DB_PASSWORD, JOB_SECRET_KEY, AUTH_SECRET, and REDIS_PASSWORD must all be set" >&2
   exit 1
 fi
 
@@ -34,6 +34,12 @@ python -m alembic upgrade head
 if [ -n "$API_DB_PASSWORD" ]; then
   export DATABASE_URL="postgresql+psycopg://clevis_api:$(_urlenc "$API_DB_PASSWORD")@db:5432/${_db_name_enc}"
 fi
+
+# Issue #191/S3: webhook ingestion queue. Built here (not left as a directly-set
+# REDIS_URL) so the raw password only ever needs to be set once, the same shape as
+# DB_USER/DB_PASSWORD/DB_NAME above -- REDIS_URL itself stays a "local dev outside
+# Docker only" var (see .env.example), same as DATABASE_URL.
+export REDIS_URL="redis://:$(_urlenc "$REDIS_PASSWORD")@redis:6379/0"
 
 # --proxy-headers/--forwarded-allow-ips: trust X-Forwarded-Proto from Traefik so
 # request.url_for() (used to build the GitHub OAuth callback/redirect_uri) reports the

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,3 +10,4 @@ cryptography==44.0.2
 bcrypt==4.2.1
 PyJWT==2.13.0
 email-validator==2.2.0
+redis==5.2.1

--- a/apps/api/src/core/config.py
+++ b/apps/api/src/core/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     database_url: SecretStr
     job_secret_key: SecretStr   # Fernet key for saved-token + job token encryption
     auth_secret: SecretStr      # JWT signing secret
+    redis_url: SecretStr        # issue #191/S3 -- webhook ingestion queue (Redis Streams);
+                                 # SecretStr since a production URL may embed AUTH credentials
 
     # Deploy-time config with safe defaults. Override via env per environment/install.
     # cors_origins is a security boundary read once at startup; github_api_base is where

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     Integer,
+    LargeBinary,
     String,
     Text,
     UniqueConstraint,
@@ -106,6 +107,38 @@ class Job(Base):
     # finishes. Null for a job that was claimed before this column existed, or hasn't had
     # its first heartbeat tick yet.
     heartbeat_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class WebhookDelivery(Base):
+    """Durable landing spot for verified GitHub webhook payloads (issue #191/S3), written by
+    the unauthenticated receiver before enqueueing onto Redis Streams. No RLS: like `jobs`,
+    this is a system-internal table -- the receiver writes it with no app.tenant_id session
+    var set (there's no authenticated tenant context at webhook-receive time), and a future
+    S4 consumer fleet needs to read across all tenants, not one tenant's rows at a time. Access
+    control is HMAC-signature verification at the receiver, not row-level tenant isolation."""
+
+    __tablename__ = "webhook_deliveries"
+    __table_args__ = (
+        Index("ix_webhook_deliveries_tenant_id", "tenant_id"),
+        Index("ix_webhook_deliveries_status", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Nullable: resolution can fail (installation not found -- e.g. a webhook for an org that
+    # uninstalled between delivery and processing).
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    # X-GitHub-Delivery. Not unique-constrained: GitHub redelivers the same delivery id on
+    # retry, and deduping is the future S4 event-processor's job, not this table's.
+    delivery_id: Mapped[str] = mapped_column(String, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)  # X-GitHub-Event
+    installation_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Exact verified raw body bytes, not re-serialized JSON, so a byte-for-byte copy of what
+    # HMAC was checked against is preserved for any future signature re-verification/replay.
+    payload: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    # queued | queue_failed -- queue_failed lets a future re-enqueue sweep find rows whose
+    # Redis XADD didn't succeed even though the payload itself was durably stored.
+    status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
 class SavedToken(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -335,6 +335,20 @@ def set_session_user(db: Session, user_id: int) -> None:
     db.execute(text(f"SET app.user_id = {int(user_id)}"))
 
 
+def set_session_tenant(db: Session, tenant_id: int) -> None:
+    """Sets app.tenant_id alone, for system code paths that resolve a tenant_id without an
+    acting user -- e.g. the GitHub webhook receiver (issue #191/S3), which runs before any
+    authenticated session exists (HMAC-signature-verified, not login-gated), so there's no
+    app.user_id to set alongside it. Satisfies the tenant_id-equality half of migration
+    0031's github_installations/memberships policies. The tenant_id here must come from a
+    trusted resolution (e.g. resolve_installation_tenant_id(), migration 0035's SECURITY
+    DEFINER function) -- this call only sets session state for RLS to read, it does not
+    itself verify the caller is entitled to that tenant. Same plain-SET reasoning as
+    set_session_user/rbac.set_tenant_session_context -- see their docstrings.
+    """
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+
+
 def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:

--- a/apps/api/src/core/redis_client.py
+++ b/apps/api/src/core/redis_client.py
@@ -1,0 +1,20 @@
+"""Thin Redis client accessor for the webhook ingestion queue (issue #191/S3).
+
+A single process-wide client (redis-py pools connections internally, so this isn't
+"one connection" -- it's one client object reusing a pool), lazily constructed from
+settings.redis_url the first time it's needed rather than at import time, so a test
+run that never touches Redis never has to have it reachable.
+"""
+
+import redis
+
+from src.core.config import settings
+
+_client: redis.Redis | None = None
+
+
+def get_redis_client() -> redis.Redis:
+    global _client
+    if _client is None:
+        _client = redis.Redis.from_url(settings.redis_url.get_secret_value(), decode_responses=True)
+    return _client

--- a/apps/api/src/core/redis_client.py
+++ b/apps/api/src/core/redis_client.py
@@ -13,8 +13,25 @@ from src.core.config import settings
 _client: redis.Redis | None = None
 
 
+# redis-py 5.2.1 defaults both timeouts to None (block forever). The webhook receiver
+# calls xadd() synchronously from inside an async route (src/routers/webhooks.py), so an
+# unresponsive-but-not-yet-refused Redis (e.g. a network partition, not just "connection
+# refused") would otherwise stall the whole event loop, not just this one request --
+# unlike a fast connection error, which the existing try/except already handles fine.
+# Finite but generous relative to a webhook receiver's expected response time; no
+# automatic retries (the caller's own queue_failed fallback is the retry story, and
+# retrying writes here risks a duplicate XADD with no dedupe defined yet).
+_SOCKET_CONNECT_TIMEOUT_SECONDS = 2
+_SOCKET_TIMEOUT_SECONDS = 2
+
+
 def get_redis_client() -> redis.Redis:
     global _client
     if _client is None:
-        _client = redis.Redis.from_url(settings.redis_url.get_secret_value(), decode_responses=True)
+        _client = redis.Redis.from_url(
+            settings.redis_url.get_secret_value(),
+            decode_responses=True,
+            socket_connect_timeout=_SOCKET_CONNECT_TIMEOUT_SECONDS,
+            socket_timeout=_SOCKET_TIMEOUT_SECONDS,
+        )
     return _client

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -1,8 +1,8 @@
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from src.core.db import GitHubInstallation
+from src.core.db import GitHubInstallation, set_session_tenant
 from src.repositories import tenant_repo
 
 
@@ -144,9 +144,25 @@ def delete_by_installation_id(db: Session, installation_id: int) -> tuple[int, i
     Returns (rows deleted, tenant_id of the first deleted row) -- the tenant_id lets the
     webhook handler's audit_repo.write call attribute the deletion under RLS (issue #330);
     every row here already has tenant_id populated by upsert's _resolve_tenant_id, so this
-    is just reading back what's already there before the rows are gone."""
+    is just reading back what's already there before the rows are gone.
+
+    Called from the unauthenticated webhook receiver (issue #191/S3), which never sets
+    app.tenant_id/app.user_id -- under RLS (migration 0031's FORCE ROW LEVEL SECURITY on
+    this table) that made both the SELECT and DELETE below silently see zero rows, every
+    time (issue #191/S3 PR 2 fix). resolve_installation_tenant_id() (migration 0035, a
+    SECURITY DEFINER function) resolves tenant_id first, bypassing RLS for that one lookup
+    the same way the table owner already does; once resolved, set_session_tenant supplies
+    the session context RLS expects so the actual SELECT/DELETE that follows are evaluated
+    normally, under a session that now legitimately satisfies the tenant_id-equality
+    policy branch -- not a second RLS bypass."""
+    tenant_id = db.execute(
+        text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": installation_id}
+    ).scalar()
+    if tenant_id is not None:
+        set_session_tenant(db, tenant_id)
+
     rows = db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).all()
-    tenant_id = rows[0].tenant_id if rows else None
+    resolved_tenant_id = rows[0].tenant_id if rows else tenant_id
     count = db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).delete()
     db.commit()
-    return count, tenant_id
+    return count, resolved_tenant_id

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,7 +1,9 @@
 """GitHub App webhook receiver.
 
   POST /webhooks/github   verifies X-Hub-Signature-256, then handles installation
-                           lifecycle events to keep github_installations in sync.
+                           lifecycle events to keep github_installations in sync, and
+                           durably queues a bounded set of event types (issue #191/S3)
+                           for a future event-processor fleet (S4, not built yet).
 """
 
 import hashlib
@@ -10,16 +12,32 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
-from src.core.db import get_db
+from src.core.db import WebhookDelivery, get_db
 from src.core.rate_limit import rate_limit
+from src.core.redis_client import get_redis_client
 from src.repositories import audit_repo, installation_repo
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Mirrors the event types apps/api/src/routers/github.py's Activity Feed already
+# summarizes (PushEvent/PullRequestEvent/IssuesEvent/ReleaseEvent/CreateEvent via
+# GitHub's Events API) -- these are the webhook equivalents (X-GitHub-Event header
+# names, not GitHub Events API `type` strings, hence "create" not "CreateEvent").
+# S4 (a future event-processor fleet, out of scope here) is what will eventually let
+# the Activity Feed move from polling to these queued rows; until then they just
+# accumulate in webhook_deliveries with status="queued", which is the expected
+# handoff state, not a bug.
+_INGESTED_EVENT_TYPES = {"push", "pull_request", "issues", "release", "create"}
+
+# Redis Stream key the ingestion path XADDs onto; a future S4 consumer group reads
+# from this same key.
+_WEBHOOK_STREAM_KEY = "webhook_events"
 
 # GitHub caps webhook deliveries around 25MB; refuse anything larger long before that
 # so a body this endpoint (unauthenticated until the signature check passes) can't be
@@ -70,6 +88,7 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Malformed webhook payload")
 
     event = request.headers.get("X-GitHub-Event", "")
+    delivery_id = request.headers.get("X-GitHub-Delivery", "")
 
     if event == "installation" and payload.get("action") == "deleted":
         _handle_installation_deleted(db, payload)
@@ -87,8 +106,61 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
     # installation) has nothing to sync yet — github_installations tracks the
     # installation itself, not per-repo access, so there's no row-level change
     # to make here today. Accepted (200) so GitHub doesn't retry.
+    elif event in _INGESTED_EVENT_TYPES:
+        _handle_ingested_event(db, event, delivery_id, raw_body, payload)
 
     return {"ok": True}
+
+
+def _resolve_event_installation_id(payload: dict) -> int | None:
+    installation_id = (payload.get("installation") or {}).get("id")
+    if not isinstance(installation_id, int) or isinstance(installation_id, bool):
+        return None
+    return installation_id
+
+
+def _handle_ingested_event(db: Session, event: str, delivery_id: str, raw_body: bytes, payload: dict) -> None:
+    installation_id = _resolve_event_installation_id(payload)
+
+    tenant_id = None
+    if installation_id is not None:
+        # SECURITY DEFINER lookup (migration 0035), same as installation_repo's
+        # delete-under-RLS fix (issue #191/S3 PR 2) -- this receiver never has an
+        # authenticated session, so it never has app.tenant_id set to look this up
+        # the normal way.
+        tenant_id = db.execute(
+            text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": installation_id}
+        ).scalar()
+
+    row = WebhookDelivery(
+        tenant_id=tenant_id,
+        delivery_id=delivery_id,
+        event_type=event,
+        installation_id=installation_id,
+        payload=raw_body,
+        status="queued",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    try:
+        client = get_redis_client()
+        client.xadd(
+            _WEBHOOK_STREAM_KEY,
+            {
+                "delivery_row_id": row.id,
+                "event_type": event,
+                "tenant_id": tenant_id if tenant_id is not None else "",
+            },
+        )
+    except Exception:
+        # A transient Redis blip isn't GitHub's retry problem to solve -- the payload
+        # is already durably stored above. Mark it so a future re-enqueue sweep (out
+        # of scope here) can find it; still a 200 to GitHub either way.
+        logger.exception("Failed to enqueue webhook_deliveries row %s onto Redis stream %s", row.id, _WEBHOOK_STREAM_KEY)
+        row.status = "queue_failed"
+        db.commit()
 
 
 def _handle_installation_deleted(db: Session, payload: dict) -> None:

--- a/apps/api/tests/test_installation_deleted_rls_fix.py
+++ b/apps/api/tests/test_installation_deleted_rls_fix.py
@@ -29,7 +29,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
-from src.core.db import GitHubInstallation, Org, Tenant, User
+from src.core.db import GitHubInstallation, Org, Tenant, User, set_session_user
 from src.core.rbac import set_tenant_session_context
 from src.repositories import installation_repo, org_repo
 
@@ -115,14 +115,21 @@ def test_installation_deleted_removes_the_row_with_no_session_context_set():
                 assert still_present is None
             finally:
                 session.rollback()
-                # Restore tenant context (if the test's own delete-under-test didn't
-                # already remove the row via the fix, e.g. when run against the pre-fix
-                # code) so this cleanup's own writes against RLS-protected
-                # github_installations/tenants aren't blocked by the very same gap this
-                # PR fixes -- deliberately using the raw SET here, not the fix's
-                # SECURITY DEFINER path, since cleanup already has tenant/user in scope.
-                if tenant is not None and user is not None:
-                    set_tenant_session_context(session, tenant.id, user.id)
+                # Restore context (if the test's own delete-under-test didn't already
+                # remove the row via the fix, e.g. when run against the pre-fix code) so
+                # this cleanup's own writes against RLS-protected github_installations/
+                # tenants aren't blocked by the very same gap this PR fixes --
+                # deliberately using the raw SET here, not the fix's SECURITY DEFINER
+                # path, since cleanup already has tenant/user in scope. Falls back to
+                # set_session_user alone when tenant resolution itself failed (tenant is
+                # still None) but user was created -- restoring at least the user-scoped
+                # half of RLS's self-access clause instead of skipping restoration
+                # entirely (CodeRabbit finding on PR #337).
+                if user is not None:
+                    if tenant is not None:
+                        set_tenant_session_context(session, tenant.id, user.id)
+                    else:
+                        set_session_user(session, user.id)
                 if installation is not None:
                     session.execute(
                         text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987654}
@@ -195,8 +202,11 @@ def test_resolve_installation_tenant_id_bypasses_rls_with_no_session_context():
                 assert resolved == tenant.id
             finally:
                 session.rollback()
-                if tenant is not None and user is not None:
-                    set_tenant_session_context(session, tenant.id, user.id)
+                if user is not None:
+                    if tenant is not None:
+                        set_tenant_session_context(session, tenant.id, user.id)
+                    else:
+                        set_session_user(session, user.id)
                 session.execute(
                     text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
                 )

--- a/apps/api/tests/test_installation_deleted_rls_fix.py
+++ b/apps/api/tests/test_installation_deleted_rls_fix.py
@@ -1,0 +1,216 @@
+"""Regression test for issue #191/S3 PR 2: the GitHub webhook receiver's
+installation.deleted handler was silently no-op'ing under the real, non-superuser
+clevis_api role (issue #330) because it never set the app.tenant_id/app.user_id session
+vars migration 0031's RLS policy on github_installations reads -- see
+installation_repo.delete_by_installation_id's docstring and migration 0035's docstring
+for the full explanation.
+
+Deliberately does NOT use the shared `db` fixture (conftest.py). That fixture joins an
+already-open outer transaction via SQLAlchemy's `join_transaction_mode="create_savepoint"`
+-- each `Session.commit()` inside a test only releases a SAVEPOINT, it doesn't end the
+real Postgres transaction. Plain `SET` (used by set_tenant_session_context) is
+connection-scoped, so that's fine either way, but this test needs to prove the bug exists
+with NO session context carried over from an unrelated earlier write in the same test --
+using a real connection with real commits (mirroring production's one-connection-per-
+request lifecycle: get_db() hands out a brand-new session per request, so a webhook
+request's connection never inherits an admin request's app.tenant_id) makes that explicit
+rather than relying on savepoint semantics happening to keep it isolated.
+
+Same skip-when-unavailable convention as test_rls_isolation.py: reuses DATABASE_URL when
+the suite is already running as clevis_api (CI), or swaps credentials via API_DB_PASSWORD
+for an opt-in local run.
+"""
+
+import os
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import GitHubInstallation, Org, Tenant, User
+from src.core.rbac import set_tenant_session_context
+from src.repositories import installation_repo, org_repo
+
+
+def _clevis_api_engine():
+    url = urlsplit(settings.database_url.get_secret_value())
+    if url.username == "clevis_api":
+        return create_engine(settings.database_url.get_secret_value())
+
+    password = os.environ.get("API_DB_PASSWORD")
+    if not password:
+        pytest.skip(
+            "neither DATABASE_URL nor API_DB_PASSWORD point at clevis_api -- "
+            "provision the role (docker/provision-api-role-existing-deployment.sh) "
+            "and set API_DB_PASSWORD to exercise this test locally"
+        )
+    port = f":{url.port}" if url.port is not None else ""
+    netloc = f"clevis_api:{quote(password, safe='')}@{url.hostname}{port}"
+    return create_engine(urlunsplit((url.scheme, netloc, url.path, url.query, url.fragment)))
+
+
+def test_installation_deleted_removes_the_row_with_no_session_context_set():
+    engine = _clevis_api_engine()
+    with engine.connect() as conn:
+        session = Session(bind=conn, expire_on_commit=False)
+        user = org = tenant = installation = None
+        try:
+            try:
+                # Setup mirrors the real authenticated sync path (installations.py's
+                # sync_org_installation): an admin's request resolves the org's tenant and
+                # explicitly sets session context before writing github_installations,
+                # exactly like migration 0031's docstring documents as the one org-scoped
+                # write's fix.
+                user = User(
+                    email="installation-rls-fix@test.local", name=None, password_hash=None, is_workspace_admin=False
+                )
+                session.add(user)
+                session.commit()
+
+                org = Org(github_login="installation-rls-fix-org")
+                session.add(org)
+                session.commit()
+
+                # org_repo.ensure_tenant_linked (not a direct org.tenant_id assignment):
+                # orgs' WITH CHECK (migration 0033) requires app.tenant_id to already match
+                # on any UPDATE, and this is the one call site allowed to set it to a
+                # brand-new tenant it just created -- see that function's own docstring.
+                org = org_repo.ensure_tenant_linked(session, org)
+                tenant = session.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+
+                set_tenant_session_context(session, tenant.id, user.id)
+                installation = installation_repo.create(
+                    session,
+                    account_login="installation-rls-fix-org",
+                    account_type="Organization",
+                    auth_mode="app",
+                    installation_id=987654,
+                    org_id=org.id,
+                )
+                assert installation.tenant_id == tenant.id
+
+                # This is the crux of the regression: reset session context to model the
+                # webhook receiver's actual runtime state -- an unauthenticated request on
+                # a connection that has never called set_tenant_session_context/
+                # set_session_user. Before the fix, delete_by_installation_id's own
+                # SELECT/DELETE against github_installations evaluated RLS's
+                # tenant_id/owner_user_id-equality policy to NULL OR NULL and silently
+                # matched zero rows.
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+
+                removed, resolved_tenant_id = installation_repo.delete_by_installation_id(session, 987654)
+
+                assert removed == 1
+                assert resolved_tenant_id == tenant.id
+
+                # Confirm it's actually gone, not just miscounted -- re-resolve via the
+                # SECURITY DEFINER lookup (migration 0035), which bypasses RLS the same way
+                # the fix itself does, so this assertion isn't fooled by the same bug.
+                still_present = session.execute(
+                    text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": 987654}
+                ).scalar()
+                assert still_present is None
+            finally:
+                session.rollback()
+                # Restore tenant context (if the test's own delete-under-test didn't
+                # already remove the row via the fix, e.g. when run against the pre-fix
+                # code) so this cleanup's own writes against RLS-protected
+                # github_installations/tenants aren't blocked by the very same gap this
+                # PR fixes -- deliberately using the raw SET here, not the fix's
+                # SECURITY DEFINER path, since cleanup already has tenant/user in scope.
+                if tenant is not None and user is not None:
+                    set_tenant_session_context(session, tenant.id, user.id)
+                if installation is not None:
+                    session.execute(
+                        text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987654}
+                    )
+                if org is not None:
+                    session.execute(text("UPDATE orgs SET tenant_id = NULL WHERE id = :id"), {"id": org.id})
+                if tenant is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant.id})
+                if org is not None:
+                    session.execute(text("DELETE FROM orgs WHERE id = :id"), {"id": org.id})
+                if user is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user.id})
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+                session.commit()
+        finally:
+            session.close()
+    engine.dispose()
+
+
+def test_resolve_installation_tenant_id_bypasses_rls_with_no_session_context():
+    """Narrower unit check on migration 0035's function itself, isolated from the repo-
+    level delete flow above: it must resolve tenant_id purely from installation_id,
+    regardless of session context, since that's precisely the pre-authentication
+    condition it exists to handle."""
+    engine = _clevis_api_engine()
+    with engine.connect() as conn:
+        session = Session(bind=conn, expire_on_commit=False)
+        user = org = tenant = None
+        try:
+            try:
+                user = User(
+                    email="resolve-fn-rls-fix@test.local", name=None, password_hash=None, is_workspace_admin=False
+                )
+                session.add(user)
+                session.commit()
+
+                org = Org(github_login="resolve-fn-rls-fix-org")
+                session.add(org)
+                session.commit()
+
+                org = org_repo.ensure_tenant_linked(session, org)
+                tenant = session.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+
+                set_tenant_session_context(session, tenant.id, user.id)
+                installation_repo.create(
+                    session,
+                    account_login="resolve-fn-rls-fix-org",
+                    account_type="Organization",
+                    auth_mode="app",
+                    installation_id=987655,
+                    org_id=org.id,
+                )
+                session.commit()
+
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+
+                # Sanity check: with no session context, a plain SELECT against the
+                # RLS-protected table itself is blocked (proving this test's "no context"
+                # state is real, not accidentally leaked).
+                blocked = session.execute(
+                    text("SELECT id FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
+                ).fetchall()
+                assert blocked == []
+
+                resolved = session.execute(
+                    text("SELECT resolve_installation_tenant_id(:iid)"), {"iid": 987655}
+                ).scalar()
+                assert resolved == tenant.id
+            finally:
+                session.rollback()
+                if tenant is not None and user is not None:
+                    set_tenant_session_context(session, tenant.id, user.id)
+                session.execute(
+                    text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
+                )
+                if org is not None:
+                    session.execute(text("UPDATE orgs SET tenant_id = NULL WHERE id = :id"), {"id": org.id})
+                if tenant is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant.id})
+                if org is not None:
+                    session.execute(text("DELETE FROM orgs WHERE id = :id"), {"id": org.id})
+                if user is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user.id})
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+                session.commit()
+        finally:
+            session.close()
+    engine.dispose()

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -10,9 +10,11 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from src.core.config import settings
-from src.core.db import AuditLog, get_db
+from src.core.db import AuditLog, WebhookDelivery, get_db
+from src.core.redis_client import get_redis_client
 from src.repositories import installation_repo, org_repo
-from src.routers.webhooks import router as webhooks_router
+from src.routers import webhooks as webhooks_module
+from src.routers.webhooks import _WEBHOOK_STREAM_KEY, router as webhooks_router
 
 _SECRET = "test-webhook-secret"
 
@@ -26,22 +28,41 @@ def webhook_client(db, monkeypatch):
     return TestClient(app)
 
 
+@pytest.fixture()
+def redis_client():
+    # FLUSHDB, not a per-test key prefix: the ingestion path's stream key is a fixed
+    # module constant, not parameterized per test, so isolating one test's entries
+    # from another's needs the whole (test) DB cleared -- fine since this is a
+    # dedicated Redis instance for the test suite, never a shared/production one.
+    client = get_redis_client()
+    client.flushdb()
+    yield client
+    client.flushdb()
+
+
 def _sign(body: bytes, secret: str = _SECRET) -> str:
     return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _post(client, event: str, payload: dict, *, secret: str = _SECRET, signature: str | None = None):
+def _post(
+    client,
+    event: str,
+    payload: dict,
+    *,
+    secret: str = _SECRET,
+    signature: str | None = None,
+    headers_extra: dict | None = None,
+):
     body = json.dumps(payload).encode()
     sig = signature if signature is not None else _sign(body, secret)
-    return client.post(
-        "/webhooks/github",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-GitHub-Event": event,
-            "X-Hub-Signature-256": sig,
-        },
-    )
+    headers = {
+        "Content-Type": "application/json",
+        "X-GitHub-Event": event,
+        "X-Hub-Signature-256": sig,
+    }
+    if headers_extra:
+        headers.update(headers_extra)
+    return client.post("/webhooks/github", content=body, headers=headers)
 
 
 def test_rejects_missing_signature(webhook_client):
@@ -179,6 +200,77 @@ def test_installation_deleted_ignores_non_integer_installation_id(db, webhook_cl
     # Nothing should be deleted, and no exception should propagate from a type mismatch
     # hitting the database — an installation_id of the wrong type must be a safe no-op.
     assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1
+
+
+def test_push_event_writes_webhook_delivery_row_and_queues_it(db, webhook_client, redis_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(
+        webhook_client,
+        "push",
+        {"installation": {"id": 42}, "ref": "refs/heads/main"},
+        headers_extra={"X-GitHub-Delivery": "delivery-abc-123"},
+    )
+
+    assert resp.status_code == 200
+    rows = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-abc-123").all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == "push"
+    assert row.installation_id == 42
+    assert row.status == "queued"
+    assert row.tenant_id is not None
+    assert json.loads(row.payload) == {"installation": {"id": 42}, "ref": "refs/heads/main"}
+
+    entries = redis_client.xrange(_WEBHOOK_STREAM_KEY)
+    assert len(entries) == 1
+    _, fields = entries[0]
+    assert fields["event_type"] == "push"
+    assert fields["delivery_row_id"] == str(row.id)
+    assert fields["tenant_id"] == str(row.tenant_id)
+
+
+def test_ingested_event_without_installation_still_queues_with_null_tenant(db, webhook_client, redis_client):
+    resp = _post(webhook_client, "issues", {"action": "opened"}, headers_extra={"X-GitHub-Delivery": "delivery-no-inst"})
+
+    assert resp.status_code == 200
+    row = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-no-inst").first()
+    assert row is not None
+    assert row.installation_id is None
+    assert row.tenant_id is None
+    assert row.status == "queued"
+
+    entries = redis_client.xrange(_WEBHOOK_STREAM_KEY)
+    assert len(entries) == 1
+    assert entries[0][1]["tenant_id"] == ""
+
+
+def test_unrecognized_event_type_does_not_write_a_webhook_delivery_row(db, webhook_client, redis_client):
+    resp = _post(webhook_client, "ping", {"zen": "hello"})
+
+    assert resp.status_code == 200
+    assert db.query(WebhookDelivery).count() == 0
+    assert redis_client.xrange(_WEBHOOK_STREAM_KEY) == []
+
+
+def test_redis_unreachable_still_returns_200_and_marks_row_queue_failed(db, webhook_client, monkeypatch):
+    class _BrokenClient:
+        def xadd(self, *args, **kwargs):
+            raise ConnectionError("redis unreachable")
+
+    monkeypatch.setattr(webhooks_module, "get_redis_client", lambda: _BrokenClient())
+
+    resp = _post(
+        webhook_client, "release", {"action": "published"}, headers_extra={"X-GitHub-Delivery": "delivery-redis-down"}
+    )
+
+    assert resp.status_code == 200
+    row = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-redis-down").first()
+    assert row is not None
+    assert row.status == "queue_failed"
 
 
 def test_route_is_registered_on_the_real_app(db, monkeypatch):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,15 +47,22 @@ services:
   # Redis for under S1 -- this is the first consumer to actually need it.
   # --appendonly yes: stream entries must survive a container restart, since a lost
   # entry here is a lost/delayed webhook event, not just a cache miss.
+  # --requirepass: every other stateful service in this file (Postgres) requires a
+  # credential; leaving Redis open would let any other compromised container on the
+  # shared `clevis` network read, delete, or inject stream entries (e.g. spoofing a
+  # fake tenant_id into the future S4 consumer's input). REDIS_PASSWORD is required
+  # (apps/api/entrypoint.sh's "must all be set" check), mirroring DB_PASSWORD.
   redis:
     container_name: redis
     image: redis:7-alpine
     mem_limit: 256m
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ["sh", "-c", "redis-server --appendonly yes --requirepass \"$REDIS_PASSWORD\""]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     volumes:
       - redisdata:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli -a \"$REDIS_PASSWORD\" ping | grep -q PONG"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,28 @@ services:
     networks:
       - clevis
 
+  # Issue #191/S3: managed queue for webhook ingestion (Redis Streams), plus the
+  # cache/token-broker role docs/architecture/clevis-architecture.md already earmarks
+  # Redis for under S1 -- this is the first consumer to actually need it.
+  # --appendonly yes: stream entries must survive a container restart, since a lost
+  # entry here is a lost/delayed webhook event, not just a cache miss.
+  redis:
+    container_name: redis
+    image: redis:7-alpine
+    mem_limit: 256m
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - clevis
+
   api:
     container_name: api
     build:
@@ -54,6 +76,8 @@ services:
       - "8080"
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
@@ -126,3 +150,4 @@ networks:
 
 volumes:
   pgdata:
+  redisdata:

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -56,5 +56,18 @@ GRANT USAGE ON SCHEMA public TO clevis_api;
 GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config TO clevis_api;
 GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq TO clevis_api;
 
+-- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
+-- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
+-- conditional on clevis_api already existing, which isn't true the first time this
+-- script runs on a deployment that's adopting the role. Guarded by existence so this
+-- script still works against a deployment where migration 0035 hasn't run yet.
+DO $do$
+BEGIN
+  IF EXISTS (SELECT FROM pg_proc WHERE proname = 'resolve_installation_tenant_id') THEN
+    GRANT EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) TO clevis_api;
+  END IF;
+END
+$do$;
+
 COMMIT;
 EOSQL

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -53,8 +53,13 @@ $fmt$, :'api_password') \gexec
 
 GRANT CONNECT ON DATABASE :"db_name" TO clevis_api;
 GRANT USAGE ON SCHEMA public TO clevis_api;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config TO clevis_api;
-GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq TO clevis_api;
+GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
+GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
+
+-- resolve_installation_tenant_id() (migration 0035, issue #191/S3 PR 2) needs no GRANT
+-- here -- Postgres functions default to PUBLIC EXECUTE unless explicitly revoked, unlike
+-- tables, so it's already callable without this script's help. Mentioned only so the next
+-- person editing this file doesn't wonder why it's missing from the list above.
 
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -56,11 +56,6 @@ GRANT USAGE ON SCHEMA public TO clevis_api;
 GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
 GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
 
--- resolve_installation_tenant_id() (migration 0035, issue #191/S3 PR 2) needs no GRANT
--- here -- Postgres functions default to PUBLIC EXECUTE unless explicitly revoked, unlike
--- tables, so it's already callable without this script's help. Mentioned only so the next
--- person editing this file doesn't wonder why it's missing from the list above.
-
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
 -- conditional on clevis_api already existing, which isn't true the first time this

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -16,7 +16,7 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
    cp .env.example .env
    ```
 
-2. Fill in `.env`. Six vars are hard-required (the app fails to start without them) — `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY` (`openssl rand -hex 32`), `AUTH_SECRET` (`openssl rand -hex 32`), `NEXT_PUBLIC_API_BASE`. Everything else in `.env.example` has a safe default and only needs overriding per environment (e.g. `CORS_ORIGINS` for your real UI domain, `GITHUB_API_BASE` for GitHub Enterprise).
+2. Fill in `.env`. Seven vars are hard-required (the app fails to start without them) — `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `JOB_SECRET_KEY` (`openssl rand -hex 32`), `AUTH_SECRET` (`openssl rand -hex 32`), `NEXT_PUBLIC_API_BASE`, `REDIS_PASSWORD` (`openssl rand -hex 32` — auths the `redis` service used for webhook ingestion, issue #191). Everything else in `.env.example` has a safe default and only needs overriding per environment (e.g. `CORS_ORIGINS` for your real UI domain, `GITHUB_API_BASE` for GitHub Enterprise).
 
 3. Register a GitHub App on github.com (**Settings → Developer settings → GitHub Apps → New GitHub App**) so users can connect their orgs after the instance is running. The App form asks for three separate URLs — each one is where GitHub sends the browser back to at a different point in the flow, so don't reuse one URL for another's purpose:
    - **Homepage URL** — your deployed UI URL. Shown on the App's public listing page; not used in any redirect.


### PR DESCRIPTION
## Summary

First of 4 staged PRs for issue #191's prerequisite, **S3 — Webhook ingestion + queue**. Issue #191 (S4 Event processors) explicitly names S3 as blocking it, and S3 doesn't exist yet: today's `POST /webhooks/github` only handles `installation.deleted`/`installation.created` — no queue, no raw-payload storage, no other event types processed.

This PR is **pure infra scaffolding — zero behavior change**. Nothing reads or writes any of the new plumbing yet; the existing webhook receiver is untouched.

- **`docker-compose.yml`**: new `redis` service (Redis Streams). Chosen over SQS (this deployment is self-hosted Docker-Compose/Coolify, not AWS-native) and over extending the `jobs` table (the architecture doc is explicit that `jobs` is for low-volume user-triggered ops, not high-volume webhook fan-in — Redis Streams' consumer groups give the retry/ack semantics that would otherwise need hand-rolling). The architecture doc already earmarks Redis for S1 token caching regardless, so this repo needs it soon either way.
- **New required env var `REDIS_URL`** (`apps/api/src/core/config.py`) — documented in `.env.example` and `AGENTS.md` (required vars bumped 6 → 7).
- **New migration `0034`** (`webhook_deliveries` table): durable Postgres landing spot for raw verified webhook payloads (`bytea`, not re-serialized JSON) before they're queued. Chosen over standing up MinIO now — nothing reads payloads back out until a future S4 consumer exists, so object storage is infra ahead of need at this stage (flagged in the migration docstring as a proportionate-for-now choice, not permanent).
- **Deliberately no Row-Level Security** on `webhook_deliveries`, unlike this repo's tenant-scoped tables. The receiver writes this table on an unauthenticated connection with no `app.tenant_id` session var set (there's no authenticated tenant context at webhook-receive time), so a tenant-matching `WITH CHECK` would reject every insert regardless of resolution success. Structured like `jobs`/`app_config` instead (see migration `0030`'s docstring for why those are RLS-exempt) — a future S4 consumer also needs to read across all tenants at once, not one tenant's rows at a time.
- Grants `clevis_api` access to the new table + its sequence inline, per migration `0032`'s stated policy that a new table needs its own reviewed grant rather than silently inheriting one.
- CI: new `redis:7-alpine` service container in the `python` job (unused by any test yet, but required for `Settings()` to construct since `redis_url` has no default) and a `REDIS_URL` line in the E2E job's generated `.env`.

## Flags per AGENTS.md guardrails

- **Migration included** (`0034_add_webhook_deliveries.py`) — pure additive `CREATE TABLE` + grants, no existing table touched, no data-loss risk.
- **New required env var** (`REDIS_URL`) — no safe default, since without it the webhook receiver has nothing to queue onto.
- **CI workflow change** — new service container + env var, `python` and `e2e` jobs.

## Out of scope (see full plan)

S4 (event processors, normalization, aggregates, delivery-id dedupe) is not part of this or any of the 4 S3 PRs. PR 2 (next) fixes a real RLS gap found while researching this found in the *existing* `installation.deleted` handler. PR 3 adds the actual generic ingestion path. PR 4 is docs.

## Test plan

- [x] `alembic upgrade head` applies cleanly; `alembic check` reports no model/migration drift
- [x] Full `pytest -q` green locally (646 passed, 1 skipped, 3 xpassed — unchanged from before this PR)
- [ ] CI green (new Redis service container in both `python` and `e2e` jobs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable webhook delivery tracking with event metadata, processing status, timestamps, and preserved payloads.
  - Added durable queuing for supported GitHub events, including graceful recording of queue failures.
  - Added password-protected Redis support with persistence, health monitoring, and automatic startup configuration.
  - Added local and Docker configuration options for the webhook queue.

- **Documentation**
  - Documented webhook delivery records, Redis authentication, queue configuration, and required setup values.

- **Chores**
  - Updated automated testing environments to provision Redis and validate queue-dependent workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->