### PR TITLE
fix(api): resolve installation tenant_id via SECURITY DEFINER for RLS-safe webhook deletes

### DIFF
--- a/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
+++ b/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
@@ -60,6 +60,12 @@ def upgrade() -> None:
         $$;
         """
     )
+    # Postgres grants EXECUTE on a new function to PUBLIC by default (unlike tables) --
+    # left alone, the GRANT below wouldn't actually narrow anything, since every role
+    # that can connect could already call this function and read any installation's
+    # tenant_id, defeating the "narrow, deliberately scoped" bypass this migration's
+    # docstring describes (CodeRabbit finding on PR #337).
+    op.execute("REVOKE EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) FROM PUBLIC")
     op.execute(
         """
         DO $$

--- a/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
+++ b/apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py
@@ -1,0 +1,77 @@
+"""Add resolve_installation_tenant_id() SECURITY DEFINER function (issue #191, S3 PR 2 of 4).
+
+**Fixes a genuine, already-live production bug** -- not a refactor. Migration 0031 put
+`github_installations` under `FORCE ROW LEVEL SECURITY` with policy
+`USING (tenant_id = app.tenant_id OR owner_user_id = app.user_id)`. The GitHub webhook
+receiver (`src/routers/webhooks.py`, `POST /webhooks/github`) is unauthenticated by
+design -- it verifies the request via HMAC signature, not a login session -- so it never
+calls `require_org_role`/`require_personal_tenant` (the only places that set the
+`app.tenant_id`/`app.user_id` session vars this policy reads). Under the real runtime
+`clevis_api` role (non-superuser since #330), that means `_handle_installation_deleted`'s
+lookup against `github_installations` evaluates the policy to `NULL OR NULL` -- every row
+invisible, every time. The uninstall-cleanup delete has been silently no-op'ing in
+production since #330 cut the API over to `clevis_api`: GitHub's `installation.deleted`
+webhook fires, signature verifies, handler runs, `DELETE` affects 0 rows, no error, no
+audit log entry, and the stale `github_installations` row (and its now-invalid
+`token_ref`) is never cleaned up.
+
+This migration adds a narrow SECURITY DEFINER function, owned by whichever role runs
+migrations (the DB_USER bootstrap superuser -- table owner, unconditionally bypasses RLS
+regardless of FORCE), that does exactly one read: resolve a GitHub installation_id to its
+tenant_id. `clevis_api` is granted EXECUTE on it, not BYPASSRLS on the role itself --
+BYPASSRLS is an all-or-nothing role attribute that would neuter RLS for every query the
+API makes, not just this one pre-authentication lookup. The webhook handler (PR 2's other
+half, in installation_repo.py) calls this function first to resolve tenant_id, then sets
+`app.tenant_id` for the rest of the request via the existing plain-SET pattern
+(src/core/db.py's set_session_user, src/core/rbac.py's set_tenant_session_context) so the
+actual DELETE that follows is evaluated under a session that now legitimately satisfies
+the policy's tenant_id-equality branch -- not bypassing RLS for the delete itself, just
+supplying the session context RLS already expects to find.
+
+Upgrade is purely additive (one new function) -- zero data-loss risk. Downgrade drops the
+function; do not run it against a real environment without explicit confirmation
+(AGENTS.md) since it would silently reintroduce the bug this migration fixes.
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-08-16
+"""
+
+from alembic import op
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION resolve_installation_tenant_id(p_installation_id integer)
+        RETURNS integer
+        LANGUAGE sql
+        SECURITY DEFINER
+        SET search_path = pg_catalog, public
+        AS $$
+            SELECT tenant_id FROM github_installations
+            WHERE installation_id = p_installation_id
+            LIMIT 1
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) TO clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS resolve_installation_tenant_id(integer)")

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,3 +10,4 @@ cryptography==44.0.2
 bcrypt==4.2.1
 PyJWT==2.13.0
 email-validator==2.2.0
+redis==5.2.1

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -335,6 +335,20 @@ def set_session_user(db: Session, user_id: int) -> None:
     db.execute(text(f"SET app.user_id = {int(user_id)}"))
 
 
