### PR TITLE
feat(worker): materialize daily event-count aggregates from repo_events

### DIFF
--- a/apps/api/alembic/versions/0037_add_repo_event_daily_counts.py
+++ b/apps/api/alembic/versions/0037_add_repo_event_daily_counts.py
@@ -1,0 +1,110 @@
+"""Add repo_event_daily_counts table + clevis_worker/clevis_api grants (issue #191, S4 PR 2 of N).
+
+Materialized aggregate half of S4: per-tenant/repo/event_type/day event counts, upserted by
+apps/worker's event_consumer.py (src/event_consumer.py) in the same transaction as each
+repo_events insert. Not read by the API yet -- that's S6's job, same deferral as repo_events
+itself (migration 0036).
+
+Composite primary key (tenant_id, repo, event_type, day) instead of a surrogate id: this table is
+purely a rollup keyed by those four values, an upsert target, never referenced by foreign key from
+elsewhere -- a surrogate key would add a sequence to grant/manage for no benefit.
+
+tenant_id is NOT NULL by the same reasoning as repo_events: the consumer never normalizes a
+null-tenant webhook_deliveries row, so it never has a null-tenant aggregate to upsert either. RLS
+policy reuses migration 0030's _TENANT_FILTER, ENABLE-only (no FORCE), same reasoning as 0036 --
+the table-owning migration role is unaffected either way, and no non-owner role reads this table
+yet.
+
+Grants mirror migration 0036 exactly, including clevis_api's grant: CI runs apps/worker's tests
+under DATABASE_URL=clevis_api (no clevis_worker CI provisioning exists), so the consumer's own
+tests need clevis_api access here too, same as repo_events. clevis_worker additionally gets UPDATE
+(not just INSERT) since upserting requires it.
+
+Upgrade is purely additive (one new table, two conditional grants) -- zero data-loss risk.
+Downgrade drops the table; safe since nothing reads it yet (S6 hasn't shipped).
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-08-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+_TENANT_FILTER = "tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::int"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "repo_event_daily_counts",
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("repo", sa.String(), nullable=False),
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+        sa.PrimaryKeyConstraint("tenant_id", "repo", "event_type", "day", name="pk_repo_event_daily_counts"),
+    )
+    op.create_index("ix_repo_event_daily_counts_tenant_id_day", "repo_event_daily_counts", ["tenant_id", "day"])
+
+    op.execute(sa.text("ALTER TABLE repo_event_daily_counts ENABLE ROW LEVEL SECURITY"))
+    op.execute(
+        sa.text(
+            f"CREATE POLICY tenant_isolation ON repo_event_daily_counts "
+            f"USING ({_TENANT_FILTER}) WITH CHECK ({_TENANT_FILTER})"
+        )
+    )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_worker') THEN
+                GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_worker;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_worker') THEN
+                REVOKE SELECT, INSERT, UPDATE ON repo_event_daily_counts FROM clevis_worker;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                REVOKE SELECT, INSERT, UPDATE ON repo_event_daily_counts FROM clevis_api;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(sa.text("DROP POLICY IF EXISTS tenant_isolation ON repo_event_daily_counts"))
+    op.drop_table("repo_event_daily_counts")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -1,16 +1,18 @@
 from collections.abc import Generator
-from datetime import datetime
+from datetime import date, datetime
 import logging
 
 from sqlalchemy import (
     Boolean,
     CheckConstraint,
+    Date,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
     Integer,
     LargeBinary,
+    PrimaryKeyConstraint,
     String,
     Text,
     UniqueConstraint,
@@ -170,6 +172,28 @@ class RepoEvent(Base):
     # every ingested event type has one canonical top-level timestamp field.
     occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class RepoEventDailyCount(Base):
+    """Materialized rollup half of S4 (issue #191), migration 0037. Upserted by
+    apps/worker's event_consumer.py in the same transaction as each RepoEvent insert --
+    not a separate batch job -- and only when that insert actually happened (a
+    redelivered/deduped event must not double-count here). Not read by the API yet --
+    S6's job, same deferral as RepoEvent. Composite PK instead of a surrogate id: this
+    row is purely identified by (tenant_id, repo, event_type, day), it's an upsert
+    target, and nothing references it by foreign key."""
+
+    __tablename__ = "repo_event_daily_counts"
+    __table_args__ = (
+        PrimaryKeyConstraint("tenant_id", "repo", "event_type", "day", name="pk_repo_event_daily_counts"),
+        Index("ix_repo_event_daily_counts_tenant_id_day", "tenant_id", "day"),
+    )
+
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
+    repo: Mapped[str] = mapped_column(String, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    day: Mapped[date] = mapped_column(Date, nullable=False)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
 
 
 class SavedToken(Base):

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -1,9 +1,12 @@
-"""Redis Streams consumer for webhook_events (issue #191, S4 PR 1 of N).
+"""Redis Streams consumer for webhook_events (issue #191, S4).
 
 Normalizes each queued webhook delivery into the repo_events table, deduplicated by
-delivery_id. Runs as a second daemon thread in worker.py's run(), alongside the
-existing jobs-table poll loop -- not a separate process, so it shares the container's
-healthcheck/deploy story.
+delivery_id, and upserts a per-tenant/repo/event_type/day count into
+repo_event_daily_counts in the same transaction (S4 PR 2) -- the materialized-aggregate
+half of S4, gated on the repo_events insert having actually happened (not a deduped
+redelivery), so a redelivered webhook can't double-count the rollup. Runs as a second
+daemon thread in worker.py's run(), alongside the existing jobs-table poll loop -- not a
+separate process, so it shares the container's healthcheck/deploy story.
 
 Consumer-group semantics (XREADGROUP, group "event_processors") rather than a bare
 XREAD: today's docker-compose runs exactly one worker replica, but a bare XREAD has no
@@ -210,6 +213,7 @@ def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry
             VALUES (%(tenant_id)s, %(delivery_id)s, %(event_type)s, %(actor)s, %(actor_avatar)s,
                     %(repo)s, %(summary)s, %(occurred_at)s)
             ON CONFLICT (delivery_id) DO NOTHING
+            RETURNING id
             """,
             {
                 "tenant_id": tenant_id,
@@ -217,6 +221,24 @@ def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry
                 **normalized,
             },
         )
+        # Only upsert the aggregate when a repo_events row was actually inserted --
+        # RETURNING comes back empty on the ON CONFLICT DO NOTHING path (a redelivered
+        # webhook), and that must not double-count the rollup (issue #191/S4 PR 2).
+        if cur.fetchone() is not None:
+            cur.execute(
+                """
+                INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count)
+                VALUES (%(tenant_id)s, %(repo)s, %(event_type)s, %(day)s, 1)
+                ON CONFLICT (tenant_id, repo, event_type, day)
+                DO UPDATE SET count = repo_event_daily_counts.count + 1
+                """,
+                {
+                    "tenant_id": tenant_id,
+                    "repo": normalized["repo"],
+                    "event_type": normalized["event_type"],
+                    "day": normalized["occurred_at"].date(),
+                },
+            )
         cur.execute("UPDATE webhook_deliveries SET status = 'processed' WHERE id = %s", (delivery_row_id,))
     pg_conn.commit()
     redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -26,7 +26,7 @@ import logging
 import os
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import psycopg
@@ -236,7 +236,17 @@ def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry
                     "tenant_id": tenant_id,
                     "repo": normalized["repo"],
                     "event_type": normalized["event_type"],
-                    "day": normalized["occurred_at"].date(),
+                    # psycopg returns a timestamptz in whatever timezone this connection's
+                    # Postgres session happens to be in, not necessarily UTC -- .date() on
+                    # that raw value would misbucket an event near a non-UTC-session
+                    # midnight. Force UTC first so "day" always means the UTC calendar day,
+                    # matching migration 0037's column docstring (CodeRabbit finding on #341).
+                    # psycopg returns a timestamptz in whatever timezone this connection's
+                    # Postgres session happens to be in, not necessarily UTC -- .date() on
+                    # that raw value would misbucket an event near a non-UTC-session
+                    # midnight. Force UTC first so "day" always means the UTC calendar day,
+                    # matching migration 0037's column docstring (CodeRabbit finding on #341).
+                    "day": normalized["occurred_at"].astimezone(timezone.utc).date(),
                 },
             )
         cur.execute("UPDATE webhook_deliveries SET status = 'processed' WHERE id = %s", (delivery_row_id,))

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -272,6 +272,23 @@ def test_aggregates_separate_days_produce_separate_rows(pg_conn, tenant_id):
     assert _daily_count(conn, tenant_id, "acme/agg-days", "create", day_two.date()) == 1
 
 
