### PR TITLE
feat(api): re-point the Activity Feed at repo_events for connected orgs

### DIFF
--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -203,7 +203,16 @@ def org_events(
     # below) avoids silently regressing it to an empty feed. Mirrors token_resolution.py's
     # own "prefer installation, fall back to client token" precedent, applied to the read
     # path instead of the auth path.
-    if installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=org_login) is not None:
+    #
+    # get_for_org's own filter only matches on org_id/account_login (it's a general lookup,
+    # also used to just display "is something connected" in list endpoints) -- a row can
+    # exist with installation_id IS NULL (e.g. sync_org_installation's known-admin path lets
+    # a caller re-sync org metadata without a real installation_id). Checking
+    # installation_id here too, rather than widening get_for_org itself, mirrors
+    # token_resolution.py's _from_installation, which guards the exact same gap at its own
+    # call site instead of baking the check into the shared repository function.
+    installation = installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=org_login)
+    if installation is not None and installation.installation_id is not None:
         return _fetch_events_from_repo_events(db, org_login, ctx.org.tenant_id, payload.per_page)
 
     client_token = payload.token.get_secret_value() if payload.token else None

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -20,8 +20,9 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from src.core.db import get_db
+from src.core.db import RepoEvent, get_db
 from src.core.rbac import OrgContext, require_org_role
+from src.repositories import installation_repo
 from src.schemas.github import (
     FailedRunsInput,
     FailedRunsResponse,
@@ -35,6 +36,19 @@ from src.schemas.github import (
 )
 from src.services.github_client import GitHubClient, github_error as _github_error
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token
+
+# repo_events.event_type is the lowercase vocabulary apps/worker's event_consumer.py and
+# backfill.py both write (issue #191/#192) -- the UI's event-feed.tsx filter chips match
+# against GitHub's own raw PascalCase event type strings (e.g. "PushEvent"), the same
+# strings the live-GitHub path below has always returned. Reversing the map here keeps
+# the response contract identical regardless of which path served it.
+_EVENT_TYPE_TO_GITHUB = {
+    "push": "PushEvent",
+    "pull_request": "PullRequestEvent",
+    "issues": "IssuesEvent",
+    "release": "ReleaseEvent",
+    "create": "CreateEvent",
+}
 
 router = APIRouter()
 
@@ -124,6 +138,37 @@ def _fetch_events(org_login: str, token: str, per_page: int) -> OrgEventsRespons
     return OrgEventsResponse(org=org_login, events=events)
 
 
+def _fetch_events_from_repo_events(db: Session, org_login: str, tenant_id: int, per_page: int) -> OrgEventsResponse:
+    """S6: serves the Activity Feed from the already-populated, already-fresh repo_events
+    table (S3 webhooks + S4 normalization + S5 install-time backfill/gap-healing) instead
+    of a live GitHub call -- no token, no GitHub rate-limit exposure, no cache needed (a
+    cheap indexed DB read doesn't need one). Relies on the tenant session context
+    require_org_role's dependency already set (RLS, migration 0036) -- tenant_id is passed
+    through explicitly only for the WHERE clause, not to re-establish that context.
+    Bot-filtered here at read time, matching backfill.py's own note that repo_events itself
+    stores every actor unfiltered by design (filtering is a display concern, not storage)."""
+    rows = (
+        db.query(RepoEvent)
+        .filter(RepoEvent.tenant_id == tenant_id, ~RepoEvent.actor.like("%[bot]"))
+        .order_by(RepoEvent.occurred_at.desc())
+        .limit(per_page)
+        .all()
+    )
+    events = [
+        OrgEvent(
+            id=str(row.id),
+            type=_EVENT_TYPE_TO_GITHUB.get(row.event_type, row.event_type),
+            actor=row.actor,
+            actor_avatar=row.actor_avatar,
+            repo=row.repo,
+            summary=row.summary,
+            created_at=row.occurred_at,
+        )
+        for row in rows
+    ]
+    return OrgEventsResponse(org=org_login, events=events)
+
+
 def _evict_expired_events(now: float) -> None:
     # Same reasoning as repos.py's _evict_expired_stats: token_hash rotates hourly with
     # each fresh installation token, so stale keys would otherwise accumulate forever.
@@ -151,6 +196,16 @@ def org_events(
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
     db: Session = Depends(get_db),
 ):
+    # repo_events only ever gets rows for a tenant with a connected GitHub App
+    # installation -- webhooks, install-time backfill, and gap-healing (S3-S5) all require
+    # one. An org still on the legacy PAT-only path has no installation and therefore no
+    # repo_events rows; falling through to the live-GitHub path for that case (unchanged
+    # below) avoids silently regressing it to an empty feed. Mirrors token_resolution.py's
+    # own "prefer installation, fall back to client token" precedent, applied to the read
+    # path instead of the auth path.
+    if installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=org_login) is not None:
+        return _fetch_events_from_repo_events(db, org_login, ctx.org.tenant_id, payload.per_page)
+
     client_token = payload.token.get_secret_value() if payload.token else None
     try:
         token = resolve_org_token(db, org_id=ctx.org.id, account_login=org_login, client_token=client_token)