+def set_session_tenant(db: Session, tenant_id: int) -> None:
+    """Sets app.tenant_id alone, for system code paths that resolve a tenant_id without an
+    acting user -- e.g. the GitHub webhook receiver (issue #191/S3), which runs before any
+    authenticated session exists (HMAC-signature-verified, not login-gated), so there's no
+    app.user_id to set alongside it. Satisfies the tenant_id-equality half of migration
+    0031's github_installations/memberships policies. The tenant_id here must come from a
+    trusted resolution (e.g. resolve_installation_tenant_id(), migration 0035's SECURITY
+    DEFINER function) -- this call only sets session state for RLS to read, it does not
+    itself verify the caller is entitled to that tenant. Same plain-SET reasoning as
+    set_session_user/rbac.set_tenant_session_context -- see their docstrings.
+    """
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+
+
 def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:

--- a/apps/api/src/core/redis_client.py
+++ b/apps/api/src/core/redis_client.py
@@ -1,0 +1,20 @@
+"""Thin Redis client accessor for the webhook ingestion queue (issue #191/S3).
+
+A single process-wide client (redis-py pools connections internally, so this isn't
+"one connection" -- it's one client object reusing a pool), lazily constructed from
+settings.redis_url the first time it's needed rather than at import time, so a test
+run that never touches Redis never has to have it reachable.
+"""
+
+import redis
+
+from src.core.config import settings
+
+_client: redis.Redis | None = None
+
+
+def get_redis_client() -> redis.Redis:
+    global _client
+    if _client is None:
+        _client = redis.Redis.from_url(settings.redis_url.get_secret_value(), decode_responses=True)
+    return _client

--- a/apps/api/src/core/redis_client.py
+++ b/apps/api/src/core/redis_client.py
@@ -13,8 +13,25 @@ from src.core.config import settings
 _client: redis.Redis | None = None
 
 
+# redis-py 5.2.1 defaults both timeouts to None (block forever). The webhook receiver
+# calls xadd() synchronously from inside an async route (src/routers/webhooks.py), so an
+# unresponsive-but-not-yet-refused Redis (e.g. a network partition, not just "connection
+# refused") would otherwise stall the whole event loop, not just this one request --
+# unlike a fast connection error, which the existing try/except already handles fine.
+# Finite but generous relative to a webhook receiver's expected response time; no
+# automatic retries (the caller's own queue_failed fallback is the retry story, and
+# retrying writes here risks a duplicate XADD with no dedupe defined yet).
+_SOCKET_CONNECT_TIMEOUT_SECONDS = 2
+_SOCKET_TIMEOUT_SECONDS = 2
+
+
 def get_redis_client() -> redis.Redis:
     global _client
     if _client is None:
-        _client = redis.Redis.from_url(settings.redis_url.get_secret_value(), decode_responses=True)
+        _client = redis.Redis.from_url(
+            settings.redis_url.get_secret_value(),
+            decode_responses=True,
+            socket_connect_timeout=_SOCKET_CONNECT_TIMEOUT_SECONDS,
+            socket_timeout=_SOCKET_TIMEOUT_SECONDS,
+        )
     return _client

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -1,8 +1,8 @@
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from src.core.db import GitHubInstallation
+from src.core.db import GitHubInstallation, set_session_tenant
 from src.repositories import tenant_repo
 
 