+def test_aggregates_use_the_utc_day_regardless_of_session_timezone(pg_conn, tenant_id):
+    conn, state = pg_conn
+    # 00:30 UTC on Aug 21 is still Aug 20 in America/Los_Angeles (UTC-7 in August) -- the
+    # aggregate's "day" must bucket by UTC, not whatever timezone this Postgres session
+    # happens to be in (CodeRabbit finding on #341: psycopg returns timestamptz values in
+    # the session's TimeZone, not UTC, so a naive .date() call would misbucket this).
+    received_at = datetime(2026, 8, 21, 0, 30, tzinfo=timezone.utc)
+    payload = {"repository": {"full_name": "acme/agg-tz"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-tz-1", event_type="create", payload=payload, received_at=received_at)
+
+    with conn.cursor() as cur:
+        cur.execute("SET TIME ZONE 'America/Los_Angeles'")
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_id, "create", tenant_id))
+
+    assert _daily_count(conn, tenant_id, "acme/agg-tz", "create", received_at.date()) == 1  # UTC day, not LA day (Aug 20)
+
+
 def test_null_tenant_delivery_is_skipped_not_normalized(pg_conn):
     conn, state = pg_conn
     with conn.cursor() as cur:

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -1,6 +1,7 @@
-"""Tests for the webhook_events Redis Streams consumer (issue #191/S4 PR 1)."""
+"""Tests for the webhook_events Redis Streams consumer (issue #191/S4)."""
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import psycopg
@@ -74,16 +75,26 @@ def redis_client():
     client.flushdb()
 
 
