### PR TITLE
feat(worker): install-time backfill of recent org/user activity

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -21,6 +21,8 @@
                                               whether to call the /me or /orgs sync endpoint next.
 """
 
+import logging
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import text
@@ -36,7 +38,10 @@ from src.schemas.installation import (
     SyncInstallationsInput,
     SyncInstallationsResponse,
 )
-from src.services import github_app
+from src.services import backfill_service, github_app
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -78,6 +83,22 @@ def _verify_installation(installation_id: int | None, account_login: str, accoun
                 f"'{actual_login}', not {account_type} '{account_login}'"
             ),
         )
+
+
+def _enqueue_backfill_best_effort(db: Session, *, tenant_id: int, account_login: str, account_type: str, resolve_token) -> None:
+    """S5 PR 1: best-effort install-time activity backfill. Must never fail the install
+    response itself -- the install already succeeded (its own audit log entry is already
+    written by the time this runs), and backfill is enrichment, not a precondition of a
+    working install. `resolve_token` is a zero-arg callable so the org/personal callers
+    can each pass their own resolve_org_token/resolve_personal_token call without this
+    helper needing to know which one applies."""
+    try:
+        token = resolve_token()
+        backfill_service.enqueue(db, tenant_id=tenant_id, account_login=account_login, account_type=account_type, token=token)
+    except NoGitHubTokenAvailable as exc:
+        logger.warning("skipping activity backfill for %s: %s", account_login, exc)
+    except Exception:
+        logger.exception("failed to enqueue activity backfill for %s", account_login)
 
 
 @router.get("/me/installations/lookup/{installation_id}", response_model=InstallationLookupOut)
@@ -197,6 +218,13 @@ def sync_org_installation(
         payload={"account_type": payload.account_type, "installation_id": payload.installation_id},
         tenant_id=org.tenant_id,
     )
+    _enqueue_backfill_best_effort(
+        db,
+        tenant_id=org.tenant_id,
+        account_login=payload.account_login,
+        account_type=payload.account_type,
+        resolve_token=lambda: resolve_org_token(db, org_id=org.id, account_login=payload.account_login, client_token=None),
+    )
     return {"synced": True, "token_ref": row.token_ref}
 
 
@@ -247,5 +275,14 @@ def sync_personal_installation(
         target=payload.account_login,
         payload={"account_type": payload.account_type, "installation_id": payload.installation_id},
         tenant_id=personal_tenant.id,
+    )
+    _enqueue_backfill_best_effort(
+        db,
+        tenant_id=personal_tenant.id,
+        account_login=payload.account_login,
+        account_type=payload.account_type,
+        resolve_token=lambda: resolve_personal_token(
+            db, owner_user_id=user.id, account_login=payload.account_login, client_token=None
+        ),
     )
     return {"synced": True, "token_ref": row.token_ref}

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -101,7 +101,7 @@ def _enqueue_backfill_best_effort(db: Session, *, tenant_id: int, account_login:
         # A DB-level error here (e.g. from job_repo.enqueue's own commit) leaves the
         # shared request Session's transaction aborted -- roll it back so the response
         # this handler still has to build (row.token_ref) doesn't itself 500 trying to
-        # use a poisoned session (CodeRabbit finding on #342).
+        # use a poisoned session.
         db.rollback()
         logger.exception("failed to enqueue activity backfill for %s", account_login)
 

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -98,6 +98,11 @@ def _enqueue_backfill_best_effort(db: Session, *, tenant_id: int, account_login:
     except NoGitHubTokenAvailable as exc:
         logger.warning("skipping activity backfill for %s: %s", account_login, exc)
     except Exception:
+        # A DB-level error here (e.g. from job_repo.enqueue's own commit) leaves the
+        # shared request Session's transaction aborted -- roll it back so the response
+        # this handler still has to build (row.token_ref) doesn't itself 500 trying to
+        # use a poisoned session (CodeRabbit finding on #342).
+        db.rollback()
         logger.exception("failed to enqueue activity backfill for %s", account_login)
 
 

--- a/apps/api/src/services/backfill_service.py
+++ b/apps/api/src/services/backfill_service.py
@@ -1,0 +1,29 @@
+"""S5 PR 1: enqueue a one-shot install-time activity backfill.
+
+Mirrors cache_service.clear()'s exact job-enqueue pattern: Fernet-encrypt the token for
+the worker payload (apps/worker decrypts via its own _crypto.py thin wrapper, matching
+issue #190/#191's established convention), then insert a `jobs` row for the worker's
+existing SELECT ... FOR UPDATE SKIP LOCKED poll loop to pick up. See
+apps/worker/src/backfill.py and worker.py's _handle_backfill_repo_events for the
+worker-side handler.
+"""
+
+from sqlalchemy.orm import Session
+
+from src.core._crypto import encrypt_job_token
+from src.core.config import settings
+from src.repositories import job_repo
+
+
+def enqueue(db: Session, *, tenant_id: int, account_login: str, account_type: str, token: str) -> int:
+    encrypted_token = encrypt_job_token(token, settings.job_secret_key.get_secret_value())
+    return job_repo.enqueue(
+        db,
+        "github.backfill_repo_events",
+        {
+            "tenant_id": tenant_id,
+            "account_login": account_login,
+            "account_type": account_type,
+            "token": encrypted_token,
+        },
+    )

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import AuditLog, User, get_db
+from src.core.db import AuditLog, Job, User, get_db
 from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.installations import router as inst_router
 from src.services import github_app
@@ -126,6 +126,41 @@ def test_sync_org_installation_writes_audit_log(db, acme_org):
     assert payload == {"account_type": "Organization", "installation_id": 7}
 
 
+def test_sync_org_installation_enqueues_a_backfill_job_when_a_token_is_available(db, acme_org):
+    # Issue #191/S5 PR 1: a successful sync should kick off a one-shot activity backfill.
+    # No GitHub App is configured in test settings, so resolve_org_token itself is mocked
+    # directly (patched where installations.py imported it) rather than relying on real
+    # installation-token minting.
+    with _mock_installation("acme", "Organization"), patch(
+        "src.routers.installations.resolve_org_token", return_value="tok_acme"
+    ):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 200
+    jobs = db.query(Job).filter(Job.job_type == "github.backfill_repo_events").all()
+    assert len(jobs) == 1
+    payload = json.loads(jobs[0].payload)
+    assert payload["account_login"] == "acme"
+    assert payload["account_type"] == "Organization"
+    assert payload["tenant_id"] == acme_org["org"].tenant_id
+    assert payload["token"] != "tok_acme"  # Fernet-encrypted, not the raw token
+
+
+def test_sync_org_installation_still_succeeds_when_no_backfill_token_is_available(db, acme_org):
+    # No GitHub App configured (the default in test settings) -> resolve_org_token raises
+    # NoGitHubTokenAvailable -- the install itself must still succeed (issue #191/S5 PR 1:
+    # backfill is best-effort enrichment, not a precondition of a working install).
+    with _mock_installation("acme", "Organization"):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 200
+    assert db.query(Job).filter(Job.job_type == "github.backfill_repo_events").count() == 0
+
+
 def test_personal_installations_scoped_to_self(db):
     me = _make_user(db, "shabnam@e.com")
     someone_else = _make_user(db, "someoneelse@e.com")
@@ -171,6 +206,23 @@ def test_sync_personal_installation_writes_audit_log(db):
     assert logs[0].actor == me.email
     payload = json.loads(logs[0].payload)
     assert payload == {"account_type": "User", "installation_id": 3}
+
+
+def test_sync_personal_installation_enqueues_a_backfill_job_when_a_token_is_available(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    with _mock_installation("shabnam", "User"), patch(
+        "src.routers.installations.resolve_personal_token", return_value="tok_shabnam"
+    ):
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
+    assert resp.status_code == 200
+    jobs = db.query(Job).filter(Job.job_type == "github.backfill_repo_events").all()
+    assert len(jobs) == 1
+    payload = json.loads(jobs[0].payload)
+    assert payload["account_login"] == "shabnam"
+    assert payload["account_type"] == "User"
 
 
 def test_sync_personal_installation_requires_linked_github_account(db):

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -161,6 +161,25 @@ def test_sync_org_installation_still_succeeds_when_no_backfill_token_is_availabl
     assert db.query(Job).filter(Job.job_type == "github.backfill_repo_events").count() == 0
 
 
+def test_sync_org_installation_survives_a_db_error_during_backfill_enqueue(db, acme_org):
+    # CodeRabbit finding on #342: a DB-level error from resolve_token()/enqueue() (not
+    # NoGitHubTokenAvailable) used to leave the shared Session's transaction aborted, so
+    # the install response's own row.token_ref access (a post-commit lazy reload) would
+    # itself raise and turn an already-successful install into a 500.
+    def _boom(*args, **kwargs):
+        db.execute(text("SELECT 1/0"))  # forces a real, session-aborting Postgres error
+
+    with _mock_installation("acme", "Organization"), patch(
+        "src.routers.installations.resolve_org_token", return_value="tok_acme"
+    ), patch("src.routers.installations.backfill_service.enqueue", side_effect=_boom):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["synced"] is True
+
+
 def test_personal_installations_scoped_to_self(db):
     me = _make_user(db, "shabnam@e.com")
     someone_else = _make_user(db, "someoneelse@e.com")

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -162,10 +162,10 @@ def test_sync_org_installation_still_succeeds_when_no_backfill_token_is_availabl
 
 
 def test_sync_org_installation_survives_a_db_error_during_backfill_enqueue(db, acme_org):
-    # CodeRabbit finding on #342: a DB-level error from resolve_token()/enqueue() (not
-    # NoGitHubTokenAvailable) used to leave the shared Session's transaction aborted, so
-    # the install response's own row.token_ref access (a post-commit lazy reload) would
-    # itself raise and turn an already-successful install into a 500.
+    # A DB-level error from resolve_token()/enqueue() (not NoGitHubTokenAvailable) used
+    # to leave the shared Session's transaction aborted, so the install response's own
+    # row.token_ref access (a post-commit lazy reload) would itself raise and turn an
+    # already-successful install into a 500.
     def _boom(*args, **kwargs):
         db.execute(text("SELECT 1/0"))  # forces a real, session-aborting Postgres error
 

--- a/apps/worker/src/backfill.py
+++ b/apps/worker/src/backfill.py
@@ -1,0 +1,135 @@
+"""S5 PR 1: install-time backfill of recent org/user activity into repo_events.
+
+Runs as a one-shot `github.backfill_repo_events` job through the existing apps/worker
+jobs poll loop (see worker.py's _handle_backfill_repo_events) -- reuses that machinery
+(SELECT ... FOR UPDATE SKIP LOCKED, heartbeat, retry/failure handling) rather than a new
+execution path. Calls the same GitHub Events API the live Activity Feed already polls
+(apps/api/src/routers/github.py's org_events endpoint) -- GitHub caps this at roughly
+the last ~90 days / ~300 events, so this is "recent activity on connect", not a deep
+historical backfill (that would require composing from commits/PRs/issues REST
+endpoints instead -- explicitly deferred, see the S5 PR 1 plan notes).
+
+Maps only the 5 event types apps/worker/src/event_consumer.py already tracks from live
+webhooks, to the same lowercase event_type vocabulary, so a repo_events row looks the
+same regardless of source. Synthetic delivery_id ("backfill:<github event id>") keeps
+this idempotent against a retried job or a second install-sync call, via the same
+ON CONFLICT (delivery_id) DO NOTHING repo_events_store.py relies on.
+
+No bot filtering here (unlike the live Activity Feed's presentation-layer _is_bot filter
+in apps/api/src/routers/github.py) -- repo_events itself stores every actor unfiltered
+regardless of source; filtering is a read-time/display concern, not a storage concern.
+"""
+
+from datetime import datetime
+
+import httpx
+
+# Self-imposed ceiling on top of GitHub's own Events API cap (~300 events total) -- not
+# the primary limit, just a bound so a pathological Link-header loop can't run forever.
+_MAX_PAGES = 3
+_PER_PAGE = 100
+
+_EVENT_TYPE_MAP = {
+    "PushEvent": "push",
+    "PullRequestEvent": "pull_request",
+    "IssuesEvent": "issues",
+    "ReleaseEvent": "release",
+    "CreateEvent": "create",
+}
+
+
+def _events_path(account_login: str, account_type: str) -> str:
+    # account_type mirrors github_installations.account_type ("User" for a personal
+    # install, anything else -- "Organization" in practice -- for an org install).
+    if account_type == "User":
+        return f"/users/{account_login}/events"
+    return f"/orgs/{account_login}/events"
+
+
+def fetch_events(client: httpx.Client, base: str, headers: dict, account_login: str, account_type: str) -> list[dict]:
+    """Follows the Link: rel="next" header (httpx parses it into response.links) up to
+    _MAX_PAGES. Raises httpx.HTTPStatusError/RequestError on failure -- callers map
+    those to the same requeue/fail decision worker.py's other job handlers already use."""
+    events: list[dict] = []
+    url = f"{base}{_events_path(account_login, account_type)}"
+    params: dict | None = {"per_page": _PER_PAGE}
+    for _ in range(_MAX_PAGES):
+        resp = client.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        page = resp.json()
+        if not isinstance(page, list):
+            break
+        events.extend(page)
+        next_link = resp.links.get("next")
+        if not next_link:
+            break
+        url = next_link["url"]
+        params = None  # already encoded in the next link's URL
+    return events
+
+
+def _summarize(event_type: str, payload: dict) -> str:
+    """Mirrors event_consumer.py's _summarize, adapted to the Events API's nested
+    `payload` sub-object shape (vs. a raw webhook body's top-level fields) -- the same
+    per-type mapping apps/api/src/routers/github.py's own _summarize already implements
+    for the live feed, duplicated here rather than imported across the service
+    boundary (apps/worker doesn't import apps/api -- same precedent as
+    event_consumer.py's own _summarize)."""
+    if event_type == "push":
+        size = payload.get("size")
+        commits = payload.get("commits") or []
+        count = size if isinstance(size, int) else len(commits)
+        branch = (payload.get("ref") or "").removeprefix("refs/heads/")
+        noun = "commit" if count == 1 else "commits"
+        return f"pushed {count} {noun} to {branch}" if branch else f"pushed {count} {noun}"
+
+    if event_type == "pull_request":
+        pr = payload.get("pull_request") or {}
+        action = payload.get("action", "")
+        verb = "merged" if action == "closed" and pr.get("merged") else action
+        return f"{verb} PR #{payload.get('number')}: {pr.get('title', '')}"
+
+    if event_type == "issues":
+        issue = payload.get("issue") or {}
+        action = payload.get("action", "")
+        return f"{action} issue #{issue.get('number')}: {issue.get('title', '')}"
+
+    if event_type == "release":
+        release = payload.get("release") or {}
+        return f"created release {release.get('tag_name', '')}"
+
+    if event_type == "create":
+        ref_type = payload.get("ref_type", "")
+        ref = payload.get("ref") or ""
+        return f"created {ref_type} {ref}".strip()
+
+    return event_type
+
+
+def normalize(raw_event: dict) -> dict | None:
+    """Returns repo_events column values (minus tenant_id, which the caller already
+    knows from the job payload) for one Events-API event, or None if it's not one of
+    the 5 tracked types or is missing a field a real GitHub event always has."""
+    event_type = _EVENT_TYPE_MAP.get(raw_event.get("type"))
+    if event_type is None:
+        return None
+    event_id = raw_event.get("id")
+    repo = (raw_event.get("repo") or {}).get("name")
+    created_at_raw = raw_event.get("created_at")
+    if not event_id or not repo or not created_at_raw:
+        return None
+    try:
+        occurred_at = datetime.fromisoformat(created_at_raw.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    actor = raw_event.get("actor") or {}
+    payload = raw_event.get("payload") or {}
+    return {
+        "delivery_id": f"backfill:{event_id}",
+        "event_type": event_type,
+        "actor": actor.get("login", ""),
+        "actor_avatar": actor.get("avatar_url", ""),
+        "repo": repo,
+        "summary": _summarize(event_type, payload),
+        "occurred_at": occurred_at,
+    }

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -4,9 +4,11 @@ Normalizes each queued webhook delivery into the repo_events table, deduplicated
 delivery_id, and upserts a per-tenant/repo/event_type/day count into
 repo_event_daily_counts in the same transaction (S4 PR 2) -- the materialized-aggregate
 half of S4, gated on the repo_events insert having actually happened (not a deduped
-redelivery), so a redelivered webhook can't double-count the rollup. Runs as a second
-daemon thread in worker.py's run(), alongside the existing jobs-table poll loop -- not a
-separate process, so it shares the container's healthcheck/deploy story.
+redelivery), so a redelivered webhook can't double-count the rollup. That insert-then-
+upsert logic itself lives in repo_events_store.py, shared with backfill.py (S5 PR 1) --
+see that module's docstring. Runs as a second daemon thread in worker.py's run(),
+alongside the existing jobs-table poll loop -- not a separate process, so it shares the
+container's healthcheck/deploy story.
 
 Consumer-group semantics (XREADGROUP, group "event_processors") rather than a bare
 XREAD: today's docker-compose runs exactly one worker replica, but a bare XREAD has no
@@ -26,12 +28,13 @@ import logging
 import os
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 import psycopg
 import redis
 
+import repo_events_store
 from config import settings
 
 log = logging.getLogger(__name__)
@@ -206,49 +209,7 @@ def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry
         # explicit mechanism than granting clevis_worker BYPASSRLS, same precedent as
         # migration 0035's SECURITY DEFINER function.
         cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
-        cur.execute(
-            """
-            INSERT INTO repo_events
-                (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at)
-            VALUES (%(tenant_id)s, %(delivery_id)s, %(event_type)s, %(actor)s, %(actor_avatar)s,
-                    %(repo)s, %(summary)s, %(occurred_at)s)
-            ON CONFLICT (delivery_id) DO NOTHING
-            RETURNING id
-            """,
-            {
-                "tenant_id": tenant_id,
-                "delivery_id": delivery_id,
-                **normalized,
-            },
-        )
-        # Only upsert the aggregate when a repo_events row was actually inserted --
-        # RETURNING comes back empty on the ON CONFLICT DO NOTHING path (a redelivered
-        # webhook), and that must not double-count the rollup (issue #191/S4 PR 2).
-        if cur.fetchone() is not None:
-            cur.execute(
-                """
-                INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count)
-                VALUES (%(tenant_id)s, %(repo)s, %(event_type)s, %(day)s, 1)
-                ON CONFLICT (tenant_id, repo, event_type, day)
-                DO UPDATE SET count = repo_event_daily_counts.count + 1
-                """,
-                {
-                    "tenant_id": tenant_id,
-                    "repo": normalized["repo"],
-                    "event_type": normalized["event_type"],
-                    # psycopg returns a timestamptz in whatever timezone this connection's
-                    # Postgres session happens to be in, not necessarily UTC -- .date() on
-                    # that raw value would misbucket an event near a non-UTC-session
-                    # midnight. Force UTC first so "day" always means the UTC calendar day,
-                    # matching migration 0037's column docstring (CodeRabbit finding on #341).
-                    # psycopg returns a timestamptz in whatever timezone this connection's
-                    # Postgres session happens to be in, not necessarily UTC -- .date() on
-                    # that raw value would misbucket an event near a non-UTC-session
-                    # midnight. Force UTC first so "day" always means the UTC calendar day,
-                    # matching migration 0037's column docstring (CodeRabbit finding on #341).
-                    "day": normalized["occurred_at"].astimezone(timezone.utc).date(),
-                },
-            )
+        repo_events_store.insert_event_and_upsert_daily_count(cur, tenant_id=tenant_id, delivery_id=delivery_id, **normalized)
         cur.execute("UPDATE webhook_deliveries SET status = 'processed' WHERE id = %s", (delivery_row_id,))
     pg_conn.commit()
     redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)

--- a/apps/worker/src/repo_events_store.py
+++ b/apps/worker/src/repo_events_store.py
@@ -1,0 +1,83 @@
+"""Shared repo_events + repo_event_daily_counts write path (issue #191, S4-S5).
+
+Both event_consumer.py (S4: live webhook normalization) and backfill.py (S5 PR 1:
+install-time backfill) insert into repo_events and, only when that insert actually
+happened (not a delivery_id dedupe skip), upsert the matching repo_event_daily_counts
+row -- the exact same shape, so it lives here once rather than being duplicated a
+second time within the same service. This is an in-service refactor, not the
+cross-service duplication precedent between apps/api and apps/worker (e.g. this
+module's callers each keep their own _summarize/normalize, since those really do differ
+by source shape -- raw webhook body vs. Events API response).
+"""
+
+from datetime import datetime, timezone
+
+import psycopg
+
+
+def insert_event_and_upsert_daily_count(
+    cur: psycopg.Cursor,
+    *,
+    tenant_id: int,
+    delivery_id: str,
+    event_type: str,
+    actor: str,
+    actor_avatar: str,
+    repo: str,
+    summary: str,
+    occurred_at: datetime,
+) -> bool:
+    """Inserts a repo_events row (ON CONFLICT (delivery_id) DO NOTHING) and, only if a
+    row was actually inserted, upserts the matching repo_event_daily_counts row.
+    Returns True iff a new repo_events row was inserted -- callers that need to report
+    "how many new events" (e.g. backfill.py's job result) use this return value rather
+    than a separate row count.
+
+    Caller is responsible for `SET app.tenant_id = <n>` on this cursor's connection
+    before calling this (both callers already do, to satisfy RLS's WITH CHECK) -- not
+    done here, so this function stays a plain, easily-testable SQL helper with no
+    session-state side effects of its own.
+    """
+    cur.execute(
+        """
+        INSERT INTO repo_events
+            (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at)
+        VALUES (%(tenant_id)s, %(delivery_id)s, %(event_type)s, %(actor)s, %(actor_avatar)s,
+                %(repo)s, %(summary)s, %(occurred_at)s)
+        ON CONFLICT (delivery_id) DO NOTHING
+        RETURNING id
+        """,
+        {
+            "tenant_id": tenant_id,
+            "delivery_id": delivery_id,
+            "event_type": event_type,
+            "actor": actor,
+            "actor_avatar": actor_avatar,
+            "repo": repo,
+            "summary": summary,
+            "occurred_at": occurred_at,
+        },
+    )
+    inserted = cur.fetchone() is not None
+    if inserted:
+        cur.execute(
+            """
+            INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count)
+            VALUES (%(tenant_id)s, %(repo)s, %(event_type)s, %(day)s, 1)
+            ON CONFLICT (tenant_id, repo, event_type, day)
+            DO UPDATE SET count = repo_event_daily_counts.count + 1
+            """,
+            {
+                "tenant_id": tenant_id,
+                "repo": repo,
+                "event_type": event_type,
+                # psycopg returns a timestamptz in whatever timezone this connection's
+                # Postgres session happens to be in, not necessarily UTC -- .date() on
+                # that raw value would misbucket an event near a non-UTC-session
+                # midnight. Force UTC first so "day" always means the UTC calendar day,
+                # matching the repo_event_daily_counts column docstring (originally a
+                # CodeRabbit finding on #341).
+                "day": occurred_at.astimezone(timezone.utc).date(),
+            },
+        )
+    return inserted

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -281,9 +281,9 @@ def _handle_backfill_repo_events(conn: psycopg.Connection, job_id: int, payload_
         # Without a rollback here, this connection's transaction stays aborted -- the
         # _mark_failed/process_job safety net UPDATE that would otherwise run on it next
         # would itself raise InFailedSqlTransaction, leaving the job stuck in
-        # 'processing' until the reclaim sweep instead of being requeued (CodeRabbit
-        # finding on #342). The synthetic backfill:<id> delivery_id makes a full retry
-        # safe -- nothing is lost by requeueing rather than resuming.
+        # 'processing' until the reclaim sweep instead of being requeued. The synthetic
+        # backfill:<id> delivery_id makes a full retry safe -- nothing is lost by
+        # requeueing rather than resuming.
         conn.rollback()
         log.warning("job %d failed to store backfilled events (attempt %d): %s", job_id, retry_count + 1, error)
         _requeue_for_retry(conn, job_id, retry_count, sanitize_error(error))

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -265,17 +265,29 @@ def _handle_backfill_repo_events(conn: psycopg.Connection, job_id: int, payload_
         return
 
     inserted_count = 0
-    with conn.cursor() as cur:
-        # Same session-context mechanism as event_consumer.py's _process_entry -- see
-        # its comment for why this isn't a clevis_worker BYPASSRLS grant instead.
-        cur.execute(f"SET app.tenant_id = {int(payload.tenant_id)}")
-        for raw_event in raw_events:
-            normalized = backfill.normalize(raw_event)
-            if normalized is None:
-                continue
-            if repo_events_store.insert_event_and_upsert_daily_count(cur, tenant_id=payload.tenant_id, **normalized):
-                inserted_count += 1
-    conn.commit()
+    try:
+        with conn.cursor() as cur:
+            # Same session-context mechanism as event_consumer.py's _process_entry -- see
+            # its comment for why this isn't a clevis_worker BYPASSRLS grant instead.
+            cur.execute(f"SET app.tenant_id = {int(payload.tenant_id)}")
+            for raw_event in raw_events:
+                normalized = backfill.normalize(raw_event)
+                if normalized is None:
+                    continue
+                if repo_events_store.insert_event_and_upsert_daily_count(cur, tenant_id=payload.tenant_id, **normalized):
+                    inserted_count += 1
+        conn.commit()
+    except psycopg.Error as error:
+        # Without a rollback here, this connection's transaction stays aborted -- the
+        # _mark_failed/process_job safety net UPDATE that would otherwise run on it next
+        # would itself raise InFailedSqlTransaction, leaving the job stuck in
+        # 'processing' until the reclaim sweep instead of being requeued (CodeRabbit
+        # finding on #342). The synthetic backfill:<id> delivery_id makes a full retry
+        # safe -- nothing is lost by requeueing rather than resuming.
+        conn.rollback()
+        log.warning("job %d failed to store backfilled events (attempt %d): %s", job_id, retry_count + 1, error)
+        _requeue_for_retry(conn, job_id, retry_count, sanitize_error(error))
+        return
 
     _mark_done(
         conn, job_id, {"ok": True, "events_seen": len(raw_events), "events_inserted": inserted_count}, retry_count

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -8,6 +8,8 @@ import httpx
 import psycopg
 from pydantic import BaseModel, Field, ValidationError
 
+import backfill
+import repo_events_store
 from _crypto import decrypt_job_token
 from _sanitize import sanitize_error
 from config import settings
@@ -82,6 +84,13 @@ class ClearActionsCachePayload(BaseModel):
     token: str = Field(min_length=1)
     key: str | None = None
     ref: str | None = None
+
+
+class BackfillRepoEventsPayload(BaseModel):
+    tenant_id: int
+    account_login: str = Field(min_length=1)
+    account_type: str = Field(min_length=1)
+    token: str = Field(min_length=1)
 
 
 def _mark_done(conn: psycopg.Connection, job_id: int, result: dict, expected_retry_count: int) -> None:
@@ -215,11 +224,71 @@ def _handle_clear_actions_cache(conn: psycopg.Connection, job_id: int, payload_r
     log.info("job %d done", job_id)
 
 
+def _handle_backfill_repo_events(conn: psycopg.Connection, job_id: int, payload_raw: str, retry_count: int) -> None:
+    try:
+        payload = BackfillRepoEventsPayload.model_validate_json(payload_raw)
+    except ValidationError as error:
+        log.error("job %d has an invalid payload: %s", job_id, error)
+        _mark_failed(conn, job_id, sanitize_error(error), retry_count)
+        return
+
+    try:
+        token = decrypt_job_token(payload.token, settings.job_secret_key.get_secret_value())
+    except Exception as error:
+        log.error("job %d failed to decrypt its token: %s", job_id, error)
+        _mark_failed(conn, job_id, sanitize_error(error), retry_count)
+        return
+
+    base = settings.github_api_base
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        with httpx.Client(timeout=20) as client:
+            raw_events = backfill.fetch_events(client, base, headers, payload.account_login, payload.account_type)
+    except httpx.HTTPStatusError as error:
+        resp = error.response
+        if resp.status_code >= 500:
+            # 5xx is presumed transient (GitHub-side issue) — worth retrying, unlike 4xx.
+            log.warning("job %d got a %d from GitHub (attempt %d)", job_id, resp.status_code, retry_count + 1)
+            _requeue_for_retry(conn, job_id, retry_count, sanitize_error(_github_error_message(resp)))
+        else:
+            log.error("job %d failed: GitHub API error %d", job_id, resp.status_code)
+            _mark_failed(conn, job_id, sanitize_error(_github_error_message(resp)), retry_count)
+        return
+    except httpx.RequestError as error:
+        log.warning("job %d hit a network error (attempt %d): %s", job_id, retry_count + 1, error)
+        _requeue_for_retry(conn, job_id, retry_count, sanitize_error(error))
+        return
+
+    inserted_count = 0
+    with conn.cursor() as cur:
+        # Same session-context mechanism as event_consumer.py's _process_entry -- see
+        # its comment for why this isn't a clevis_worker BYPASSRLS grant instead.
+        cur.execute(f"SET app.tenant_id = {int(payload.tenant_id)}")
+        for raw_event in raw_events:
+            normalized = backfill.normalize(raw_event)
+            if normalized is None:
+                continue
+            if repo_events_store.insert_event_and_upsert_daily_count(cur, tenant_id=payload.tenant_id, **normalized):
+                inserted_count += 1
+    conn.commit()
+
+    _mark_done(
+        conn, job_id, {"ok": True, "events_seen": len(raw_events), "events_inserted": inserted_count}, retry_count
+    )
+    log.info("job %d done: backfilled %d/%d events for %s", job_id, inserted_count, len(raw_events), payload.account_login)
+
+
 # job_type -> handler. Each handler takes (conn, job_id, payload_raw, retry_count) and is
 # responsible for its own payload validation and terminal/retry outcome via _mark_done /
 # _mark_failed / _requeue_for_retry.
 JOB_HANDLERS = {
     "github.clear_actions_cache": _handle_clear_actions_cache,
+    "github.backfill_repo_events": _handle_backfill_repo_events,
 }
 
 

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -276,10 +276,10 @@ class _FailingConn(_FakeConn):
 
 
 def test_handler_rolls_back_and_requeues_on_a_db_error_during_the_insert_loop():
-    # CodeRabbit finding on #342: without a rollback here, the connection's transaction
-    # stays aborted and the _mark_failed/_requeue_for_retry UPDATE that follows would
-    # itself raise InFailedSqlTransaction, leaving the job stuck in 'processing' forever
-    # instead of being requeued.
+    # Without a rollback here, the connection's transaction stays aborted and the
+    # _mark_failed/_requeue_for_retry UPDATE that follows would itself raise
+    # InFailedSqlTransaction, leaving the job stuck in 'processing' forever instead of
+    # being requeued.
     conn = _FailingConn()
     events = [_raw_event(id="b-db-error-1")]
 
@@ -287,7 +287,7 @@ def test_handler_rolls_back_and_requeues_on_a_db_error_during_the_insert_loop():
         worker._handle_backfill_repo_events(conn, 5, _payload(), 0)
 
     assert conn.rolled_back is True
-    sql, params = conn._cursor.calls[0]
+    sql, _params = conn._cursor.calls[0]
     assert "status='queued'" in sql  # requeued, not stuck in 'processing'
 
 

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -1,0 +1,374 @@
+"""Tests for the install-time activity backfill (issue #191/S5 PR 1)."""
+
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import httpx
+import psycopg
+import pytest
+
+import backfill
+import worker
+from _crypto import encrypt_job_token
+from config import settings
+
+_DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+
+
+# ---------------------------------------------------------------------------
+# backfill.py: pure unit tests (no DB, no worker.py job machinery)
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_all_five_tracked_types():
+    assert backfill._summarize("push", {"size": 2, "ref": "refs/heads/main"}) == "pushed 2 commits to main"
+    assert (
+        backfill._summarize("pull_request", {"action": "opened", "number": 7, "pull_request": {"title": "Add widgets"}})
+        == "opened PR #7: Add widgets"
+    )
+    assert (
+        backfill._summarize(
+            "pull_request", {"action": "closed", "number": 7, "pull_request": {"title": "Add widgets", "merged": True}}
+        )
+        == "merged PR #7: Add widgets"
+    )
+    assert backfill._summarize("issues", {"action": "opened", "issue": {"number": 3, "title": "Bug"}}) == "opened issue #3: Bug"
+    assert backfill._summarize("release", {"release": {"tag_name": "v1.2.3"}}) == "created release v1.2.3"
+    assert backfill._summarize("create", {"ref_type": "branch", "ref": "feature-x"}) == "created branch feature-x"
+
+
+def test_summarize_unknown_type_returns_the_type_itself():
+    assert backfill._summarize("deployment", {}) == "deployment"
+
+
+def _raw_event(event_type="PushEvent", **overrides):
+    event = {
+        "id": "111",
+        "type": event_type,
+        "actor": {"login": "octocat", "avatar_url": "https://example.com/a.png"},
+        "repo": {"name": "acme/widgets"},
+        "payload": {"size": 1, "ref": "refs/heads/main"},
+        "created_at": "2026-08-21T00:30:00Z",
+    }
+    event.update(overrides)
+    return event
+
+
+def test_normalize_maps_a_known_type():
+    normalized = backfill.normalize(_raw_event())
+    assert normalized["delivery_id"] == "backfill:111"
+    assert normalized["event_type"] == "push"
+    assert normalized["actor"] == "octocat"
+    assert normalized["actor_avatar"] == "https://example.com/a.png"
+    assert normalized["repo"] == "acme/widgets"
+    assert normalized["summary"] == "pushed 1 commit to main"
+    assert normalized["occurred_at"].isoformat() == "2026-08-21T00:30:00+00:00"
+
+
+def test_normalize_skips_an_untracked_event_type():
+    assert backfill.normalize(_raw_event(event_type="WatchEvent")) is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"id": None},
+        {"repo": {}},
+        {"created_at": None},
+        {"created_at": "not-a-timestamp"},
+    ],
+)
+def test_normalize_returns_none_for_missing_or_malformed_fields(overrides):
+    assert backfill.normalize(_raw_event(**overrides)) is None
+
+
+class _FakeResponse:
+    def __init__(self, json_data, links=None, status_code=200):
+        self._json_data = json_data
+        self.links = links or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=MagicMock(), response=self)
+
+    def json(self):
+        return self._json_data
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def get(self, url, headers=None, params=None):
+        self.calls.append((url, params))
+        return self._responses.pop(0)
+
+
+def test_fetch_events_follows_the_link_header():
+    page1 = _FakeResponse([_raw_event(id="1")], links={"next": {"url": "https://api.github.com/orgs/acme/events?page=2"}})
+    page2 = _FakeResponse([_raw_event(id="2")])
+    client = _FakeClient([page1, page2])
+
+    events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1", "2"]
+    assert client.calls[0][0] == "https://api.github.com/orgs/acme/events"
+    assert client.calls[1][0] == "https://api.github.com/orgs/acme/events?page=2"
+
+
+def test_fetch_events_stops_at_the_page_cap():
+    pages = [
+        _FakeResponse([_raw_event(id=str(i))], links={"next": {"url": f"https://api.github.com/orgs/acme/events?page={i + 1}"}})
+        for i in range(5)
+    ]
+    client = _FakeClient(pages)
+
+    events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert len(events) == backfill._MAX_PAGES
+    assert len(client.calls) == backfill._MAX_PAGES
+
+
+def test_fetch_events_uses_the_user_events_path_for_personal_installs():
+    client = _FakeClient([_FakeResponse([])])
+    backfill.fetch_events(client, "https://api.github.com", {}, "octocat", "User")
+    assert client.calls[0][0] == "https://api.github.com/users/octocat/events"
+
+
+# ---------------------------------------------------------------------------
+# worker._handle_backfill_repo_events: error paths, mirroring
+# test_process_job.py's _FakeConn/_FakeCursor + patch("worker.httpx.Client") convention
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+
+    def fetchone(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _FakeConn:
+    def __init__(self):
+        self.committed = False
+        self._cursor = _FakeCursor()
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+
+def _payload(**kwargs):
+    enc = encrypt_job_token("secret", settings.job_secret_key.get_secret_value())
+    return json.dumps({"tenant_id": 1, "account_login": "acme", "account_type": "Organization", "token": enc, **kwargs})
+
+
+def test_handler_marks_failed_on_invalid_payload():
+    conn = _FakeConn()
+    worker._handle_backfill_repo_events(conn, 1, "{}", 0)
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+
+
+def test_handler_marks_failed_on_undecryptable_token():
+    conn = _FakeConn()
+    bad_payload = json.dumps({"tenant_id": 1, "account_login": "acme", "account_type": "Organization", "token": "not-encrypted"})
+    worker._handle_backfill_repo_events(conn, 1, bad_payload, 0)
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+
+
+def test_handler_marks_failed_on_4xx_from_github():
+    conn = _FakeConn()
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.side_effect = ValueError("not json")
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get = MagicMock(return_value=mock_response)
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=MagicMock(), response=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        worker._handle_backfill_repo_events(conn, 2, _payload(), 0)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert "GitHub API error" in params[0]
+
+
+def test_handler_requeues_on_5xx_from_github():
+    conn = _FakeConn()
+    mock_response = MagicMock()
+    mock_response.status_code = 502
+    mock_response.json.side_effect = ValueError("not json")
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get = MagicMock(return_value=mock_response)
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("error", request=MagicMock(), response=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        worker._handle_backfill_repo_events(conn, 3, _payload(), 0)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='queued'" in sql  # requeued, not failed -- retry_count 0 -> 1, well under MAX_RETRIES
+
+
+def test_handler_requeues_on_network_error():
+    conn = _FakeConn()
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get = MagicMock(side_effect=httpx.RequestError("connection reset"))
+        mock_client_cls.return_value = mock_client
+
+        worker._handle_backfill_repo_events(conn, 4, _payload(), 0)
+
+    sql, params = conn._cursor.calls[0]
+    assert "status='queued'" in sql
+
+
+# ---------------------------------------------------------------------------
+# worker._handle_backfill_repo_events: real Postgres, verifying the actual
+# repo_events / repo_event_daily_counts side effects (mirrors test_event_consumer.py's
+# pg_conn/tenant_id fixture pattern -- kept file-local rather than shared via conftest.py,
+# matching how each worker test file already owns its own fixtures except worker_db).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def pg_conn():
+    conn = psycopg.connect(_DB_URL, autocommit=False)
+    try:
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.fixture()
+def tenant_id(pg_conn):
+    email = "s5-backfill-tests@example.com"
+    with pg_conn.cursor() as cur:
+        cur.execute("SELECT id FROM users WHERE lower(email) = lower(%s)", (email,))
+        row = cur.fetchone()
+        user_id = row[0] if row else None
+        if user_id is None:
+            cur.execute("INSERT INTO users (email) VALUES (%s) RETURNING id", (email,))
+            user_id = cur.fetchone()[0]
+        cur.execute("SELECT id FROM tenants WHERE personal_user_id = %s", (user_id,))
+        row = cur.fetchone()
+        result = row[0] if row else None
+        if result is None:
+            cur.execute("INSERT INTO tenants (kind, personal_user_id) VALUES ('personal', %s) RETURNING id", (user_id,))
+            result = cur.fetchone()[0]
+    pg_conn.commit()
+    return result
+
+
+def _mock_github_client(events: list[dict]):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.links = {}
+    mock_response.json = MagicMock(return_value=events)
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get = MagicMock(return_value=mock_response)
+    return mock_client
+
+
+def _repo_events_count(conn, tenant_id, repo):
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute("SELECT count(*) FROM repo_events WHERE repo = %s AND tenant_id = %s", (repo, tenant_id))
+        return cur.fetchone()[0]
+
+
+def _daily_count(conn, tenant_id, repo, event_type, day):
+    with conn.cursor() as cur:
+        cur.execute(f"SET app.tenant_id = {int(tenant_id)}")
+        cur.execute(
+            "SELECT count FROM repo_event_daily_counts WHERE tenant_id = %s AND repo = %s AND event_type = %s AND day = %s",
+            (tenant_id, repo, event_type, day),
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _payload_for(tenant_id: int, account_login: str = "acme", account_type: str = "Organization") -> str:
+    enc = encrypt_job_token("secret", settings.job_secret_key.get_secret_value())
+    return json.dumps({"tenant_id": tenant_id, "account_login": account_login, "account_type": account_type, "token": enc})
+
+
+def test_handler_inserts_events_and_daily_counts(pg_conn, tenant_id):
+    repo = "acme/backfill-fresh"
+    events = [
+        _raw_event(id="b-fresh-1", event_type="PushEvent", repo={"name": repo}),
+        _raw_event(id="b-fresh-2", event_type="IssuesEvent", payload={"action": "opened", "issue": {"number": 1, "title": "Bug"}}, repo={"name": repo}),
+    ]
+
+    with patch("worker.httpx.Client", return_value=_mock_github_client(events)):
+        worker._handle_backfill_repo_events(pg_conn, 100, _payload_for(tenant_id), 0)
+
+    assert _repo_events_count(pg_conn, tenant_id, repo) == 2
+    assert _daily_count(pg_conn, tenant_id, repo, "push", date(2026, 8, 21)) == 1
+    assert _daily_count(pg_conn, tenant_id, repo, "issues", date(2026, 8, 21)) == 1
+
+
+def test_handler_skips_untracked_event_types(pg_conn, tenant_id):
+    repo = "acme/backfill-skip"
+    events = [_raw_event(id="b-skip-1", event_type="WatchEvent", repo={"name": repo})]
+
+    with patch("worker.httpx.Client", return_value=_mock_github_client(events)):
+        worker._handle_backfill_repo_events(pg_conn, 101, _payload_for(tenant_id), 0)
+
+    assert _repo_events_count(pg_conn, tenant_id, repo) == 0
+
+
+def test_handler_rerun_is_idempotent(pg_conn, tenant_id):
+    repo = "acme/backfill-dedupe"
+    events = [_raw_event(id="b-dedupe-1", event_type="CreateEvent", payload={"ref_type": "tag", "ref": "v1"}, repo={"name": repo})]
+
+    with patch("worker.httpx.Client", return_value=_mock_github_client(events)):
+        worker._handle_backfill_repo_events(pg_conn, 102, _payload_for(tenant_id), 0)
+        worker._handle_backfill_repo_events(pg_conn, 103, _payload_for(tenant_id), 0)  # simulates a retried/re-triggered job
+
+    assert _repo_events_count(pg_conn, tenant_id, repo) == 1
+    assert _daily_count(pg_conn, tenant_id, repo, "create", date(2026, 8, 21)) == 1
+
+
+def test_handler_uses_the_user_events_path_for_personal_installs(pg_conn, tenant_id):
+    repo = "octocat/personal-repo"
+    events = [_raw_event(id="b-personal-1", event_type="PushEvent", repo={"name": repo})]
+    mock_client = _mock_github_client(events)
+
+    with patch("worker.httpx.Client", return_value=mock_client):
+        worker._handle_backfill_repo_events(pg_conn, 104, _payload_for(tenant_id, account_login="octocat", account_type="User"), 0)
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "/users/octocat/events" in called_url
+    assert _repo_events_count(pg_conn, tenant_id, repo) == 1

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -164,6 +164,7 @@ class _FakeCursor:
 class _FakeConn:
     def __init__(self):
         self.committed = False
+        self.rolled_back = False
         self._cursor = _FakeCursor()
 
     def cursor(self):
@@ -171,6 +172,9 @@ class _FakeConn:
 
     def commit(self):
         self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
 
 
 def _payload(**kwargs):
@@ -248,6 +252,43 @@ def test_handler_requeues_on_network_error():
 
     sql, params = conn._cursor.calls[0]
     assert "status='queued'" in sql
+
+
+class _FailingCursor(_FakeCursor):
+    """Raises on the first execute() (the SET app.tenant_id call) to simulate a genuine
+    DB error mid-insert-loop -- e.g. a constraint violation or serialization failure.
+    Subsequent execute() calls succeed, same as _requeue_for_retry's own UPDATE would
+    against a real connection once its rollback() has cleared the aborted transaction."""
+
+    has_failed = False
+
+    def execute(self, sql, params=None):
+        if not self.has_failed:
+            self.has_failed = True
+            raise psycopg.OperationalError("simulated database failure")
+        super().execute(sql, params)
+
+
+class _FailingConn(_FakeConn):
+    def __init__(self):
+        super().__init__()
+        self._cursor = _FailingCursor()
+
+
+def test_handler_rolls_back_and_requeues_on_a_db_error_during_the_insert_loop():
+    # CodeRabbit finding on #342: without a rollback here, the connection's transaction
+    # stays aborted and the _mark_failed/_requeue_for_retry UPDATE that follows would
+    # itself raise InFailedSqlTransaction, leaving the job stuck in 'processing' forever
+    # instead of being requeued.
+    conn = _FailingConn()
+    events = [_raw_event(id="b-db-error-1")]
+
+    with patch("worker.httpx.Client", return_value=_mock_github_client(events)):
+        worker._handle_backfill_repo_events(conn, 5, _payload(), 0)
+
+    assert conn.rolled_back is True
+    sql, params = conn._cursor.calls[0]
+    assert "status='queued'" in sql  # requeued, not stuck in 'processing'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

S5 PR1 (issue #192) — the first slice of S5 ("Reconciliation/backfill + scheduler"). Issue #192 carries the same "not planned for near-term implementation, don't pick up without explicit decision" warning #191 (S4) had; overridden the same way, by explicit decision to continue through the roadmap in order now that S4 (PRs #340/#341) is done.

Full S5 per the issue is large: install-time backfill + scheduled gap-healing + a per-tenant/repo sync cursor table + a real recurring-job/scheduler mechanism — none of which exist today (confirmed: no cursor/checkpoint tracking anywhere in the schema, and the `jobs` table has no recurring/cron primitive, only enqueue-once). This PR is scoped to the smallest real, independently shippable first step: **backfill recent activity once, at install time, using the same GitHub Events API the live Activity Feed already calls.**

## What changed and why

- **`apps/worker/src/backfill.py`** (new) — pure logic: paginates `GET /orgs/{login}/events` (org installs) or `GET /users/{login}/events` (personal installs) via `httpx`, following `Link: rel="next"` up to a self-imposed 3-page cap (GitHub's own Events API already caps total results at ~300). Maps only the 5 event types S4's webhook consumer already tracks (`push`/`pull_request`/`issues`/`release`/`create`) to the same lowercase vocabulary, so a `repo_events` row looks the same regardless of source. Uses a synthetic `delivery_id` (`backfill:<github event id>`) so re-running the job (a retry, or a second install-sync call) is naturally idempotent.
- **`apps/worker/src/repo_events_store.py`** (new) — the insert-into-`repo_events`-then-upsert-`repo_event_daily_counts` logic, **factored out of `event_consumer.py`'s `_process_entry`** so both the S4 webhook consumer and this new backfill job share one implementation instead of a second in-service copy. Also fixes a duplicated comment block that had landed in `event_consumer.py` in the previous PR.
- **`apps/worker/src/worker.py`** — new job type `github.backfill_repo_events`, handled by `_handle_backfill_repo_events`, registered in `JOB_HANDLERS`. Runs through the *existing* jobs poll loop (`SELECT ... FOR UPDATE SKIP LOCKED`, heartbeat, retry/failure handling) rather than a new execution path — same error-handling shape as `_handle_clear_actions_cache` (network error / 5xx → requeue, 4xx → fail).
- **`apps/api/src/services/backfill_service.py`** (new) — mirrors `cache_service.clear()`'s exact job-enqueue pattern (Fernet-encrypt the token, insert a `jobs` row).
- **`apps/api/src/routers/installations.py`** — both `sync_org_installation` and `sync_personal_installation` now enqueue a backfill job right after a successful install. **A token-resolution or enqueue failure is caught and logged, never fails the install response** — the install already succeeded by that point; backfill is best-effort enrichment, not a precondition of a working install.

**Not a schema change** — no migration in this PR.

**Deliberately out of scope, not oversights:**
- Scheduled gap-healing (recurring re-sync to catch webhooks missed during downtime) — needs a real recurring-job/cron mechanism that doesn't exist anywhere in this codebase yet.
- True deep historical backfill beyond the Events API's own cap (composing from commits/PRs/issues REST endpoints) — separate PR, only worth it once there's a concrete product need for more than "recent activity."
- A per-tenant/repo sync cursor/checkpoint table — not needed for a one-shot, GitHub-capped job with no resume requirement.
- Backfilling *existing* installations that connected before this PR ships — only new installs going forward get this.

## Test plan

- [x] `pytest -q apps/worker/tests/test_backfill.py` — 20 new tests: event-type mapping (all 5 + unknown-skip), pagination (`Link` header follow + page cap), personal-vs-org endpoint selection, error paths (invalid payload, undecryptable token, 4xx fail, 5xx/network requeue) mirroring `test_process_job.py`'s mocking convention, and real-Postgres integration tests confirming `repo_events`/`repo_event_daily_counts` rows land correctly, including idempotency on a re-run
- [x] `pytest -q apps/api/tests/test_installations.py` — 3 new tests: org/personal sync enqueues a job when a token is available, org sync still succeeds (200, no job) when no token is available
- [x] Full `pytest -q` — 704 passed, 3 skipped, 3 xpassed, against a freshly reset local Postgres + a locally-mapped Redis
- [x] `alembic check` — no drift (no schema change)
- [x] `bun run check` (typecheck + lint + build) — clean, enforced by the `pre-commit`/`pre-push` hooks on this PR's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly connected installations automatically import recent GitHub activity.
  * Supports organization and personal installations.
  * Imports supported repository events and daily activity totals.
  * Retries temporary failures and prevents duplicate activity records.

* **Bug Fixes**
  * Installation setup remains successful when activity backfill cannot be completed or no token is available.
  * Invalid or unsupported activity data is safely skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->