--- a/apps/api/tests/test_github_events.py
+++ b/apps/api/tests/test_github_events.py
@@ -384,6 +384,23 @@ def test_events_from_repo_events_maps_all_five_tracked_types_back_to_github_styl
     }
 
 
+def test_events_falls_back_to_live_github_when_the_installation_has_no_installation_id(events_client, db, acme_org):
+    # sync_org_installation's known-admin path lets a caller re-sync org metadata without a
+    # real installation_id -- that row exists (get_for_org finds it) but there's no actual
+    # App installation behind it, so no webhook/backfill pipeline ever populated
+    # repo_events for this tenant. Must not be treated as "connected" (issue found on this
+    # PR's own review).
+    installation_repo.create(db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=None, org_id=acme_org.id)
+
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [_PUSH_EVENT]
+        resp = events_client.post("/github/orgs/acme/events", json={"token": "ghp_testtoken123456789012345678901234"})
+
+    assert resp.status_code == 200
+    mock_client.assert_called_once()
+    assert resp.json()["events"][0]["actor"] == "alice"
+
+
 def test_events_falls_back_to_live_github_when_no_installation_is_connected(events_client, acme_org):
     # acme_org (no installation fixture) -- confirms the hybrid still uses the unchanged
     # live-GitHub path for a legacy PAT-only org, not an empty feed.

--- a/apps/api/tests/test_github_events.py
+++ b/apps/api/tests/test_github_events.py
@@ -1,16 +1,19 @@
 """Tests for the org events feed router (Phase 9 groundwork)."""
 
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.github import router as github_router
 from src.routers.github import _events_cache
-from unittest.mock import patch
 
 _ADMIN = UserOut(id=1, email="admin@example.com", name=None, is_workspace_admin=False)
 