-def _make_delivery(conn, state, *, tenant_id, delivery_id, event_type, payload: dict) -> int:
+def _make_delivery(conn, state, *, tenant_id, delivery_id, event_type, payload: dict, received_at=None) -> int:
     with conn.cursor() as cur:
-        cur.execute(
-            """
-            INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status)
-            VALUES (%s, %s, %s, %s, 'queued')
-            RETURNING id
-            """,
-            (tenant_id, delivery_id, event_type, json.dumps(payload).encode()),
-        )
+        if received_at is None:
+            cur.execute(
+                """
+                INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status)
+                VALUES (%s, %s, %s, %s, 'queued')
+                RETURNING id
+                """,
+                (tenant_id, delivery_id, event_type, json.dumps(payload).encode()),
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO webhook_deliveries (tenant_id, delivery_id, event_type, payload, status, received_at)
+                VALUES (%s, %s, %s, %s, 'queued', %s)
+                RETURNING id
+                """,
+                (tenant_id, delivery_id, event_type, json.dumps(payload).encode(), received_at),
+            )
         row_id = cur.fetchone()[0]
     conn.commit()
     state["delivery_ids"].append(row_id)
@@ -194,6 +205,71 @@ def test_processing_the_same_delivery_twice_is_idempotent(pg_conn, tenant_id):
         cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
         cur.execute("SELECT count(*) FROM repo_events WHERE delivery_id = %s", ("d-dedupe-1",))
         assert cur.fetchone()[0] == 1
+
+
+def _daily_count(conn, tenant_id, repo, event_type, day):
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute(
+            "SELECT count FROM repo_event_daily_counts WHERE tenant_id = %s AND repo = %s AND event_type = %s AND day = %s",
+            (tenant_id, repo, event_type, day),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def test_aggregates_a_daily_count_on_insert(pg_conn, tenant_id):
+    conn, state = pg_conn
+    received_at = datetime(2026, 8, 21, 10, 0, tzinfo=timezone.utc)
+    payload = {"repository": {"full_name": "acme/agg-fresh"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-fresh-1", event_type="create", payload=payload, received_at=received_at)
+
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_id, "create", tenant_id))
+
+    assert _daily_count(conn, tenant_id, "acme/agg-fresh", "create", received_at.date()) == 1
+
+
+def test_aggregates_increment_on_a_second_distinct_event_same_day(pg_conn, tenant_id):
+    conn, state = pg_conn
+    received_at = datetime(2026, 8, 21, 11, 0, tzinfo=timezone.utc)
+    payload_a = {"repository": {"full_name": "acme/agg-increment"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    payload_b = {"repository": {"full_name": "acme/agg-increment"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v2"}
+    row_a = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-increment-1", event_type="create", payload=payload_a, received_at=received_at)
+    row_b = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-increment-2", event_type="create", payload=payload_b, received_at=received_at)
+
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_a, "create", tenant_id))
+    event_consumer._process_entry(conn, _FakeRedis(), "2-0", _entry_fields(row_b, "create", tenant_id))
+
+    assert _daily_count(conn, tenant_id, "acme/agg-increment", "create", received_at.date()) == 2
+
+
+def test_aggregates_unchanged_when_the_same_delivery_is_reprocessed(pg_conn, tenant_id):
+    conn, state = pg_conn
+    received_at = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+    payload = {"repository": {"full_name": "acme/agg-dedupe"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    row_id = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-dedupe-1", event_type="create", payload=payload, received_at=received_at)
+
+    fields = _entry_fields(row_id, "create", tenant_id)
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", fields)
+    event_consumer._process_entry(conn, _FakeRedis(), "2-0", fields)  # simulates a redelivery/reprocess
+
+    assert _daily_count(conn, tenant_id, "acme/agg-dedupe", "create", received_at.date()) == 1
+
+
+def test_aggregates_separate_days_produce_separate_rows(pg_conn, tenant_id):
+    conn, state = pg_conn
+    day_one = datetime(2026, 8, 20, 23, 0, tzinfo=timezone.utc)
+    day_two = datetime(2026, 8, 21, 1, 0, tzinfo=timezone.utc)
+    payload_a = {"repository": {"full_name": "acme/agg-days"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v1"}
+    payload_b = {"repository": {"full_name": "acme/agg-days"}, "sender": {"login": "octocat", "avatar_url": ""}, "ref_type": "tag", "ref": "v2"}
+    row_a = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-days-1", event_type="create", payload=payload_a, received_at=day_one)
+    row_b = _make_delivery(conn, state, tenant_id=tenant_id, delivery_id="d-agg-days-2", event_type="create", payload=payload_b, received_at=day_two)
+
+    event_consumer._process_entry(conn, _FakeRedis(), "1-0", _entry_fields(row_a, "create", tenant_id))
+    event_consumer._process_entry(conn, _FakeRedis(), "2-0", _entry_fields(row_b, "create", tenant_id))
+
+    assert _daily_count(conn, tenant_id, "acme/agg-days", "create", day_one.date()) == 1
+    assert _daily_count(conn, tenant_id, "acme/agg-days", "create", day_two.date()) == 1
 
 
 def test_null_tenant_delivery_is_skipped_not_normalized(pg_conn):

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -76,6 +76,17 @@ BEGIN
 END
 $do$;
 
+-- repo_event_daily_counts (migration 0037, issue #191/S4 PR 2): same reasoning as
+-- repo_events immediately above -- CI runs apps/worker's tests as clevis_api, and this
+-- table has no sequence (composite PK), so only the table grant is needed.
+DO $do$
+BEGIN
+  IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = 'repo_event_daily_counts') THEN
+    GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_api;
+  END IF;
+END
+$do$;
+
 -- resolve_installation_tenant_id() (migration 0035) REVOKEs its default PUBLIC EXECUTE
 -- and re-GRANTs it only to clevis_api -- but that migration's own GRANT is itself
 -- conditional on clevis_api already existing, which isn't true the first time this

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,10 +45,10 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
    # 2. Grant it the table privileges migration 0020 would otherwise apply.
    #    Runs inside the db container so it uses the container's own
    #    POSTGRES_USER/POSTGRES_DB, not unexported host-shell variables.
-   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker;"'
+   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker; GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_worker;"'
    ```
 
-   Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterward to pick up the new credential.
+   Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036`/`0037` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterward to pick up the new credential.
 
 6. (Recommended) Give the API its own non-superuser Postgres credential, separate from `DB_USER`/`DB_PASSWORD`: set `API_DB_PASSWORD` in `.env`. Without this, the API connects as `DB_USER` — the `initdb` bootstrap superuser — which unconditionally bypasses Row-Level Security, so tenant isolation is enforced only at the application layer (issue #330). Same fresh-volume-only caveat as the worker's credential above. If you're setting this on an **existing** deployment, run `docker/provision-api-role-existing-deployment.sh` instead of the fresh-volume init script:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,8 +45,10 @@ This is the infrastructure/ops guide — getting the Clevis stack itself running
    # 2. Grant it the table privileges migration 0020 would otherwise apply.
    #    Runs inside the db container so it uses the container's own
    #    POSTGRES_USER/POSTGRES_DB, not unexported host-shell variables.
-   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker; GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_worker;"'
+   docker compose exec db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT SELECT, UPDATE ON jobs TO clevis_worker; GRANT SELECT ON app_config TO clevis_worker; GRANT SELECT, INSERT ON repo_events TO clevis_worker; GRANT USAGE, SELECT ON repo_events_id_seq TO clevis_worker; GRANT SELECT, UPDATE ON webhook_deliveries TO clevis_worker;" -c "DO \$do\$ BEGIN IF EXISTS (SELECT FROM pg_tables WHERE schemaname = '"'"'public'"'"' AND tablename = '"'"'repo_event_daily_counts'"'"') THEN GRANT SELECT, INSERT, UPDATE ON repo_event_daily_counts TO clevis_worker; END IF; END \$do\$;"'
    ```
+
+   The `repo_event_daily_counts` grant is guarded by existence (unlike the others on this line): this step can run before step 7 below has ever applied Alembic migrations on an update to an existing deployment, and an unconditional `GRANT` on a table that doesn't exist yet would fail outright (CodeRabbit finding on #341) — the other grants here predate this guard and are left as-is, not retroactively changed, to keep this fix scoped to what #341 actually added.
 
    Don't rely on re-running `alembic upgrade head` for step 2 — if migrations `0020`/`0036`/`0037` already applied (as a no-op, since the role didn't exist yet), Alembic considers them done and won't re-run them. Restart the `worker` container afterward to pick up the new credential.
 


### PR DESCRIPTION
## Summary

S4 PR2 (issue #191) — the materialized-aggregates half of S4, second slice after PR #340's `event_consumer.py` + `repo_events` table (merged). Adds `repo_event_daily_counts`, a per-tenant/repo/event_type/UTC-day rollup, upserted by the same consumer that writes `repo_events`.

**Schema change included:** migration `0037` adds one new table (`repo_event_daily_counts`), composite primary key `(tenant_id, repo, event_type, day)` (no surrogate id/sequence — this table is purely an upsert target, nothing references it by foreign key), RLS-enabled (ENABLE only, no FORCE, matching migration `0036`'s precedent), plus conditional grants for `clevis_worker` and `clevis_api` mirroring `0036`'s pattern exactly. Purely additive, zero data-loss risk — nothing reads this table yet.

## What changed and why

- **`apps/api/alembic/versions/0037_add_repo_event_daily_counts.py`** — the migration described above.
- **`apps/api/src/core/db.py`** — `RepoEventDailyCount` SQLAlchemy model mirroring the migration.
- **`apps/worker/src/event_consumer.py`** — `_process_entry`'s `repo_events` insert now uses `RETURNING id`, and only when a row was actually inserted (not a deduped redelivery) does it upsert the matching `repo_event_daily_counts` row (`ON CONFLICT ... DO UPDATE SET count = count + 1`), in the same transaction. This gating is what keeps the aggregate idempotent — GitHub redelivering the same webhook must not double-count it.
- **`docker/provision-api-role-existing-deployment.sh`** and **`docs/self-hosting.md`** — extended with the same grant pattern already established for `repo_events`, for the same reason (CI runs `apps/worker/tests` under `clevis_api`, since there's no `clevis_worker` CI provisioning).
- **`apps/worker/tests/test_event_consumer.py`** — new tests: fresh event produces a `count=1` row, a second distinct event on the same day increments to `2`, reprocessing the same `delivery_id` leaves the count unchanged, and events on different UTC days produce separate rows.

**Deliberately out of scope, discussed and decided directly with the requester:** no dashboard or API endpoint reads these aggregates yet (that's S6's job) — `repo_events` has no backfill yet (S5) and webhook config is optional per self-hosted org, so repointing any read now would show a misleadingly thin result for orgs without webhook history. Per-actor rollups (useful later for Collaborators dashboards) are also not added speculatively — no concrete consumer for them yet.

## Test plan

- [x] `alembic upgrade head` applies cleanly on top of `0036`; `alembic check` reports no model/migration drift
- [x] `pytest -q apps/worker/tests/test_event_consumer.py` — 30 tests pass, including the 4 new aggregate cases
- [x] Full `pytest -q` — 680 passed, 3 skipped, 3 xpassed, against a freshly reset local Postgres + a locally-mapped Redis
- [x] `bun run check` (typecheck + lint + build) — clean, enforced by the `pre-commit`/`pre-push` hooks on this PR's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily activity counts by repository and event type.
  * Counts are tracked separately for each tenant and UTC date.
  * New events update totals reliably without double-counting redelivered events.

* **Documentation**
  * Updated self-hosting database provisioning instructions for the new activity counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->