### PR TITLE
feat(worker): consume webhook_events into normalized repo_events (S4 …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,12 @@ AUTH_SECRET=           # openssl rand -hex 32  (JWT signing secret)
 NEXT_PUBLIC_API_BASE=  # e.g. https://api.yourdomain.com
 
 # REDIS_PASSWORD: issue #191/S3 -- auths the webhook ingestion queue (Redis
-# Streams). apps/api/entrypoint.sh builds REDIS_URL from this at container start
-# (same pattern as DB_USER/DB_PASSWORD/DB_NAME -> DATABASE_URL below). No safe
-# default: without it the redis service won't start (--requirepass) and the
-# webhook receiver has no queue to reach. Generate with: openssl rand -hex 32
+# Streams). apps/api/entrypoint.sh and apps/worker/entrypoint.sh (issue #191/S4 --
+# the event consumer reading that queue) both build REDIS_URL from this at container
+# start (same pattern as DB_USER/DB_PASSWORD/DB_NAME -> DATABASE_URL below). No safe
+# default: without it the redis service won't start (--requirepass) and neither the
+# webhook receiver nor the worker's consumer has a queue to reach. Generate with:
+# openssl rand -hex 32
 REDIS_PASSWORD=
 
 # ── DEPLOY-TIME CONFIG (optional, safe defaults in code) ──────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,4 +321,5 @@ jobs:
           docker run --rm --entrypoint python \
             -e DATABASE_URL=postgresql://smoke:smoke@localhost:5432/smoke \
             -e JOB_SECRET_KEY=ci-smoke-test-key-not-for-production-use-000 \
+            -e REDIS_URL=redis://smoke:6379/0 \
             clevis-worker -c "import worker"

--- a/apps/api/alembic/versions/0036_add_repo_events.py
+++ b/apps/api/alembic/versions/0036_add_repo_events.py
@@ -1,0 +1,138 @@
+"""Add repo_events table + clevis_worker grants (issue #191, S4 PR 1 of N).
+
+Normalized, deduplicated event store consumed by the API (S6, not this PR) instead of
+polling GitHub live. Populated by apps/worker's new Redis Streams consumer
+(src/event_consumer.py), which reads webhook_events, normalizes each entry, and
+INSERTs here with `ON CONFLICT (delivery_id) DO NOTHING` -- delivery_id is the actual
+idempotency key (GitHub redelivers the same X-GitHub-Delivery on retry; webhook_deliveries
+deliberately does not dedupe, per its own docstring, leaving that to this table).
+
+tenant_id is NOT NULL by design: the consumer skips normalizing any webhook_deliveries
+row whose tenant_id is null (an unresolved installation) rather than write a row here
+with no tenant to scope it to -- a deliberate scope decision (see S4 PR 1's plan notes),
+not an oversight. That keeps this table's RLS policy in the simpler "Group A" (strict
+equality) shape from migration 0030, no OR-NULL clause needed.
+
+RLS is ENABLE-only, no FORCE -- same reasoning as migration 0030: the migrating
+(table-owning) role is unaffected either way, and this only starts enforcing for a
+non-owner role (clevis_api, once it reads this table in a future S6 PR) once that role
+is actually granted access to it, which isn't happening in this migration.
+
+clevis_worker (issue #190 step 1) is granted SELECT+INSERT on repo_events (it inserts,
+never updates/deletes a normalized row) and SELECT+UPDATE on webhook_deliveries (it
+already had no grant there at all -- needs SELECT to read the payload and UPDATE to
+flip status to 'processed' once normalized). Both grants are guarded by
+`IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_worker')`, matching migration
+0020's pattern exactly, and are a no-op on any deployment that hasn't opted into
+WORKER_DB_PASSWORD (the default -- worker keeps sharing the API's role, unaffected).
+
+clevis_api is also granted SELECT+INSERT on repo_events and (already had SELECT/UPDATE
+via webhook_deliveries's existing full-CRUD grant, see migration 0032/the
+existing-deployment script) -- not because the API writes either table in this PR, but
+because CI's "Run Python tests" step runs the *entire* `pytest -q` suite, apps/worker's
+tests included, under DATABASE_URL=clevis_api (there's no clevis_worker CI provisioning
+at all -- production's worker process itself uses clevis_worker, or the shared
+superuser role by default, never clevis_api). Without this, the consumer's own tests
+would fail in CI with the exact InsufficientPrivilege class of bug migration 0035/#337
+already hit once. Same `IF EXISTS` guard as migration 0032's own clevis_api grants.
+
+The consumer satisfies this table's RLS WITH CHECK by issuing `SET app.tenant_id = <n>`
+per event before each insert (mirroring src/core/rbac.py's set_tenant_session_context),
+not by granting clevis_worker BYPASSRLS -- a narrower, explicit mechanism, consistent
+with migration 0035's SECURITY DEFINER function preferring the same over a blanket
+role-wide bypass.
+
+Upgrade is purely additive (one new table, two conditional grants) -- zero data-loss
+risk. Downgrade drops the table; safe since nothing reads it yet (S6 hasn't shipped).
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-08-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+_TENANT_FILTER = "tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::int"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "repo_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("delivery_id", sa.String(), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("actor", sa.String(), nullable=False),
+        sa.Column("actor_avatar", sa.String(), nullable=False),
+        sa.Column("repo", sa.String(), nullable=False),
+        sa.Column("summary", sa.String(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_repo_events_tenant_id", "repo_events", ["tenant_id"])
+    op.create_unique_constraint("uq_repo_events_delivery_id", "repo_events", ["delivery_id"])
+
+    op.execute(sa.text("ALTER TABLE repo_events ENABLE ROW LEVEL SECURITY"))
+    op.execute(sa.text(f"CREATE POLICY tenant_isolation ON repo_events USING ({_TENANT_FILTER}) WITH CHECK ({_TENANT_FILTER})"))
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_worker') THEN
+                GRANT SELECT, INSERT ON repo_events TO clevis_worker;
+                GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker;
+                GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT SELECT, INSERT ON repo_events TO clevis_api;
+                GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_worker') THEN
+                REVOKE SELECT, INSERT ON repo_events FROM clevis_worker;
+                REVOKE USAGE, SELECT ON repo_events_id_seq FROM clevis_worker;
+                REVOKE SELECT, UPDATE ON webhook_deliveries FROM clevis_worker;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                REVOKE SELECT, INSERT ON repo_events FROM clevis_api;
+                REVOKE USAGE, SELECT ON repo_events_id_seq FROM clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(sa.text("DROP POLICY IF EXISTS tenant_isolation ON repo_events"))
+    op.drop_table("repo_events")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -141,6 +141,37 @@ class WebhookDelivery(Base):
     received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+class RepoEvent(Base):
+    """Normalized, deduplicated event store (issue #191/S4 PR 1), populated by
+    apps/worker's Redis Streams consumer from webhook_deliveries rows. Not read by the
+    API yet -- that's S6's job. RLS-enabled (migration 0036), strict tenant_id equality
+    (no OR-NULL group): the consumer deliberately skips normalizing any
+    webhook_deliveries row with a null tenant_id rather than write one here, so this
+    table never has a null tenant_id row to begin with."""
+
+    __tablename__ = "repo_events"
+    __table_args__ = (
+        Index("ix_repo_events_tenant_id", "tenant_id"),
+        UniqueConstraint("delivery_id", name="uq_repo_events_delivery_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
+    # X-GitHub-Delivery -- the actual idempotency key; ON CONFLICT DO NOTHING on this
+    # column is what makes normalization safe to run twice on a redelivered event.
+    delivery_id: Mapped[str] = mapped_column(String, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    actor: Mapped[str] = mapped_column(String, nullable=False)
+    actor_avatar: Mapped[str] = mapped_column(String, nullable=False)
+    repo: Mapped[str] = mapped_column(String, nullable=False)
+    summary: Mapped[str] = mapped_column(String, nullable=False)
+    # The event's own timestamp where the raw payload has one; falls back to the
+    # webhook_deliveries row's received_at otherwise (see event_consumer.py) -- not
+    # every ingested event type has one canonical top-level timestamp field.
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class SavedToken(Base):
     __tablename__ = "saved_tokens"
 

--- a/apps/worker/entrypoint.sh
+++ b/apps/worker/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-if [ -z "$DB_NAME" ] || [ -z "$JOB_SECRET_KEY" ]; then
-  echo "ERROR: DB_NAME and JOB_SECRET_KEY must be set" >&2
+if [ -z "$DB_NAME" ] || [ -z "$JOB_SECRET_KEY" ] || [ -z "$REDIS_PASSWORD" ]; then
+  echo "ERROR: DB_NAME, JOB_SECRET_KEY, and REDIS_PASSWORD must be set" >&2
   exit 1
 fi
 
@@ -14,6 +14,11 @@ _urlenc() {
 }
 
 _db_name_enc=$(_urlenc "$DB_NAME")
+
+# issue #191/S4: webhook_events Redis Stream consumer (src/event_consumer.py). Built
+# here rather than left as a directly-set REDIS_URL, same reasoning as
+# apps/api/entrypoint.sh's REDIS_URL export -- the raw password only needs setting once.
+export REDIS_URL="redis://:$(_urlenc "$REDIS_PASSWORD")@redis:6379/0"
 
 # Prefer a dedicated worker DB role (issue #190) over the credential shared with the
 # API -- see docker/postgres-init/01-create-worker-role.sh for how it's provisioned.

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -3,3 +3,4 @@ pydantic==2.11.9
 pydantic-settings==2.14.2
 psycopg[binary]==3.2.9
 cryptography==48.0.1
+redis==5.2.1

--- a/apps/worker/src/config.py
+++ b/apps/worker/src/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     database_url: SecretStr
     job_secret_key: SecretStr
     github_api_base: str = "https://api.github.com"
+    # issue #191/S4 -- webhook_events Redis Stream consumer (event_consumer.py). Mirrors
+    # apps/api/src/core/config.py's redis_url exactly (same SecretStr reasoning: a
+    # production URL may embed AUTH credentials).
+    redis_url: SecretStr
 
     model_config = SettingsConfigDict(env_file=_env_file, extra="ignore")
 

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -231,8 +231,11 @@ def _sweep_pending(pg_conn: psycopg.Connection, redis_client: redis.Redis) -> No
     if not pending:
         return
 
-    to_drop = [p["message_id"] for p in pending if p["times_delivered"] > _MAX_DELIVERY_ATTEMPTS]
-    to_claim = [p["message_id"] for p in pending if p["times_delivered"] <= _MAX_DELIVERY_ATTEMPTS]
+    # >= / < , not > / <=: XCLAIM itself increments times_delivered before this entry is
+    # even processed, so an entry already at the limit would otherwise get a (limit + 1)th
+    # attempt instead of being dropped (CodeRabbit finding on PR #340).
+    to_drop = [p["message_id"] for p in pending if p["times_delivered"] >= _MAX_DELIVERY_ATTEMPTS]
+    to_claim = [p["message_id"] for p in pending if p["times_delivered"] < _MAX_DELIVERY_ATTEMPTS]
 
     for message_id in to_drop:
         log.error("stream entry %s exceeded %d delivery attempts, dropping", message_id, _MAX_DELIVERY_ATTEMPTS)
@@ -249,8 +252,20 @@ def _sweep_pending(pg_conn: psycopg.Connection, redis_client: redis.Redis) -> No
 
 
 def run() -> None:
-    redis_client = _redis_client()
-    _ensure_group(redis_client)
+    # Retried, not just attempted once: this runs on its own daemon thread (see
+    # start_background_thread) with nothing else supervising it -- an uncaught
+    # exception here (e.g. Redis not reachable yet at container startup) would
+    # otherwise kill the thread silently and leave the consumer dead until the whole
+    # worker process restarts (CodeRabbit finding on PR #340).
+    redis_client = None
+    while redis_client is None:
+        try:
+            redis_client = _redis_client()
+            _ensure_group(redis_client)
+        except (redis.RedisError, OSError) as error:
+            log.error("event consumer initialization error: %s", type(error).__name__)
+            redis_client = None
+            time.sleep(5)
     log.info("event consumer started, group=%s consumer=%s", _GROUP_NAME, _CONSUMER_NAME)
 
     while True:

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -1,0 +1,286 @@
+"""Redis Streams consumer for webhook_events (issue #191, S4 PR 1 of N).
+
+Normalizes each queued webhook delivery into the repo_events table, deduplicated by
+delivery_id. Runs as a second daemon thread in worker.py's run(), alongside the
+existing jobs-table poll loop -- not a separate process, so it shares the container's
+healthcheck/deploy story.
+
+Consumer-group semantics (XREADGROUP, group "event_processors") rather than a bare
+XREAD: today's docker-compose runs exactly one worker replica, but a bare XREAD has no
+way to resume after a restart without either replaying the whole stream or tracking a
+cursor somewhere else -- a consumer group's last-delivered-id and pending-entries-list
+already live in Redis and survive a consumer restart for free, and the same mechanism
+is what lets a second replica join safely whenever the worker is actually scaled (the
+issue's own "autoscaled consumers" framing). XPENDING + XCLAIM cover the case where a
+consumer dies mid-processing (mirrors worker.py's _reclaim_stale_jobs for the jobs
+table); a poison-pill entry that fails past _MAX_DELIVERY_ATTEMPTS is XACKed (dropped
+from the group) rather than reclaimed forever -- nothing is actually lost, since
+webhook_deliveries keeps the raw payload permanently for manual inspection/reprocessing.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import psycopg
+import redis
+
+from config import settings
+
+log = logging.getLogger(__name__)
+
+_DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+
+# Must match apps/api/src/routers/webhooks.py's _WEBHOOK_STREAM_KEY -- the two services
+# don't share code (independently deployable per AGENTS.md), so this is a duplicated
+# constant, not an import; keep them in sync by hand if either ever changes.
+_STREAM_KEY = "webhook_events"
+_GROUP_NAME = "event_processors"
+_CONSUMER_NAME = f"worker-{os.getpid()}"
+
+# How long a claimed-but-unacked entry sits idle before another pass reclaims it --
+# comfortably longer than any single event's normalize+insert should ever take.
+_RECLAIM_IDLE_MS = 60_000
+# Shares the jobs table's MAX_RETRIES posture (worker.py): a repeatedly-failing entry
+# is dropped, not retried forever, since retrying can't fix a genuinely malformed
+# payload and a stuck poison pill would otherwise block reclaim of everything behind it.
+_MAX_DELIVERY_ATTEMPTS = 5
+# Blocks up to this long per XREADGROUP call so the loop still wakes regularly to touch
+# the heartbeat file and pick up a poison-pill sweep, even with no new stream entries.
+_BLOCK_MS = 5_000
+_BATCH_SIZE = 10
+
+# Separate heartbeat file from worker.py's HEARTBEAT_FILE -- both threads touch their
+# own file every loop iteration; the docker-compose healthcheck only reads worker.py's
+# HEARTBEAT_FILE today (v1: a hung consumer thread doesn't fail the container
+# healthcheck on its own, same gap as any other purely-Python-level hang would have
+# without a dedicated liveness probe for this specific thread -- flagged, not solved
+# here, since the jobs-table loop staying healthy is still useful signal on its own).
+_HEARTBEAT_FILE = Path("/tmp/worker_event_consumer_heartbeat")
+
+_client: redis.Redis | None = None
+
+
+def _redis_client() -> redis.Redis:
+    global _client
+    if _client is None:
+        _client = redis.Redis.from_url(
+            settings.redis_url.get_secret_value(),
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+    return _client
+
+
+def _touch_heartbeat() -> None:
+    try:
+        _HEARTBEAT_FILE.write_text(str(time.time()))
+    except OSError as exc:
+        log.warning("could not write event consumer heartbeat file %s: %s", _HEARTBEAT_FILE, exc)
+
+
+def _ensure_group(client: redis.Redis) -> None:
+    try:
+        client.xgroup_create(_STREAM_KEY, _GROUP_NAME, id="0", mkstream=True)
+    except redis.ResponseError as error:
+        if "BUSYGROUP" not in str(error):
+            raise
+
+
+def _summarize(event_type: str, payload: dict) -> str:
+    """Per-event-type summary text. Mirrors apps/api/src/routers/github.py's
+    _summarize, adapted to the raw webhook body's shape (the top-level fields of a
+    GitHub webhook payload for these five event types are the same shape as the
+    Events API's nested `payload` object _summarize already handles -- e.g. a webhook
+    pull_request event's top-level `action`/`number`/`pull_request` match
+    payload.action/payload.number/payload.pull_request there) rather than a live
+    GitHub Events-API response, since this consumer only ever sees the raw webhook
+    body stored in webhook_deliveries.payload."""
+    if event_type == "push":
+        commits = payload.get("commits") or []
+        count = len(commits)
+        branch = (payload.get("ref") or "").removeprefix("refs/heads/")
+        noun = "commit" if count == 1 else "commits"
+        return f"pushed {count} {noun} to {branch}" if branch else f"pushed {count} {noun}"
+
+    if event_type == "pull_request":
+        pr = payload.get("pull_request") or {}
+        action = payload.get("action", "")
+        verb = "merged" if action == "closed" and pr.get("merged") else action
+        return f"{verb} PR #{payload.get('number')}: {pr.get('title', '')}"
+
+    if event_type == "issues":
+        issue = payload.get("issue") or {}
+        action = payload.get("action", "")
+        return f"{action} issue #{issue.get('number')}: {issue.get('title', '')}"
+
+    if event_type == "release":
+        release = payload.get("release") or {}
+        return f"created release {release.get('tag_name', '')}"
+
+    if event_type == "create":
+        ref_type = payload.get("ref_type", "")
+        ref = payload.get("ref") or ""
+        return f"created {ref_type} {ref}".strip()
+
+    return event_type
+
+
+def _normalize(event_type: str, payload: dict, received_at: datetime) -> dict | None:
+    """Returns the repo_events column values for this webhook payload, or None if it
+    can't be normalized (missing repository/sender -- shouldn't happen for a real
+    GitHub delivery, but the receiver doesn't validate payload shape beyond JSON-ness,
+    so defend against a malformed/test payload rather than crash the consumer loop)."""
+    repository = payload.get("repository") or {}
+    sender = payload.get("sender") or {}
+    repo_full_name = repository.get("full_name")
+    if not repo_full_name:
+        return None
+    return {
+        "event_type": event_type,
+        "actor": sender.get("login", ""),
+        "actor_avatar": sender.get("avatar_url", ""),
+        "repo": repo_full_name,
+        "summary": _summarize(event_type, payload),
+        # No single canonical top-level timestamp exists across all five webhook payload
+        # shapes (e.g. push has no top-level timestamp at all) -- fall back to
+        # webhook_deliveries.received_at, the ingestion time, rather than parse a
+        # different nested field per event type for a v1 that isn't read by any UI yet.
+        "occurred_at": received_at,
+    }
+
+
+def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry_id: str, fields: dict) -> None:
+    delivery_row_id = fields.get("delivery_row_id")
+    if delivery_row_id is None:
+        log.error("stream entry %s missing delivery_row_id, dropping: %r", entry_id, fields)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+        return
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT tenant_id, delivery_id, event_type, payload, received_at FROM webhook_deliveries WHERE id = %s",
+            (delivery_row_id,),
+        )
+        row = cur.fetchone()
+
+    if row is None:
+        log.error("webhook_deliveries row %s referenced by stream entry %s not found, dropping", delivery_row_id, entry_id)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+        return
+
+    tenant_id, delivery_id, event_type, payload_bytes, received_at = row
+    if tenant_id is None:
+        # Deliberate scope decision (see S4 PR 1's plan notes): an unresolved
+        # installation has no tenant to scope a normalized row to. Ack so this entry
+        # doesn't sit pending forever; the raw payload stays in webhook_deliveries.
+        log.warning("webhook_deliveries row %s has no tenant_id, skipping normalization", delivery_row_id)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+        return
+
+    try:
+        payload = json.loads(payload_bytes)
+    except json.JSONDecodeError:
+        log.error("webhook_deliveries row %s has malformed JSON payload, dropping", delivery_row_id)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+        return
+
+    normalized = _normalize(event_type, payload, received_at)
+    if normalized is None:
+        log.error("webhook_deliveries row %s has no repository.full_name, dropping", delivery_row_id)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+        return
+
+    with pg_conn.cursor() as cur:
+        # Mirrors src.core.rbac.set_tenant_session_context: a plain SET (not SET
+        # LOCAL) read by this table's RLS policy (migration 0036), scoped to this
+        # connection for the duration of the INSERT that follows -- a narrower,
+        # explicit mechanism than granting clevis_worker BYPASSRLS, same precedent as
+        # migration 0035's SECURITY DEFINER function.
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute(
+            """
+            INSERT INTO repo_events
+                (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at)
+            VALUES (%(tenant_id)s, %(delivery_id)s, %(event_type)s, %(actor)s, %(actor_avatar)s,
+                    %(repo)s, %(summary)s, %(occurred_at)s)
+            ON CONFLICT (delivery_id) DO NOTHING
+            """,
+            {
+                "tenant_id": tenant_id,
+                "delivery_id": delivery_id,
+                **normalized,
+            },
+        )
+        cur.execute("UPDATE webhook_deliveries SET status = 'processed' WHERE id = %s", (delivery_row_id,))
+    pg_conn.commit()
+    redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
+
+
+def _sweep_pending(pg_conn: psycopg.Connection, redis_client: redis.Redis) -> None:
+    """Reclaims entries idle longer than _RECLAIM_IDLE_MS (a prior consumer likely
+    crashed mid-processing), or drops ones that have failed too many times."""
+    pending = redis_client.xpending_range(
+        _STREAM_KEY, _GROUP_NAME, min="-", max="+", count=100, idle=_RECLAIM_IDLE_MS
+    )
+    if not pending:
+        return
+
+    to_drop = [p["message_id"] for p in pending if p["times_delivered"] > _MAX_DELIVERY_ATTEMPTS]
+    to_claim = [p["message_id"] for p in pending if p["times_delivered"] <= _MAX_DELIVERY_ATTEMPTS]
+
+    for message_id in to_drop:
+        log.error("stream entry %s exceeded %d delivery attempts, dropping", message_id, _MAX_DELIVERY_ATTEMPTS)
+        redis_client.xack(_STREAM_KEY, _GROUP_NAME, message_id)
+
+    if not to_claim:
+        return
+    claimed = redis_client.xclaim(_STREAM_KEY, _GROUP_NAME, _CONSUMER_NAME, min_idle_time=_RECLAIM_IDLE_MS, message_ids=to_claim)
+    for entry_id, fields in claimed:
+        try:
+            _process_entry(pg_conn, redis_client, entry_id, fields)
+        except Exception:
+            log.exception("failed to process reclaimed stream entry %s", entry_id)
+
+
+def run() -> None:
+    redis_client = _redis_client()
+    _ensure_group(redis_client)
+    log.info("event consumer started, group=%s consumer=%s", _GROUP_NAME, _CONSUMER_NAME)
+
+    while True:
+        _touch_heartbeat()
+        try:
+            with psycopg.connect(_DB_URL) as pg_conn:
+                _sweep_pending(pg_conn, redis_client)
+
+                response = redis_client.xreadgroup(
+                    _GROUP_NAME, _CONSUMER_NAME, {_STREAM_KEY: ">"}, count=_BATCH_SIZE, block=_BLOCK_MS
+                )
+                for _stream_key, entries in response or []:
+                    for entry_id, fields in entries:
+                        try:
+                            _process_entry(pg_conn, redis_client, entry_id, fields)
+                        except Exception:
+                            # Left unacked on purpose -- _sweep_pending reclaims it next
+                            # pass once _RECLAIM_IDLE_MS has elapsed, same "one bad
+                            # entry doesn't take down the loop" posture as
+                            # worker.py's process_job.
+                            log.exception("failed to process stream entry %s", entry_id)
+        except (psycopg.OperationalError, redis.RedisError) as error:
+            log.error("event consumer connection error: %s", type(error).__name__)
+            time.sleep(5)
+        except Exception as error:
+            log.error("event consumer loop error: %s", type(error).__name__)
+            time.sleep(5)
+
+
+def start_background_thread() -> threading.Thread:
+    thread = threading.Thread(target=run, daemon=True, name="event-consumer")
+    thread.start()
+    return thread

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -356,4 +356,12 @@ def run() -> None:
 
 
 if __name__ == "__main__":
+    import event_consumer
+
+    # Runs on its own daemon thread, independent of this module's jobs-table poll loop
+    # below -- see event_consumer.py's module docstring for why (Redis Streams consumer
+    # group, issue #191/S4 PR 1). A crash inside it is caught and logged by its own
+    # run() loop and doesn't take down the process; it does not currently fail the
+    # container healthcheck on its own (see event_consumer.py's _HEARTBEAT_FILE note).
+    event_consumer.start_background_thread()
     run()

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -1,9 +1,11 @@
 """Tests for the webhook_events Redis Streams consumer (issue #191/S4 PR 1)."""
 
 import json
+from unittest.mock import MagicMock
 
 import psycopg
 import pytest
+import redis
 
 import event_consumer
 from config import settings
@@ -267,3 +269,184 @@ def test_full_loop_reads_from_redis_and_reclaims_a_crashed_consumers_entry(pg_co
         cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
         cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-e2e-1",))
         assert cur.fetchone()[0] == 1
+
+
+def test_summarize_unknown_event_type_returns_the_event_type_itself():
+    assert event_consumer._summarize("deployment", {}) == "deployment"
+
+
+def test_normalize_returns_none_when_repository_full_name_is_missing():
+    assert event_consumer._normalize("push", {"sender": {"login": "octocat"}}, None) is None
+
+
+def test_process_entry_drops_malformed_json_payload(pg_conn, tenant_id):
+    conn, state = pg_conn
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status)
+            VALUES (%s, 'd-malformed-1', 'push', %s, 'queued')
+            RETURNING id
+            """,
+            (tenant_id, b"not json"),
+        )
+        row_id = cur.fetchone()[0]
+    conn.commit()
+    state["delivery_ids"].append(row_id)
+
+    redis_client = _FakeRedis()
+    event_consumer._process_entry(conn, redis_client, "1-0", _entry_fields(row_id, "push", tenant_id))
+
+    assert len(redis_client.acked) == 1
+    with conn.cursor() as cur:
+        cur.execute("SELECT status FROM webhook_deliveries WHERE id = %s", (row_id,))
+        assert cur.fetchone()[0] == "queued"
+
+
+def test_process_entry_drops_payload_missing_repository(pg_conn, tenant_id):
+    conn, state = pg_conn
+    row_id = _make_delivery(
+        conn, state, tenant_id=tenant_id, delivery_id="d-no-repo-1", event_type="push",
+        payload={"sender": {"login": "octocat"}},
+    )
+
+    redis_client = _FakeRedis()
+    event_consumer._process_entry(conn, redis_client, "1-0", _entry_fields(row_id, "push", tenant_id))
+
+    assert len(redis_client.acked) == 1
+    with conn.cursor() as cur:
+        cur.execute("SELECT status FROM webhook_deliveries WHERE id = %s", (row_id,))
+        assert cur.fetchone()[0] == "queued"
+
+
+def test_ensure_group_is_idempotent_when_group_already_exists(redis_client):
+    event_consumer._ensure_group(redis_client)
+    event_consumer._ensure_group(redis_client)  # BUSYGROUP the second time -- must not raise
+
+
+def test_ensure_group_reraises_non_busygroup_errors(monkeypatch):
+    fake = MagicMock()
+    fake.xgroup_create.side_effect = redis.ResponseError("some other error")
+    with pytest.raises(redis.ResponseError):
+        event_consumer._ensure_group(fake)
+
+
+def test_touch_heartbeat_writes_the_file():
+    event_consumer._touch_heartbeat()
+    assert event_consumer._HEARTBEAT_FILE.exists()
+
+
+def test_touch_heartbeat_swallows_oserror(monkeypatch):
+    monkeypatch.setattr(
+        event_consumer._HEARTBEAT_FILE.__class__, "write_text", MagicMock(side_effect=OSError("disk full"))
+    )
+    event_consumer._touch_heartbeat()  # must not raise
+
+
+def test_sweep_pending_with_nothing_pending_is_a_noop(pg_conn, redis_client):
+    conn, _state = pg_conn
+    event_consumer._ensure_group(redis_client)
+    event_consumer._sweep_pending(conn, redis_client)  # no pending entries -- returns early
+
+
+def test_sweep_pending_drops_entries_past_max_delivery_attempts(pg_conn, tenant_id, redis_client):
+    conn, state = pg_conn
+    payload = {"repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v3"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-poison-1", event_type="create", payload=payload)
+
+    event_consumer._ensure_group(redis_client)
+    entry_id = redis_client.xadd(event_consumer._STREAM_KEY, _entry_fields(row_id, "create", tenant_id))
+    redis_client.xreadgroup(event_consumer._GROUP_NAME, "c1", {event_consumer._STREAM_KEY: ">"}, count=10)
+    # xclaim increments the delivery counter each call -- push it past _MAX_DELIVERY_ATTEMPTS.
+    for _ in range(event_consumer._MAX_DELIVERY_ATTEMPTS + 1):
+        redis_client.xclaim(event_consumer._STREAM_KEY, event_consumer._GROUP_NAME, "c1", min_idle_time=0, message_ids=[entry_id])
+
+    # _sweep_pending only considers entries idle at least _RECLAIM_IDLE_MS -- these were
+    # just claimed, so drop it to 0 for this test rather than sleep for real.
+    original_idle = event_consumer._RECLAIM_IDLE_MS
+    event_consumer._RECLAIM_IDLE_MS = 0
+    try:
+        event_consumer._sweep_pending(conn, redis_client)
+    finally:
+        event_consumer._RECLAIM_IDLE_MS = original_idle
+
+    pending = redis_client.xpending_range(event_consumer._STREAM_KEY, event_consumer._GROUP_NAME, min="-", max="+", count=10)
+    assert pending == []  # dropped (acked), not reclaimed/reprocessed
+    with conn.cursor() as cur:
+        cur.execute("SELECT status FROM webhook_deliveries WHERE id = %s", (row_id,))
+        assert cur.fetchone()[0] == "queued"  # never actually processed
+
+
+def test_sweep_pending_logs_and_continues_when_claimed_entry_processing_raises(pg_conn, tenant_id, redis_client, monkeypatch):
+    conn, state = pg_conn
+    payload = {"repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v4"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-raises-1", event_type="create", payload=payload)
+
+    event_consumer._ensure_group(redis_client)
+    redis_client.xadd(event_consumer._STREAM_KEY, _entry_fields(row_id, "create", tenant_id))
+    redis_client.xreadgroup(event_consumer._GROUP_NAME, "dead-consumer", {event_consumer._STREAM_KEY: ">"}, count=10)
+
+    monkeypatch.setattr(event_consumer, "_process_entry", MagicMock(side_effect=RuntimeError("boom")))
+    original_idle = event_consumer._RECLAIM_IDLE_MS
+    event_consumer._RECLAIM_IDLE_MS = 0
+    try:
+        event_consumer._sweep_pending(conn, redis_client)  # must not raise
+    finally:
+        event_consumer._RECLAIM_IDLE_MS = original_idle
+
+
+class _StopLoop(Exception):
+    pass
+
+
+def test_run_processes_a_stream_entry_then_stops(pg_conn, tenant_id, redis_client, monkeypatch):
+    conn, state = pg_conn
+    payload = {"repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v5"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-run-loop-1", event_type="create", payload=payload)
+
+    event_consumer._ensure_group(redis_client)
+    redis_client.xadd(event_consumer._STREAM_KEY, _entry_fields(row_id, "create", tenant_id))
+
+    monkeypatch.setattr(event_consumer, "_redis_client", lambda: redis_client)
+    monkeypatch.setattr(event_consumer, "_BLOCK_MS", 100)
+    # _touch_heartbeat is called first thing every loop iteration -- no-op on the first
+    # call (let the iteration actually run), raise on the second so run()'s `while True`
+    # stops after processing exactly one batch.
+    monkeypatch.setattr(event_consumer, "_touch_heartbeat", MagicMock(side_effect=[None, _StopLoop]))
+
+    with pytest.raises(_StopLoop):
+        event_consumer.run()
+
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-run-loop-1",))
+        assert cur.fetchone()[0] == 1
+
+
+def test_run_recovers_from_a_connection_error(monkeypatch):
+    # psycopg.connect raising is caught *inside* run()'s own try/except (by design --
+    # it must never let a connection blip kill the loop), so a sentinel raised there
+    # would just be swallowed by that same except, not reach this test. Use the
+    # _touch_heartbeat hook (called once per iteration, outside the try) to stop the
+    # loop instead, and assert connect() was retried across iterations.
+    monkeypatch.setattr(event_consumer, "_redis_client", lambda: MagicMock())
+    monkeypatch.setattr(event_consumer, "_ensure_group", MagicMock())
+    monkeypatch.setattr(event_consumer.psycopg, "connect", MagicMock(side_effect=psycopg.OperationalError("refused")))
+    monkeypatch.setattr(event_consumer.time, "sleep", MagicMock())
+    monkeypatch.setattr(event_consumer, "_touch_heartbeat", MagicMock(side_effect=[None, None, _StopLoop]))
+
+    with pytest.raises(_StopLoop):
+        event_consumer.run()
+
+    assert event_consumer.psycopg.connect.call_count == 2  # retried instead of crashing after the first failure
+
+
+def test_start_background_thread_runs_in_the_background(monkeypatch):
+    ran = []
+    monkeypatch.setattr(event_consumer, "run", lambda: ran.append(True))
+
+    thread = event_consumer.start_background_thread()
+    thread.join(timeout=2)
+
+    assert ran == [True]
+    assert not thread.is_alive()

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -441,6 +441,29 @@ def test_run_recovers_from_a_connection_error(monkeypatch):
     assert event_consumer.psycopg.connect.call_count == 2  # retried instead of crashing after the first failure
 
 
+def test_run_retries_initialization_instead_of_dying_on_a_startup_redis_error(monkeypatch):
+    # A Redis error constructing the client or creating the consumer group used to be
+    # completely uncaught -- run() would raise straight out, silently killing the
+    # daemon thread it's started on forever (CodeRabbit finding on PR #340).
+    attempts = {"n": 0}
+
+    def _flaky_redis_client():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise redis.ConnectionError("not ready yet")
+        return MagicMock()
+
+    monkeypatch.setattr(event_consumer, "_redis_client", _flaky_redis_client)
+    monkeypatch.setattr(event_consumer, "_ensure_group", MagicMock())
+    monkeypatch.setattr(event_consumer.time, "sleep", MagicMock())
+    monkeypatch.setattr(event_consumer, "_touch_heartbeat", MagicMock(side_effect=_StopLoop))
+
+    with pytest.raises(_StopLoop):
+        event_consumer.run()
+
+    assert attempts["n"] == 2  # retried after the first failure instead of raising out of run()
+
+
 def test_start_background_thread_runs_in_the_background(monkeypatch):
     ran = []
     monkeypatch.setattr(event_consumer, "run", lambda: ran.append(True))

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -1,0 +1,269 @@
+"""Tests for the webhook_events Redis Streams consumer (issue #191/S4 PR 1)."""
+
+import json
+
+import psycopg
+import pytest
+
+import event_consumer
+from config import settings
+
+_DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+
+
+@pytest.fixture()
+def pg_conn():
+    conn = psycopg.connect(_DB_URL, autocommit=False)
+    # Only webhook_deliveries rows get cleaned up: clevis_api/clevis_worker are
+    # deliberately not granted DELETE on repo_events (migration 0036 -- the consumer
+    # only ever inserts a normalized row, never updates/deletes one), so a test
+    # connection running as either role can't clean those up even if it wanted to.
+    # Deleting the shared test tenant/user (see the tenant_id fixture below) would
+    # also fail on repo_events's tenant_id FK for the same reason -- so that tenant is
+    # never deleted either, just reused across runs. Harmless: every test here uses a
+    # delivery_id unique to itself, and CI's Postgres service container is ephemeral
+    # per run, so nothing accumulates across CI runs -- only repeated local runs
+    # against a persistent dev volume leave a few small rows behind.
+    state = {"delivery_ids": []}
+    try:
+        yield conn, state
+    finally:
+        # A failed assertion inside a `with conn.cursor()` block can leave the
+        # connection's transaction aborted (INERROR) -- rollback first so the cleanup
+        # DELETE below doesn't itself silently no-op on an already-broken transaction.
+        conn.rollback()
+        with conn.cursor() as cur:
+            if state["delivery_ids"]:
+                cur.execute("DELETE FROM webhook_deliveries WHERE id = ANY(%s)", (state["delivery_ids"],))
+        conn.commit()
+        conn.close()
+
+
+@pytest.fixture()
+def tenant_id(pg_conn):
+    """A single shared tenant reused by every test in this file (find-or-create,
+    never deleted -- see pg_conn's docstring for why)."""
+    conn, _state = pg_conn
+    email = "s4-consumer-tests@example.com"
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM users WHERE lower(email) = lower(%s)", (email,))
+        row = cur.fetchone()
+        if row:
+            user_id = row[0]
+        else:
+            cur.execute("INSERT INTO users (email) VALUES (%s) RETURNING id", (email,))
+            user_id = cur.fetchone()[0]
+        cur.execute("SELECT id FROM tenants WHERE personal_user_id = %s", (user_id,))
+        row = cur.fetchone()
+        if row:
+            result = row[0]
+        else:
+            cur.execute("INSERT INTO tenants (kind, personal_user_id) VALUES ('personal', %s) RETURNING id", (user_id,))
+            result = cur.fetchone()[0]
+    conn.commit()
+    return result
+
+
+@pytest.fixture()
+def redis_client():
+    client = event_consumer._redis_client()
+    client.flushdb()
+    yield client
+    client.flushdb()
+
+
+def _make_delivery(conn, state, *, tenant_id, delivery_id, event_type, payload: dict) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status)
+            VALUES (%s, %s, %s, %s, 'queued')
+            RETURNING id
+            """,
+            (tenant_id, delivery_id, event_type, json.dumps(payload).encode()),
+        )
+        row_id = cur.fetchone()[0]
+    conn.commit()
+    state["delivery_ids"].append(row_id)
+    return row_id
+
+
+def _entry_fields(row_id: int, event_type: str, tenant_id: int) -> dict:
+    return {"delivery_row_id": str(row_id), "event_type": event_type, "tenant_id": str(tenant_id)}
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.acked = []
+
+    def xack(self, *args, **kwargs):
+        self.acked.append(args)
+
+
+def test_normalizes_a_push_event(pg_conn, tenant_id):
+    conn, state = pg_conn
+    row_id = _make_delivery(
+        conn,
+        state,
+        tenant_id=tenant_id,
+        delivery_id="d-push-1",
+        event_type="push",
+        payload={
+            "ref": "refs/heads/main",
+            "commits": [{"id": "abc"}, {"id": "def"}],
+            "repository": {"full_name": "acme/widgets"},
+            "sender": {"login": "octocat", "avatar_url": "https://example.com/a.png"},
+        },
+    )
+
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_id, "push", tenant_id))
+
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute(
+            "SELECT tenant_id, event_type, actor, actor_avatar, repo, summary FROM repo_events WHERE delivery_id = %s",
+            ("d-push-1",),
+        )
+        row = cur.fetchone()
+    assert row == (tenant_id, "push", "octocat", "https://example.com/a.png", "acme/widgets", "pushed 2 commits to main")
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT status FROM webhook_deliveries WHERE id = %s", (row_id,))
+        assert cur.fetchone()[0] == "processed"
+
+
+@pytest.mark.parametrize(
+    "event_type,payload,expected_summary",
+    [
+        (
+            "pull_request",
+            {"action": "opened", "number": 7, "pull_request": {"title": "Add widgets", "merged": False}},
+            "opened PR #7: Add widgets",
+        ),
+        (
+            "pull_request",
+            {"action": "closed", "number": 7, "pull_request": {"title": "Add widgets", "merged": True}},
+            "merged PR #7: Add widgets",
+        ),
+        (
+            "issues",
+            {"action": "opened", "issue": {"number": 3, "title": "Bug"}},
+            "opened issue #3: Bug",
+        ),
+        (
+            "release",
+            {"release": {"tag_name": "v1.2.3"}},
+            "created release v1.2.3",
+        ),
+        (
+            "create",
+            {"ref_type": "branch", "ref": "feature-x"},
+            "created branch feature-x",
+        ),
+    ],
+)
+def test_normalizes_each_ingested_event_type(pg_conn, tenant_id, event_type, payload, expected_summary):
+    conn, state = pg_conn
+    # Two pull_request cases share event_type ("opened" vs "closed"/merged) -- a
+    # payload-derived suffix keeps every case's delivery_id unique regardless of how
+    # many share the same event_type.
+    delivery_id = f"d-{event_type}-{abs(hash(expected_summary))}"
+    payload = {**payload, "repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id=delivery_id, event_type=event_type, payload=payload)
+
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_id, event_type, tenant_id))
+
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute("SELECT summary FROM repo_events WHERE delivery_id = %s", (delivery_id,))
+        assert cur.fetchone()[0] == expected_summary
+
+
+def test_processing_the_same_delivery_twice_is_idempotent(pg_conn, tenant_id):
+    conn, state = pg_conn
+    payload = {"repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-dedupe-1", event_type="create", payload=payload)
+
+    fields = _entry_fields(row_id, "create", tenant_id)
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", fields)
+    event_consumer._process_entry(conn, _FakeRedis(), "2-0", fields)  # simulates a redelivery/reprocess
+
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-dedupe-1",))
+        assert cur.fetchone()[0] == 1
+
+
+def test_null_tenant_delivery_is_skipped_not_normalized(pg_conn):
+    conn, state = pg_conn
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status)
+            VALUES (NULL, %s, 'issues', %s, 'queued')
+            RETURNING id
+            """,
+            ("d-no-tenant-1", json.dumps({"repository": {"full_name": "acme/widgets"}}).encode()),
+        )
+        row_id = cur.fetchone()[0]
+    conn.commit()
+    state["delivery_ids"].append(row_id)
+
+    redis_client = _FakeRedis()
+    event_consumer._process_entry(conn, redis_client, "1-0", {"delivery_row_id": str(row_id), "event_type": "issues", "tenant_id": ""})
+
+    assert len(redis_client.acked) == 1  # acked so it doesn't sit pending forever
+    with conn.cursor() as cur:
+        # Asserting absence, not presence -- no row was ever inserted for this
+        # delivery, so the count is 0 regardless of what app.tenant_id (unset here)
+        # would otherwise restrict under RLS.
+        cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-no-tenant-1",))
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT status FROM webhook_deliveries WHERE id = %s", (row_id,))
+        assert cur.fetchone()[0] == "queued"  # left as-is, not marked processed
+
+
+def test_unknown_stream_entry_missing_delivery_row_id_is_dropped_not_crashed(pg_conn):
+    conn, _state = pg_conn
+    redis_client = _FakeRedis()
+
+    event_consumer._process_entry(conn, redis_client, "1-0", {"event_type": "push"})
+
+    assert len(redis_client.acked) == 1
+
+
+def test_stream_entry_referencing_a_missing_webhook_delivery_row_is_dropped(pg_conn):
+    conn, _state = pg_conn
+    redis_client = _FakeRedis()
+
+    event_consumer._process_entry(conn, redis_client, "1-0", {"delivery_row_id": "999999999", "event_type": "push", "tenant_id": ""})
+
+    assert len(redis_client.acked) == 1
+
+
+def test_full_loop_reads_from_redis_and_reclaims_a_crashed_consumers_entry(pg_conn, tenant_id, redis_client):
+    conn, state = pg_conn
+    payload = {"repository": {"full_name": "acme/widgets"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v2"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-e2e-1", event_type="create", payload=payload)
+
+    event_consumer._ensure_group(redis_client)
+    redis_client.xadd(event_consumer._STREAM_KEY, _entry_fields(row_id, "create", tenant_id))
+
+    # Simulate a crashed consumer: read (claims the entry, delivery count -> 1) but
+    # never ack.
+    resp = redis_client.xreadgroup(event_consumer._GROUP_NAME, "dead-consumer", {event_consumer._STREAM_KEY: ">"}, count=10)
+    assert len(resp) == 1
+
+    # _sweep_pending with idle=0 reclaims it immediately (no need to actually wait
+    # _RECLAIM_IDLE_MS in a test) and processes it under this test's own connection.
+    original_idle = event_consumer._RECLAIM_IDLE_MS
+    event_consumer._RECLAIM_IDLE_MS = 0
+    try:
+        event_consumer._sweep_pending(conn, redis_client)
+    finally:
+        event_consumer._RECLAIM_IDLE_MS = original_idle
+
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-e2e-1",))
+        assert cur.fetchone()[0] == 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,8 @@ services:
         condition: service_healthy
       api:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       # worker.py touches HEARTBEAT_FILE once per poll loop iteration -- a hung-but-alive

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -56,6 +56,14 @@ GRANT USAGE ON SCHEMA public TO clevis_api;
 GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
 GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
 
+-- repo_events (migration 0036, issue #191/S4 PR 1): the API doesn't write this table
+-- itself (only apps/worker's consumer does; S6 will add API reads later), but CI runs
+-- the whole pytest suite -- apps/worker's tests included -- under clevis_api (there's
+-- no clevis_worker CI provisioning), so the consumer's own tests need this grant to
+-- pass in CI. Same reasoning as clevis_worker's own grant in migration 0036.
+GRANT SELECT, INSERT ON repo_events TO clevis_api;
+GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_api;
+
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
 -- conditional on clevis_api already existing, which isn't true the first time this

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -60,9 +60,21 @@ GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenant
 -- itself (only apps/worker's consumer does; S6 will add API reads later), but CI runs
 -- the whole pytest suite -- apps/worker's tests included -- under clevis_api (there's
 -- no clevis_worker CI provisioning), so the consumer's own tests need this grant to
--- pass in CI. Same reasoning as clevis_worker's own grant in migration 0036.
-GRANT SELECT, INSERT ON repo_events TO clevis_api;
-GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_api;
+-- pass in CI. Same reasoning as clevis_worker's own grant in migration 0036. Guarded
+-- by existence, unlike the unconditional grants above -- this script isn't only run
+-- once per deployment (its own comment above documents it as safe to re-run for
+-- password rotation too), and a re-run against a deployment that hasn't applied
+-- migration 0036 yet would otherwise fail on "relation does not exist" and roll back
+-- every grant in this transaction, including the ones that were fine (CodeRabbit
+-- finding on PR #340).
+DO $do$
+BEGIN
+  IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'repo_events') THEN
+    GRANT SELECT, INSERT ON repo_events TO clevis_api;
+    GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_api;
+  END IF;
+END
+$do$;
 
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,10 +45,10 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
    # 2. Grant it the table privileges migration 0020 would otherwise apply.
    #    Runs inside the db container so it uses the container's own
    #    POSTGRES_USER/POSTGRES_DB, not unexported host-shell variables.
-   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker;"'
+   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker;"'
    ```
 
-   Don't rely on re-running `alembic upgrade head` for step 2 — if migration `0020` already applied (as a no-op, since the role didn't exist yet), Alembic considers it done and won't re-run it. Restart the `worker` container afterwards to pick up the new credential.
+   Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterwards to pick up the new credential.
 
 6. (Recommended) Give the API its own non-superuser Postgres credential, separate from `DB_USER`/`DB_PASSWORD`: set `API_DB_PASSWORD` in `.env`. Without this, the API connects as `DB_USER` — the `initdb` bootstrap superuser — which unconditionally bypasses Row-Level Security, so tenant isolation is enforced only at the application layer (issue #330). Same fresh-volume-only caveat as the worker's credential above. If you're setting this on an **existing** deployment, run `docker/provision-api-role-existing-deployment.sh` instead of the fresh-volume init script:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -48,7 +48,7 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
    docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker;"'
    ```
 
-   Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterwards to pick up the new credential.
+   Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterward to pick up the new credential.
 
 6. (Recommended) Give the API its own non-superuser Postgres credential, separate from `DB_USER`/`DB_PASSWORD`: set `API_DB_PASSWORD` in `.env`. Without this, the API connects as `DB_USER` — the `initdb` bootstrap superuser — which unconditionally bypasses Row-Level Security, so tenant isolation is enforced only at the application layer (issue #330). Same fresh-volume-only caveat as the worker's credential above. If you're setting this on an **existing** deployment, run `docker/provision-api-role-existing-deployment.sh` instead of the fresh-volume init script:
 


### PR DESCRIPTION
…PR 1)

Schema change included: migration 0036 adds the repo_events table (RLS-enabled, tenant_id NOT NULL, delivery_id UNIQUE for dedupe) plus conditional clevis_worker and clevis_api grants on it and on webhook_deliveries -- see the migration's own docstring for why both roles need it (clevis_worker for real production use, clevis_api because CI's Python Tests step runs the whole suite, apps/worker's tests included, under DATABASE_URL=clevis_api).

Also touches docker-compose.yml (worker now depends_on redis), apps/worker's entrypoint.sh/config.py/requirements.txt (wires REDIS_URL through, mirroring the API's existing pattern), and docker/provision-api-role-existing-deployment.sh / docs/self-hosting.md (existing-deployment grant retrofits for the new table).

Issue #191/S4, scoped down from the full aspirational architecture to the smallest independently-shippable slice: a Redis Streams consumer (apps/worker/src/event_consumer.py) that reads the webhook_events stream (populated by the S3 receiver), normalizes each of the five ingested event types, and inserts into repo_events with ON CONFLICT (delivery_id) DO NOTHING as the actual idempotency mechanism. Uses a consumer group (XREADGROUP) with XPENDING/XCLAIM-based reclaim of a crashed consumer's unacked entries and a delivery-count cap that drops (not infinitely retries) a poison-pill entry -- correct for the issue's "autoscaled consumers" framing even though today's docker-compose runs a single worker replica. Deliberately out of scope for this PR: materialized aggregates, repointing the Activity Feed API at this table (both S6), and null-tenant-installation events (skipped, not normalized).

## Summary

<!-- What does this PR change, and why? -->

Closes #<!-- issue number, if any -->

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
- [ ] Relevant `pytest` tests pass (if API/worker changed)
- [ ] Docker images still build, if `Dockerfile`/deps changed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background processing for webhook events through a reliable queue.
  * Normalized webhook deliveries into repository event records with duplicate prevention.
  * Added handling for failed, malformed, missing, and stale queued deliveries.

* **Bug Fixes**
  * Improved recovery after consumer interruptions and prevented repeatedly failing messages from blocking processing.

* **Documentation**
  * Updated setup instructions for Redis authentication and existing deployments.

* **Chores**
  * Added required Redis configuration and startup health checks for the worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->