### PR TITLE
fix(worker): retry rate-limited GitHub Events API requests during backfill

### DIFF
--- a/apps/worker/src/backfill.py
+++ b/apps/worker/src/backfill.py
@@ -20,6 +20,7 @@ in apps/api/src/routers/github.py) -- repo_events itself stores every actor unfi
 regardless of source; filtering is a read-time/display concern, not a storage concern.
 """
 
+import time
 from datetime import datetime
 
 import httpx
@@ -28,6 +29,59 @@ import httpx
 # the primary limit, just a bound so a pathological Link-header loop can't run forever.
 _MAX_PAGES = 3
 _PER_PAGE = 100
+
+# Cap on honoring a server-supplied Retry-After value, so a single malformed/huge value
+# can't block a job for an unreasonable amount of time -- GitHub's real rate-limit
+# Retry-After values are ordinarily well under this. Same value as
+# packages/checks/src/checks/github_checks.py's own _MAX_RETRY_AFTER_SECONDS.
+_MAX_RETRY_AFTER_SECONDS = 60
+
+
+def _is_secondary_rate_limit(resp: httpx.Response) -> bool:
+    """GitHub's secondary/abuse rate limit commonly returns 403 (not 429), often with a
+    Retry-After header. Without this, a 403 that would succeed on retry raises immediately
+    instead of backing off like the 429 case already does. A genuine permission-denied 403
+    (token lacks scope) has neither header, so it's unaffected and still surfaces immediately.
+    Duplicated from apps/api/src/services/github_client.py and
+    packages/checks/src/checks/github_checks.py's own copies -- apps/worker doesn't import
+    apps/api, same precedent as this module's own _summarize duplicating github.py's."""
+    if resp.status_code != 403:
+        return False
+    return "Retry-After" in resp.headers or resp.headers.get("X-RateLimit-Remaining") == "0"
+
+
+def _retry_delay_seconds(resp: httpx.Response, attempt: int) -> float:
+    """Prefer the server's own Retry-After value (GitHub's rate-limit responses include one)
+    over a blind exponential backoff -- retrying before the window it asked for just burns
+    the fixed attempt budget hitting the same limit again."""
+    raw = resp.headers.get("Retry-After")
+    if raw is not None:
+        try:
+            return min(float(raw), _MAX_RETRY_AFTER_SECONDS)
+        except ValueError:
+            pass
+    return 2**attempt
+
+
+def _get_with_retry(client: httpx.Client, url: str, headers: dict, params: dict | None) -> httpx.Response:
+    """Same retry/backoff contract as GitHubClient.request and github_checks.py's own
+    _get_with_retry: 3 attempts, exponential backoff on a connection error, Retry-After-aware
+    backoff on a 429/secondary-403 rate limit or a presumed-transient 5xx. Absorbs a rate
+    limit here instead of burning a whole job attempt via worker.py's outer requeue -- issue
+    #192 calls out that this didn't happen previously."""
+    for attempt in range(3):
+        try:
+            resp = client.get(url, headers=headers, params=params)
+        except httpx.RequestError:
+            if attempt < 2:
+                time.sleep(2**attempt)
+                continue
+            raise
+        if (resp.status_code == 429 or _is_secondary_rate_limit(resp) or resp.status_code >= 500) and attempt < 2:
+            time.sleep(_retry_delay_seconds(resp, attempt))
+            continue
+        return resp
+    raise RuntimeError("request loop exhausted without returning")
 
 _EVENT_TYPE_MAP = {
     "PushEvent": "push",
@@ -48,13 +102,15 @@ def _events_path(account_login: str, account_type: str) -> str:
 
 def fetch_events(client: httpx.Client, base: str, headers: dict, account_login: str, account_type: str) -> list[dict]:
     """Follows the Link: rel="next" header (httpx parses it into response.links) up to
-    _MAX_PAGES. Raises httpx.HTTPStatusError/RequestError on failure -- callers map
-    those to the same requeue/fail decision worker.py's other job handlers already use."""
+    _MAX_PAGES. Each page is fetched via _get_with_retry, which absorbs a transient rate
+    limit/5xx internally (3 attempts) before this ever raises. Still raises
+    httpx.HTTPStatusError/RequestError once retries are exhausted -- callers map those to
+    the same requeue/fail decision worker.py's other job handlers already use."""
     events: list[dict] = []
     url = f"{base}{_events_path(account_login, account_type)}"
     params: dict | None = {"per_page": _PER_PAGE}
     for _ in range(_MAX_PAGES):
-        resp = client.get(url, headers=headers, params=params)
+        resp = _get_with_retry(client, url, headers, params)
         resp.raise_for_status()
         page = resp.json()
         if not isinstance(page, list):

--- a/apps/worker/src/backfill.py
+++ b/apps/worker/src/backfill.py
@@ -53,13 +53,32 @@ def _is_secondary_rate_limit(resp: httpx.Response) -> bool:
 def _retry_delay_seconds(resp: httpx.Response, attempt: int) -> float:
     """Prefer the server's own Retry-After value (GitHub's rate-limit responses include one)
     over a blind exponential backoff -- retrying before the window it asked for just burns
-    the fixed attempt budget hitting the same limit again."""
+    the fixed attempt budget hitting the same limit again. Falls back to X-RateLimit-Reset
+    (epoch seconds) when Retry-After is absent -- GitHub's own docs say to wait until that
+    reset time when X-RateLimit-Remaining is 0 but no Retry-After was sent (found on this
+    PR's own review; the two other copies of this retry contract in this codebase don't
+    handle this case either, so this is a deliberate improvement over parity with them, not
+    a regression). Both paths are capped at _MAX_RETRY_AFTER_SECONDS for the same reason
+    Retry-After itself is capped. If neither header is usable, a 429 or a secondary-limit
+    403 still waits the full cap (GitHub's documented minimum backoff for a rate limit)
+    rather than a fast exponential retry that would just hit the same limit again; any other
+    status (a plain 5xx) falls back to exponential, unchanged."""
     raw = resp.headers.get("Retry-After")
     if raw is not None:
         try:
             return min(float(raw), _MAX_RETRY_AFTER_SECONDS)
         except ValueError:
             pass
+    reset_raw = resp.headers.get("X-RateLimit-Reset")
+    if reset_raw is not None:
+        try:
+            delay = float(reset_raw) - time.time()
+            if delay > 0:
+                return min(delay, _MAX_RETRY_AFTER_SECONDS)
+        except ValueError:
+            pass
+    if resp.status_code == 429 or _is_secondary_rate_limit(resp):
+        return _MAX_RETRY_AFTER_SECONDS
     return 2**attempt
 
 

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -181,7 +181,9 @@ def test_fetch_events_retries_a_secondary_rate_limit_403_via_remaining_header():
 
 
 def test_fetch_events_retries_a_secondary_rate_limit_403_with_a_malformed_retry_after():
-    # A non-numeric Retry-After must fall back to exponential backoff rather than crash.
+    # A non-numeric Retry-After must not crash -- it's still a secondary-rate-limit response
+    # (the header's presence, not its validity, is what _is_secondary_rate_limit checks), so
+    # this falls through to the conservative _MAX_RETRY_AFTER_SECONDS wait, not a fast retry.
     rate_limited = _FakeResponse({}, status_code=403, headers={"Retry-After": "not-a-number"})
     success = _FakeResponse([_raw_event(id="1")])
     client = _FakeClient([rate_limited, success])
@@ -190,7 +192,37 @@ def test_fetch_events_retries_a_secondary_rate_limit_403_with_a_malformed_retry_
         events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
 
     assert [e["id"] for e in events] == ["1"]
-    mock_sleep.assert_called_once_with(1)  # 2**0
+    mock_sleep.assert_called_once_with(backfill._MAX_RETRY_AFTER_SECONDS)
+
+
+def test_retry_delay_seconds_caps_a_large_retry_after():
+    resp = _FakeResponse({}, status_code=429, headers={"Retry-After": "600"})
+    assert backfill._retry_delay_seconds(resp, 0) == backfill._MAX_RETRY_AFTER_SECONDS
+
+
+def test_retry_delay_seconds_uses_x_rate_limit_reset_when_retry_after_is_absent():
+    resp = _FakeResponse({}, status_code=403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1000030"})
+    with patch("backfill.time.time", return_value=1000000.0):
+        assert backfill._retry_delay_seconds(resp, 0) == 30.0
+
+
+def test_retry_delay_seconds_caps_a_far_future_x_rate_limit_reset():
+    resp = _FakeResponse({}, status_code=403, headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1010000"})
+    with patch("backfill.time.time", return_value=1000000.0):
+        assert backfill._retry_delay_seconds(resp, 0) == backfill._MAX_RETRY_AFTER_SECONDS
+
+
+def test_retry_delay_seconds_ignores_a_past_x_rate_limit_reset():
+    # A reset timestamp already in the past (clock skew, or the header lagging reality)
+    # must not produce a negative sleep -- fall through to the rate-limit default instead.
+    resp = _FakeResponse({}, status_code=429, headers={"X-RateLimit-Reset": "999900"})
+    with patch("backfill.time.time", return_value=1000000.0):
+        assert backfill._retry_delay_seconds(resp, 0) == backfill._MAX_RETRY_AFTER_SECONDS
+
+
+def test_retry_delay_seconds_falls_back_to_exponential_for_a_plain_5xx():
+    resp = _FakeResponse({}, status_code=502)
+    assert backfill._retry_delay_seconds(resp, 1) == 2
 
 
 def test_fetch_events_does_not_retry_a_genuine_permission_403():

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -84,10 +84,11 @@ def test_normalize_returns_none_for_missing_or_malformed_fields(overrides):
 
 
 class _FakeResponse:
-    def __init__(self, json_data, links=None, status_code=200):
+    def __init__(self, json_data, links=None, status_code=200, headers=None):
         self._json_data = json_data
         self.links = links or {}
         self.status_code = status_code
+        self.headers = headers or {}
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -136,6 +137,100 @@ def test_fetch_events_uses_the_user_events_path_for_personal_installs():
     client = _FakeClient([_FakeResponse([])])
     backfill.fetch_events(client, "https://api.github.com", {}, "octocat", "User")
     assert client.calls[0][0] == "https://api.github.com/users/octocat/events"
+
+
+# ---------------------------------------------------------------------------
+# _get_with_retry / fetch_events: GitHub rate-limit retry (issue #192 fast-follow)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_events_retries_a_429_and_succeeds():
+    rate_limited = _FakeResponse({}, status_code=429)
+    success = _FakeResponse([_raw_event(id="1")])
+    client = _FakeClient([rate_limited, success])
+
+    with patch("backfill.time.sleep") as mock_sleep:
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+    assert len(client.calls) == 2
+    mock_sleep.assert_called_once()
+
+
+def test_fetch_events_retries_a_secondary_rate_limit_403_with_retry_after():
+    rate_limited = _FakeResponse({}, status_code=403, headers={"Retry-After": "5"})
+    success = _FakeResponse([_raw_event(id="1")])
+    client = _FakeClient([rate_limited, success])
+
+    with patch("backfill.time.sleep") as mock_sleep:
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+    mock_sleep.assert_called_once_with(5.0)
+
+
+def test_fetch_events_retries_a_secondary_rate_limit_403_via_remaining_header():
+    rate_limited = _FakeResponse({}, status_code=403, headers={"X-RateLimit-Remaining": "0"})
+    success = _FakeResponse([_raw_event(id="1")])
+    client = _FakeClient([rate_limited, success])
+
+    with patch("backfill.time.sleep"):
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+
+
+def test_fetch_events_does_not_retry_a_genuine_permission_403():
+    forbidden = _FakeResponse({}, status_code=403)  # no Retry-After, no X-RateLimit-Remaining
+    client = _FakeClient([forbidden])
+
+    with patch("backfill.time.sleep") as mock_sleep:
+        with pytest.raises(httpx.HTTPStatusError):
+            backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert len(client.calls) == 1
+    mock_sleep.assert_not_called()
+
+
+def test_fetch_events_raises_after_exhausting_all_retries():
+    responses = [_FakeResponse({}, status_code=429) for _ in range(3)]
+    client = _FakeClient(responses)
+
+    with patch("backfill.time.sleep"):
+        with pytest.raises(httpx.HTTPStatusError):
+            backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert len(client.calls) == 3
+
+
+def test_fetch_events_retries_a_5xx():
+    server_error = _FakeResponse({}, status_code=502)
+    success = _FakeResponse([_raw_event(id="1")])
+    client = _FakeClient([server_error, success])
+
+    with patch("backfill.time.sleep"):
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+
+
+def test_fetch_events_retries_a_connection_error_then_succeeds():
+    success = _FakeResponse([_raw_event(id="1")])
+
+    class _FlakyClient(_FakeClient):
+        def get(self, url, headers=None, params=None):
+            self.calls.append((url, params))
+            if len(self.calls) == 1:
+                raise httpx.RequestError("connection reset")
+            return self._responses.pop(0)
+
+    client = _FlakyClient([success])
+
+    with patch("backfill.time.sleep"):
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+    assert len(client.calls) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/apps/worker/tests/test_backfill.py
+++ b/apps/worker/tests/test_backfill.py
@@ -180,6 +180,19 @@ def test_fetch_events_retries_a_secondary_rate_limit_403_via_remaining_header():
     assert [e["id"] for e in events] == ["1"]
 
 
+def test_fetch_events_retries_a_secondary_rate_limit_403_with_a_malformed_retry_after():
+    # A non-numeric Retry-After must fall back to exponential backoff rather than crash.
+    rate_limited = _FakeResponse({}, status_code=403, headers={"Retry-After": "not-a-number"})
+    success = _FakeResponse([_raw_event(id="1")])
+    client = _FakeClient([rate_limited, success])
+
+    with patch("backfill.time.sleep") as mock_sleep:
+        events = backfill.fetch_events(client, "https://api.github.com", {}, "acme", "Organization")
+
+    assert [e["id"] for e in events] == ["1"]
+    mock_sleep.assert_called_once_with(1)  # 2**0
+
+
 def test_fetch_events_does_not_retry_a_genuine_permission_403():
     forbidden = _FakeResponse({}, status_code=403)  # no Retry-After, no X-RateLimit-Remaining
     client = _FakeClient([forbidden])


### PR DESCRIPTION
## Summary

Fast-follow to PR #343 (S5 PR 2), explicitly flagged there and called out by name in issue #192:
`apps/worker/src/backfill.py`'s `fetch_events` raised immediately on any non-5xx GitHub response,
including 429/secondary-403 rate-limit responses, instead of retrying. That meant a rate limit hit
burned a whole job attempt via `worker.py`'s job-level `MAX_RETRIES` requeue rather than being
absorbed by a much cheaper in-request backoff.

- Adds `_get_with_retry` (3 attempts, `Retry-After`-aware backoff, falls back to exponential when
  the server doesn't supply one) and `_is_secondary_rate_limit` (GitHub's abuse/secondary rate
  limit is commonly a 403 with a `Retry-After` or `X-RateLimit-Remaining: 0` header, not a 429) to
  `backfill.py`.
- This duplicates the exact retry contract already independently implemented in
  `apps/api/src/services/github_client.py` and `packages/checks/src/checks/github_checks.py` — a
  third duplicate rather than a shared import, matching this codebase's established precedent that
  `apps/worker` never imports `apps/api`.
- `fetch_events` still raises `httpx.HTTPStatusError`/`RequestError` once the 3 attempts are
  exhausted, so `worker.py`'s existing 5xx-requeue/4xx-fail job-level handling is unchanged — this
  only changes what happens *before* that raise.

**No schema change, no sensitive files touched.**

## Test plan

- [x] New tests in `apps/worker/tests/test_backfill.py`: a 429 retried and succeeded; a
  secondary-rate-limit 403 retried via `Retry-After`; a secondary-rate-limit 403 retried via
  `X-RateLimit-Remaining: 0`; a genuine permission 403 (neither header) does NOT retry and raises
  immediately; all 3 attempts exhausted still raises; a plain 5xx still retries; a connection error
  still retries. Verified by reverting the fix and confirming all 7 new tests failed first (module
  didn't even expose `_get_with_retry` yet), then restoring it.
- [x] `pytest -q` — 735 passed (up from 728), against a freshly reset local Postgres + a temporary
  standalone Redis container.
- [x] `ruff check apps/worker/src apps/worker/tests` clean.
- [x] `bun run check` (typecheck + lint + build) clean — no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving GitHub events by retrying transient connection failures, rate limits, and server errors.
  * Honors server-provided retry timing when available, with capped exponential backoff otherwise.
  * Preserves pagination and reports errors normally when retries are exhausted.
  * Avoids retrying genuine permission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->