@@ -144,9 +144,25 @@ def delete_by_installation_id(db: Session, installation_id: int) -> tuple[int, i
     Returns (rows deleted, tenant_id of the first deleted row) -- the tenant_id lets the
     webhook handler's audit_repo.write call attribute the deletion under RLS (issue #330);
     every row here already has tenant_id populated by upsert's _resolve_tenant_id, so this
-    is just reading back what's already there before the rows are gone."""
+    is just reading back what's already there before the rows are gone.
+
+    Called from the unauthenticated webhook receiver (issue #191/S3), which never sets
+    app.tenant_id/app.user_id -- under RLS (migration 0031's FORCE ROW LEVEL SECURITY on
+    this table) that made both the SELECT and DELETE below silently see zero rows, every
+    time (issue #191/S3 PR 2 fix). resolve_installation_tenant_id() (migration 0035, a
+    SECURITY DEFINER function) resolves tenant_id first, bypassing RLS for that one lookup
+    the same way the table owner already does; once resolved, set_session_tenant supplies
+    the session context RLS expects so the actual SELECT/DELETE that follows are evaluated
+    normally, under a session that now legitimately satisfies the tenant_id-equality
+    policy branch -- not a second RLS bypass."""
+    tenant_id = db.execute(
+        text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": installation_id}
+    ).scalar()
+    if tenant_id is not None:
+        set_session_tenant(db, tenant_id)
+
     rows = db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).all()
-    tenant_id = rows[0].tenant_id if rows else None
+    resolved_tenant_id = rows[0].tenant_id if rows else tenant_id
     count = db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).delete()
     db.commit()
-    return count, tenant_id
+    return count, resolved_tenant_id

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,7 +1,9 @@
 """GitHub App webhook receiver.
 
   POST /webhooks/github   verifies X-Hub-Signature-256, then handles installation
-                           lifecycle events to keep github_installations in sync.
+                           lifecycle events to keep github_installations in sync, and
+                           durably queues a bounded set of event types (issue #191/S3)
+                           for a future event-processor fleet (S4, not built yet).
 """
 
 import hashlib
@@ -10,16 +12,32 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
-from src.core.db import get_db
+from src.core.db import WebhookDelivery, get_db
 from src.core.rate_limit import rate_limit
+from src.core.redis_client import get_redis_client
 from src.repositories import audit_repo, installation_repo
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Mirrors the event types apps/api/src/routers/github.py's Activity Feed already
+# summarizes (PushEvent/PullRequestEvent/IssuesEvent/ReleaseEvent/CreateEvent via
+# GitHub's Events API) -- these are the webhook equivalents (X-GitHub-Event header
+# names, not GitHub Events API `type` strings, hence "create" not "CreateEvent").
+# S4 (a future event-processor fleet, out of scope here) is what will eventually let
+# the Activity Feed move from polling to these queued rows; until then they just
+# accumulate in webhook_deliveries with status="queued", which is the expected
+# handoff state, not a bug.
+_INGESTED_EVENT_TYPES = {"push", "pull_request", "issues", "release", "create"}
+
+# Redis Stream key the ingestion path XADDs onto; a future S4 consumer group reads
+# from this same key.
+_WEBHOOK_STREAM_KEY = "webhook_events"
 
 # GitHub caps webhook deliveries around 25MB; refuse anything larger long before that
 # so a body this endpoint (unauthenticated until the signature check passes) can't be
@@ -70,6 +88,7 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="Malformed webhook payload")
 
     event = request.headers.get("X-GitHub-Event", "")
+    delivery_id = request.headers.get("X-GitHub-Delivery", "")
 
     if event == "installation" and payload.get("action") == "deleted":
         _handle_installation_deleted(db, payload)
@@ -87,8 +106,61 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
     # installation) has nothing to sync yet — github_installations tracks the
     # installation itself, not per-repo access, so there's no row-level change
     # to make here today. Accepted (200) so GitHub doesn't retry.
+    elif event in _INGESTED_EVENT_TYPES:
+        _handle_ingested_event(db, event, delivery_id, raw_body, payload)
 
     return {"ok": True}
+
+
+def _resolve_event_installation_id(payload: dict) -> int | None:
+    installation_id = (payload.get("installation") or {}).get("id")
+    if not isinstance(installation_id, int) or isinstance(installation_id, bool):
+        return None
+    return installation_id
+
+
+def _handle_ingested_event(db: Session, event: str, delivery_id: str, raw_body: bytes, payload: dict) -> None:
+    installation_id = _resolve_event_installation_id(payload)
+
+    tenant_id = None
+    if installation_id is not None:
+        # SECURITY DEFINER lookup (migration 0035), same as installation_repo's
+        # delete-under-RLS fix (issue #191/S3 PR 2) -- this receiver never has an
+        # authenticated session, so it never has app.tenant_id set to look this up
+        # the normal way.
+        tenant_id = db.execute(
+            text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": installation_id}
+        ).scalar()
+
+    row = WebhookDelivery(
+        tenant_id=tenant_id,
+        delivery_id=delivery_id,
+        event_type=event,
+        installation_id=installation_id,
+        payload=raw_body,
+        status="queued",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    try:
+        client = get_redis_client()
+        client.xadd(
+            _WEBHOOK_STREAM_KEY,
+            {
+                "delivery_row_id": row.id,
+                "event_type": event,
+                "tenant_id": tenant_id if tenant_id is not None else "",
+            },
+        )
+    except Exception:
+        # A transient Redis blip isn't GitHub's retry problem to solve -- the payload
+        # is already durably stored above. Mark it so a future re-enqueue sweep (out
+        # of scope here) can find it; still a 200 to GitHub either way.
+        logger.exception("Failed to enqueue webhook_deliveries row %s onto Redis stream %s", row.id, _WEBHOOK_STREAM_KEY)
+        row.status = "queue_failed"
+        db.commit()
 
 
 def _handle_installation_deleted(db: Session, payload: dict) -> None:

--- a/apps/api/tests/test_installation_deleted_rls_fix.py
+++ b/apps/api/tests/test_installation_deleted_rls_fix.py
@@ -29,7 +29,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
-from src.core.db import GitHubInstallation, Org, Tenant, User
+from src.core.db import GitHubInstallation, Org, Tenant, User, set_session_user
 from src.core.rbac import set_tenant_session_context
 from src.repositories import installation_repo, org_repo
 
@@ -115,14 +115,21 @@ def test_installation_deleted_removes_the_row_with_no_session_context_set():
                 assert still_present is None
             finally:
                 session.rollback()
-                # Restore tenant context (if the test's own delete-under-test didn't
-                # already remove the row via the fix, e.g. when run against the pre-fix
-                # code) so this cleanup's own writes against RLS-protected
-                # github_installations/tenants aren't blocked by the very same gap this
-                # PR fixes -- deliberately using the raw SET here, not the fix's
-                # SECURITY DEFINER path, since cleanup already has tenant/user in scope.
-                if tenant is not None and user is not None:
-                    set_tenant_session_context(session, tenant.id, user.id)
+                # Restore context (if the test's own delete-under-test didn't already
+                # remove the row via the fix, e.g. when run against the pre-fix code) so
+                # this cleanup's own writes against RLS-protected github_installations/
+                # tenants aren't blocked by the very same gap this PR fixes --
+                # deliberately using the raw SET here, not the fix's SECURITY DEFINER
+                # path, since cleanup already has tenant/user in scope. Falls back to
+                # set_session_user alone when tenant resolution itself failed (tenant is
+                # still None) but user was created -- restoring at least the user-scoped
+                # half of RLS's self-access clause instead of skipping restoration
+                # entirely (CodeRabbit finding on PR #337).
+                if user is not None:
+                    if tenant is not None:
+                        set_tenant_session_context(session, tenant.id, user.id)
+                    else:
+                        set_session_user(session, user.id)
                 if installation is not None:
                     session.execute(
                         text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987654}
@@ -195,8 +202,11 @@ def test_resolve_installation_tenant_id_bypasses_rls_with_no_session_context():
                 assert resolved == tenant.id
             finally:
                 session.rollback()
-                if tenant is not None and user is not None:
-                    set_tenant_session_context(session, tenant.id, user.id)
+                if user is not None:
+                    if tenant is not None:
+                        set_tenant_session_context(session, tenant.id, user.id)
+                    else:
+                        set_session_user(session, user.id)
                 session.execute(
                     text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
                 )

--- a/apps/api/tests/test_installation_deleted_rls_fix.py
+++ b/apps/api/tests/test_installation_deleted_rls_fix.py
@@ -1,0 +1,216 @@
+"""Regression test for issue #191/S3 PR 2: the GitHub webhook receiver's
+installation.deleted handler was silently no-op'ing under the real, non-superuser
+clevis_api role (issue #330) because it never set the app.tenant_id/app.user_id session
+vars migration 0031's RLS policy on github_installations reads -- see
+installation_repo.delete_by_installation_id's docstring and migration 0035's docstring
+for the full explanation.
+
+Deliberately does NOT use the shared `db` fixture (conftest.py). That fixture joins an
+already-open outer transaction via SQLAlchemy's `join_transaction_mode="create_savepoint"`
+-- each `Session.commit()` inside a test only releases a SAVEPOINT, it doesn't end the
+real Postgres transaction. Plain `SET` (used by set_tenant_session_context) is
+connection-scoped, so that's fine either way, but this test needs to prove the bug exists
+with NO session context carried over from an unrelated earlier write in the same test --
+using a real connection with real commits (mirroring production's one-connection-per-
+request lifecycle: get_db() hands out a brand-new session per request, so a webhook
+request's connection never inherits an admin request's app.tenant_id) makes that explicit
+rather than relying on savepoint semantics happening to keep it isolated.
+
+Same skip-when-unavailable convention as test_rls_isolation.py: reuses DATABASE_URL when
+the suite is already running as clevis_api (CI), or swaps credentials via API_DB_PASSWORD
+for an opt-in local run.
+"""
+
+import os
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import GitHubInstallation, Org, Tenant, User
+from src.core.rbac import set_tenant_session_context
+from src.repositories import installation_repo, org_repo
+
+
+def _clevis_api_engine():
+    url = urlsplit(settings.database_url.get_secret_value())
+    if url.username == "clevis_api":
+        return create_engine(settings.database_url.get_secret_value())
+
+    password = os.environ.get("API_DB_PASSWORD")
+    if not password:
+        pytest.skip(
+            "neither DATABASE_URL nor API_DB_PASSWORD point at clevis_api -- "
+            "provision the role (docker/provision-api-role-existing-deployment.sh) "
+            "and set API_DB_PASSWORD to exercise this test locally"
+        )
+    port = f":{url.port}" if url.port is not None else ""
+    netloc = f"clevis_api:{quote(password, safe='')}@{url.hostname}{port}"
+    return create_engine(urlunsplit((url.scheme, netloc, url.path, url.query, url.fragment)))
+
+
+def test_installation_deleted_removes_the_row_with_no_session_context_set():
+    engine = _clevis_api_engine()
+    with engine.connect() as conn:
+        session = Session(bind=conn, expire_on_commit=False)
+        user = org = tenant = installation = None
+        try:
+            try:
+                # Setup mirrors the real authenticated sync path (installations.py's
+                # sync_org_installation): an admin's request resolves the org's tenant and
+                # explicitly sets session context before writing github_installations,
+                # exactly like migration 0031's docstring documents as the one org-scoped
+                # write's fix.
+                user = User(
+                    email="installation-rls-fix@test.local", name=None, password_hash=None, is_workspace_admin=False
+                )
+                session.add(user)
+                session.commit()
+
+                org = Org(github_login="installation-rls-fix-org")
+                session.add(org)
+                session.commit()
+
+                # org_repo.ensure_tenant_linked (not a direct org.tenant_id assignment):
+                # orgs' WITH CHECK (migration 0033) requires app.tenant_id to already match
+                # on any UPDATE, and this is the one call site allowed to set it to a
+                # brand-new tenant it just created -- see that function's own docstring.
+                org = org_repo.ensure_tenant_linked(session, org)
+                tenant = session.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+
+                set_tenant_session_context(session, tenant.id, user.id)
+                installation = installation_repo.create(
+                    session,
+                    account_login="installation-rls-fix-org",
+                    account_type="Organization",
+                    auth_mode="app",
+                    installation_id=987654,
+                    org_id=org.id,
+                )
+                assert installation.tenant_id == tenant.id
+
+                # This is the crux of the regression: reset session context to model the
+                # webhook receiver's actual runtime state -- an unauthenticated request on
+                # a connection that has never called set_tenant_session_context/
+                # set_session_user. Before the fix, delete_by_installation_id's own
+                # SELECT/DELETE against github_installations evaluated RLS's
+                # tenant_id/owner_user_id-equality policy to NULL OR NULL and silently
+                # matched zero rows.
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+
+                removed, resolved_tenant_id = installation_repo.delete_by_installation_id(session, 987654)
+
+                assert removed == 1
+                assert resolved_tenant_id == tenant.id
+
+                # Confirm it's actually gone, not just miscounted -- re-resolve via the
+                # SECURITY DEFINER lookup (migration 0035), which bypasses RLS the same way
+                # the fix itself does, so this assertion isn't fooled by the same bug.
+                still_present = session.execute(
+                    text("SELECT resolve_installation_tenant_id(:installation_id)"), {"installation_id": 987654}
+                ).scalar()
+                assert still_present is None
+            finally:
+                session.rollback()
+                # Restore tenant context (if the test's own delete-under-test didn't
+                # already remove the row via the fix, e.g. when run against the pre-fix
+                # code) so this cleanup's own writes against RLS-protected
+                # github_installations/tenants aren't blocked by the very same gap this
+                # PR fixes -- deliberately using the raw SET here, not the fix's
+                # SECURITY DEFINER path, since cleanup already has tenant/user in scope.
+                if tenant is not None and user is not None:
+                    set_tenant_session_context(session, tenant.id, user.id)
+                if installation is not None:
+                    session.execute(
+                        text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987654}
+                    )
+                if org is not None:
+                    session.execute(text("UPDATE orgs SET tenant_id = NULL WHERE id = :id"), {"id": org.id})
+                if tenant is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant.id})
+                if org is not None:
+                    session.execute(text("DELETE FROM orgs WHERE id = :id"), {"id": org.id})
+                if user is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user.id})
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+                session.commit()
+        finally:
+            session.close()
+    engine.dispose()
+
+
+def test_resolve_installation_tenant_id_bypasses_rls_with_no_session_context():
+    """Narrower unit check on migration 0035's function itself, isolated from the repo-
+    level delete flow above: it must resolve tenant_id purely from installation_id,
+    regardless of session context, since that's precisely the pre-authentication
+    condition it exists to handle."""
+    engine = _clevis_api_engine()
+    with engine.connect() as conn:
+        session = Session(bind=conn, expire_on_commit=False)
+        user = org = tenant = None
+        try:
+            try:
+                user = User(
+                    email="resolve-fn-rls-fix@test.local", name=None, password_hash=None, is_workspace_admin=False
+                )
+                session.add(user)
+                session.commit()
+
+                org = Org(github_login="resolve-fn-rls-fix-org")
+                session.add(org)
+                session.commit()
+
+                org = org_repo.ensure_tenant_linked(session, org)
+                tenant = session.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+
+                set_tenant_session_context(session, tenant.id, user.id)
+                installation_repo.create(
+                    session,
+                    account_login="resolve-fn-rls-fix-org",
+                    account_type="Organization",
+                    auth_mode="app",
+                    installation_id=987655,
+                    org_id=org.id,
+                )
+                session.commit()
+
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+
+                # Sanity check: with no session context, a plain SELECT against the
+                # RLS-protected table itself is blocked (proving this test's "no context"
+                # state is real, not accidentally leaked).
+                blocked = session.execute(
+                    text("SELECT id FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
+                ).fetchall()
+                assert blocked == []
+
+                resolved = session.execute(
+                    text("SELECT resolve_installation_tenant_id(:iid)"), {"iid": 987655}
+                ).scalar()
+                assert resolved == tenant.id
+            finally:
+                session.rollback()
+                if tenant is not None and user is not None:
+                    set_tenant_session_context(session, tenant.id, user.id)
+                session.execute(
+                    text("DELETE FROM github_installations WHERE installation_id = :iid"), {"iid": 987655}
+                )
+                if org is not None:
+                    session.execute(text("UPDATE orgs SET tenant_id = NULL WHERE id = :id"), {"id": org.id})
+                if tenant is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant.id})
+                if org is not None:
+                    session.execute(text("DELETE FROM orgs WHERE id = :id"), {"id": org.id})
+                if user is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user.id})
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+                session.commit()
+        finally:
+            session.close()
+    engine.dispose()

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -10,9 +10,11 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from src.core.config import settings
-from src.core.db import AuditLog, get_db
+from src.core.db import AuditLog, WebhookDelivery, get_db
+from src.core.redis_client import get_redis_client
 from src.repositories import installation_repo, org_repo
-from src.routers.webhooks import router as webhooks_router
+from src.routers import webhooks as webhooks_module
+from src.routers.webhooks import _WEBHOOK_STREAM_KEY, router as webhooks_router
 
 _SECRET = "test-webhook-secret"
 
@@ -26,22 +28,41 @@ def webhook_client(db, monkeypatch):
     return TestClient(app)
 
 
+@pytest.fixture()
+def redis_client():
+    # FLUSHDB, not a per-test key prefix: the ingestion path's stream key is a fixed
+    # module constant, not parameterized per test, so isolating one test's entries
+    # from another's needs the whole (test) DB cleared -- fine since this is a
+    # dedicated Redis instance for the test suite, never a shared/production one.
+    client = get_redis_client()
+    client.flushdb()
+    yield client
+    client.flushdb()
+
+
 def _sign(body: bytes, secret: str = _SECRET) -> str:
     return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _post(client, event: str, payload: dict, *, secret: str = _SECRET, signature: str | None = None):
+def _post(
+    client,
+    event: str,
+    payload: dict,
+    *,
+    secret: str = _SECRET,
+    signature: str | None = None,
+    headers_extra: dict | None = None,
+):
     body = json.dumps(payload).encode()
     sig = signature if signature is not None else _sign(body, secret)
-    return client.post(
-        "/webhooks/github",
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-GitHub-Event": event,
-            "X-Hub-Signature-256": sig,
-        },
-    )
+    headers = {
+        "Content-Type": "application/json",
+        "X-GitHub-Event": event,
+        "X-Hub-Signature-256": sig,
+    }
+    if headers_extra:
+        headers.update(headers_extra)
+    return client.post("/webhooks/github", content=body, headers=headers)
 
 
 def test_rejects_missing_signature(webhook_client):
@@ -179,6 +200,77 @@ def test_installation_deleted_ignores_non_integer_installation_id(db, webhook_cl
     # Nothing should be deleted, and no exception should propagate from a type mismatch
     # hitting the database — an installation_id of the wrong type must be a safe no-op.
     assert len(installation_repo.list_for_org(db, org_id=org.id)) == 1
+
+
+def test_push_event_writes_webhook_delivery_row_and_queues_it(db, webhook_client, redis_client):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+
+    resp = _post(
+        webhook_client,
+        "push",
+        {"installation": {"id": 42}, "ref": "refs/heads/main"},
+        headers_extra={"X-GitHub-Delivery": "delivery-abc-123"},
+    )
+
+    assert resp.status_code == 200
+    rows = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-abc-123").all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == "push"
+    assert row.installation_id == 42
+    assert row.status == "queued"
+    assert row.tenant_id is not None
+    assert json.loads(row.payload) == {"installation": {"id": 42}, "ref": "refs/heads/main"}
+
+    entries = redis_client.xrange(_WEBHOOK_STREAM_KEY)
+    assert len(entries) == 1
+    _, fields = entries[0]
+    assert fields["event_type"] == "push"
+    assert fields["delivery_row_id"] == str(row.id)
+    assert fields["tenant_id"] == str(row.tenant_id)
+
+
+def test_ingested_event_without_installation_still_queues_with_null_tenant(db, webhook_client, redis_client):
+    resp = _post(webhook_client, "issues", {"action": "opened"}, headers_extra={"X-GitHub-Delivery": "delivery-no-inst"})
+
+    assert resp.status_code == 200
+    row = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-no-inst").first()
+    assert row is not None
+    assert row.installation_id is None
+    assert row.tenant_id is None
+    assert row.status == "queued"
+
+    entries = redis_client.xrange(_WEBHOOK_STREAM_KEY)
+    assert len(entries) == 1
+    assert entries[0][1]["tenant_id"] == ""
+
+
+def test_unrecognized_event_type_does_not_write_a_webhook_delivery_row(db, webhook_client, redis_client):
+    resp = _post(webhook_client, "ping", {"zen": "hello"})
+
+    assert resp.status_code == 200
+    assert db.query(WebhookDelivery).count() == 0
+    assert redis_client.xrange(_WEBHOOK_STREAM_KEY) == []
+
+
+def test_redis_unreachable_still_returns_200_and_marks_row_queue_failed(db, webhook_client, monkeypatch):
+    class _BrokenClient:
+        def xadd(self, *args, **kwargs):
+            raise ConnectionError("redis unreachable")
+
+    monkeypatch.setattr(webhooks_module, "get_redis_client", lambda: _BrokenClient())
+
+    resp = _post(
+        webhook_client, "release", {"action": "published"}, headers_extra={"X-GitHub-Delivery": "delivery-redis-down"}
+    )
+
+    assert resp.status_code == 200
+    row = db.query(WebhookDelivery).filter(WebhookDelivery.delivery_id == "delivery-redis-down").first()
+    assert row is not None
+    assert row.status == "queue_failed"
 
 
 def test_route_is_registered_on_the_real_app(db, monkeypatch):

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -56,5 +56,18 @@ GRANT USAGE ON SCHEMA public TO clevis_api;
 GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config TO clevis_api;
 GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq TO clevis_api;
 
+-- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
+-- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
+-- conditional on clevis_api already existing, which isn't true the first time this
+-- script runs on a deployment that's adopting the role. Guarded by existence so this
+-- script still works against a deployment where migration 0035 hasn't run yet.
+DO $do$
+BEGIN
+  IF EXISTS (SELECT FROM pg_proc WHERE proname = 'resolve_installation_tenant_id') THEN
+    GRANT EXECUTE ON FUNCTION resolve_installation_tenant_id(integer) TO clevis_api;
+  END IF;
+END
+$do$;
+
 COMMIT;
 EOSQL

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -53,8 +53,13 @@ $fmt$, :'api_password') \gexec
 
 GRANT CONNECT ON DATABASE :"db_name" TO clevis_api;
 GRANT USAGE ON SCHEMA public TO clevis_api;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config TO clevis_api;
-GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq TO clevis_api;
+GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
+GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
+
+-- resolve_installation_tenant_id() (migration 0035, issue #191/S3 PR 2) needs no GRANT
+-- here -- Postgres functions default to PUBLIC EXECUTE unless explicitly revoked, unlike
+-- tables, so it's already callable without this script's help. Mentioned only so the next
+-- person editing this file doesn't wonder why it's missing from the list above.
 
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -56,11 +56,6 @@ GRANT USAGE ON SCHEMA public TO clevis_api;
 GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
 GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
 
--- resolve_installation_tenant_id() (migration 0035, issue #191/S3 PR 2) needs no GRANT
--- here -- Postgres functions default to PUBLIC EXECUTE unless explicitly revoked, unlike
--- tables, so it's already callable without this script's help. Mentioned only so the next
--- person editing this file doesn't wonder why it's missing from the list above.
-
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
 -- conditional on clevis_api already existing, which isn't true the first time this


### PR DESCRIPTION
## Summary

Fixes a genuine, already-live production bug — not a refactor. Second PR in the S3 (webhook ingestion + queue, issue #191) stack; branches off and targets `s3-webhook-ingestion-infra` (PR #336), not `main`.

Migration 0031 put `github_installations` under `FORCE ROW LEVEL SECURITY` with policy `tenant_id = app.tenant_id OR owner_user_id = app.user_id`. The GitHub webhook receiver (`POST /webhooks/github`) is unauthenticated by design (HMAC-signature-verified, not login-gated) and never calls `require_org_role`/`require_personal_tenant` — the only places that set those session vars. Under the real runtime `clevis_api` role (non-superuser since #330), `_handle_installation_deleted`'s delete against `github_installations` has been evaluating the policy to `NULL OR NULL` — **zero rows visible, every time**. GitHub's `installation.deleted` webhook fires, the signature verifies, the handler runs, the `DELETE` silently affects 0 rows, no audit log entry is written, and the stale row (and its now-invalid `token_ref`) is never cleaned up.

## What changed

- **New migration `0035`**: adds `resolve_installation_tenant_id(installation_id)`, a narrow `SECURITY DEFINER` SQL function owned by the table-owning migration role (the DB_USER superuser — unconditionally bypasses RLS). Grants `EXECUTE` to `clevis_api` only, not `BYPASSRLS` on the role itself (which would neuter RLS for every query the API makes, not just this one pre-authentication lookup).
- **`installation_repo.delete_by_installation_id`**: now calls that function first to resolve `tenant_id`, then calls the new `set_session_tenant` helper (`src/core/db.py`) to set `app.tenant_id` for the rest of the request — so the actual `SELECT`/`DELETE` that follows is evaluated under a session that now legitimately satisfies the policy's tenant_id-equality branch. This isn't a second RLS bypass; the SECURITY DEFINER function only ever answers the one narrow "what tenant does this installation belong to" question.
- **New helper `set_session_tenant`** (`src/core/db.py`): sets `app.tenant_id` alone, for system code paths (like this one) that resolve a tenant without an acting user.

## Why a migration is included

Yes — `apps/api/alembic/versions/0035_installation_tenant_lookup_fn.py` adds one new Postgres function (`resolve_installation_tenant_id`) and grants `clevis_api` `EXECUTE` on it. Upgrade is purely additive (zero data-loss risk). Downgrade drops the function, which would silently reintroduce the bug this PR fixes — do not run it against a real environment without explicit confirmation.

## Verification

- Reproduced the bug locally against a real `clevis_api` role: wrote a regression test that explicitly resets `app.tenant_id`/`app.user_id` mid-test (to accurately model the webhook receiver's fresh-connection, no-session-context reality — the existing `test_webhooks.py` suite doesn't catch this, since its shared `db` fixture uses SAVEPOINT-based test transactions where an earlier plain `SET` in the same test leaks across what would be separate requests/connections in production).
  - Confirmed the test **fails** (`removed == 0`) against the pre-fix code.
  - Confirmed it **passes** with the fix.
- Full `pytest -q` suite (569 passed, 3 xfailed) green locally under the real `clevis_api` role.
- `alembic check` reports no model/migration drift.
- Verified migration 0035 downgrades and re-upgrades cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub installation deletion when no authenticated user or tenant session context is available.
  * Ensured installation records are removed correctly while preserving tenant isolation.
  * Improved tenant resolution for background and system-level operations.
  * Restricted tenant lookup access to authorized database operations.

* **Tests**
  * Added regression coverage for deletion and tenant resolution under restricted database access conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->