@@ -269,3 +272,125 @@ def test_events_non_member_forbidden(db):
     client = TestClient(app)
     resp = client.post("/github/orgs/acme/events", json={})
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# S6: repo_events-backed path for orgs with a connected GitHub App installation
+# (issue #191/#192's ingestion pipeline -- S3 webhooks + S4 normalization + S5
+# backfill/gap-healing -- all require one, so this is the signal used to decide
+# which path serves a given org; see org_events's own comment).
+# ---------------------------------------------------------------------------
+
+
+def _insert_repo_event(db, tenant_id, *, delivery_id, event_type, actor, repo, summary, occurred_at):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_events (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at) "
+            "VALUES (:tenant_id, :delivery_id, :event_type, :actor, '', :repo, :summary, :occurred_at)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "delivery_id": delivery_id,
+            "event_type": event_type,
+            "actor": actor,
+            "repo": repo,
+            "summary": summary,
+            "occurred_at": occurred_at,
+        },
+    )
+    db.commit()
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id)
+    return acme_org
+
+
+def test_events_served_from_repo_events_when_an_installation_is_connected(events_client, db, acme_org_with_installation):
+    now = datetime.now(timezone.utc)
+    _insert_repo_event(
+        db, acme_org_with_installation.tenant_id,
+        delivery_id="d1", event_type="push", actor="alice", repo="acme/api", summary="pushed 2 commits to main", occurred_at=now,
+    )
+
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        resp = events_client.post("/github/orgs/acme/events", json={})
+
+    assert resp.status_code == 200
+    mock_client.assert_not_called()
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["type"] == "PushEvent"  # mapped back from repo_events' lowercase "push"
+    assert events[0]["actor"] == "alice"
+    assert events[0]["summary"] == "pushed 2 commits to main"
+
+
+def test_events_from_repo_events_orders_newest_first_and_respects_per_page(events_client, db, acme_org_with_installation):
+    now = datetime.now(timezone.utc)
+    for i in range(3):
+        _insert_repo_event(
+            db, acme_org_with_installation.tenant_id,
+            delivery_id=f"d{i}", event_type="push", actor="alice", repo="acme/api", summary=f"push {i}",
+            occurred_at=now - timedelta(minutes=3 - i),
+        )
+
+    resp = events_client.post("/github/orgs/acme/events", json={"per_page": 2})
+
+    assert resp.status_code == 200
+    summaries = [e["summary"] for e in resp.json()["events"]]
+    assert summaries == ["push 2", "push 1"]  # newest first, capped at per_page
+
+
+def test_events_from_repo_events_excludes_bot_actors(events_client, db, acme_org_with_installation):
+    now = datetime.now(timezone.utc)
+    _insert_repo_event(
+        db, acme_org_with_installation.tenant_id,
+        delivery_id="d1", event_type="push", actor="alice", repo="acme/api", summary="pushed", occurred_at=now,
+    )
+    _insert_repo_event(
+        db, acme_org_with_installation.tenant_id,
+        delivery_id="d2", event_type="push", actor="dependabot[bot]", repo="acme/api", summary="pushed", occurred_at=now,
+    )
+
+    resp = events_client.post("/github/orgs/acme/events", json={})
+
+    events = resp.json()["events"]
+    assert len(events) == 1
+    assert events[0]["actor"] == "alice"
+
+
+def test_events_from_repo_events_maps_all_five_tracked_types_back_to_github_style(
+    events_client, db, acme_org_with_installation
+):
+    now = datetime.now(timezone.utc)
+    for i, event_type in enumerate(["push", "pull_request", "issues", "release", "create"]):
+        _insert_repo_event(
+            db, acme_org_with_installation.tenant_id,
+            delivery_id=f"t{i}", event_type=event_type, actor="alice", repo="acme/api", summary=event_type,
+            occurred_at=now - timedelta(minutes=i),
+        )
+
+    resp = events_client.post("/github/orgs/acme/events", json={})
+
+    types_by_summary = {e["summary"]: e["type"] for e in resp.json()["events"]}
+    assert types_by_summary == {
+        "push": "PushEvent",
+        "pull_request": "PullRequestEvent",
+        "issues": "IssuesEvent",
+        "release": "ReleaseEvent",
+        "create": "CreateEvent",
+    }
+
+
+def test_events_falls_back_to_live_github_when_no_installation_is_connected(events_client, acme_org):
+    # acme_org (no installation fixture) -- confirms the hybrid still uses the unchanged
+    # live-GitHub path for a legacy PAT-only org, not an empty feed.
+    with patch("src.routers.github.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = [_PUSH_EVENT]
+        resp = events_client.post("/github/orgs/acme/events", json={"token": "ghp_testtoken123456789012345678901234"})
+
+    assert resp.status_code == 200
+    mock_client.assert_called_once()
+    assert resp.json()["events"][0]["actor"] == "alice"


### PR DESCRIPTION
## Summary

The ingestion pipeline built across S3-S5 (webhook receiver → event processors → `repo_events` →
install-time backfill + scheduled gap-healing) is fully shipped, but nothing in `apps/api` ever
read from it — the live Activity Feed still called GitHub synchronously on every page load. Per
`docs/plan.md`'s Stage → feature-module map, Phase 9 (Activity Feed) is gated by S3-S4, not S6, so
this re-point doesn't need to wait for the rest of S6's aggregates-API/SSE work.

- `POST /github/orgs/{org_login}/events` now checks whether the org has a connected GitHub App
  installation (`installation_repo.get_for_org`). If so, it serves from `repo_events` — RLS-scoped
  via the tenant context `require_org_role`'s dependency already establishes, bot-filtered at query
  time, ordered by `occurred_at desc`, capped at `per_page` — with **no GitHub call, no token, no
  rate-limit exposure**.
- An org still on the legacy PAT-only path has no installation and therefore no `repo_events` rows.
  That case falls through **unchanged** to the existing live-GitHub `_cached_events` path, so it
  isn't silently regressed to an empty feed. Mirrors `token_resolution.py`'s own "prefer
  installation, fall back to client token" precedent, applied to the read path instead of the auth
  path.
- `repo_events.event_type` is the lowercase vocabulary the worker writes
  (`push`/`pull_request`/`issues`/`release`/`create`); the UI's `event-feed.tsx` filter chips match
  GitHub's own PascalCase event type strings (`PushEvent`, etc.), so the response maps back
  explicitly — the `OrgEvent`/`OrgEventsResponse` contract stays byte-for-byte identical regardless
  of which path served it. **Zero UI changes.**

No schema change, no sensitive files touched (RBAC/auth code untouched — `require_org_role` is
reused exactly as-is).

## Why

This is real, immediately-usable value from S3-S5's work: instant Activity Feed loads with no
GitHub rate-limit exposure for any org that's connected the GitHub App, without waiting for the
rest of S6's aggregates-API/SSE stage to land first.

## Test plan

- [x] New tests in `apps/api/tests/test_github_events.py`: DB-backed path used when an installation
  is connected (no GitHub call made); results ordered newest-first and capped at `per_page`; bot
  actors excluded; all 5 tracked event types map back to their GitHub-style PascalCase string; an
  org with no installation still falls back to the unchanged live-GitHub path. Verified by
  reverting the implementation and confirming the 4 new DB-path tests failed first, then restoring
  it — all 13 pre-existing tests in this file (all exercising the no-installation fixture) pass
  unmodified, confirming the legacy path is untouched.
- [x] `pytest -q` — 746 passed (up from 741), against a freshly reset local Postgres + a
  standalone Redis container.
- [x] `ruff check` clean.
- [x] `bun run check` (typecheck + lint + build) clean — no UI changes.
- [ ] Manual end-to-end browser check against a real connected org — **not done**: this local
  environment has no `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` configured (confirmed unset in
  `.env`), so there's no way to exercise a real installation locally. Relying on the automated
  coverage above instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization activity feeds now include repository events from connected GitHub App installations.
  * Events are displayed with recognizable GitHub event types, sorted newest first, paginated, and filtered to exclude bot activity.

* **Bug Fixes**
  * Improved activity-feed reliability for installations while preserving the existing live GitHub fallback when no valid installation is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->