### PR TITLE
feat(api): add first aggregates-first read + SSE endpoints (S6 foundation)

### DIFF
--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -14,16 +14,20 @@ sibling org-scoped router's convention of defining its complete path locally.
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from src.core.db import RepoEvent, get_db
+from src.core.db import RepoEvent, RepoEventDailyCount, get_db
 from src.core.rbac import OrgContext, require_org_role
 from src.repositories import installation_repo
 from src.schemas.github import (
+    ActivitySummaryEntry,
+    ActivitySummaryResponse,
     FailedRunsInput,
     FailedRunsResponse,
     FailedRunSummary,
@@ -224,6 +228,114 @@ def org_events(
         return _cached_events(org_login, token, payload.per_page)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
+
+
+# ---------------------------------------------------------------------------
+# S6 foundation: first read path against a pre-computed aggregate table instead
+# of repo_events row-by-row or a live GitHub call. repo_event_daily_counts
+# (migration 0037, S4 PR 2) has been upserted by apps/worker's event_consumer.py
+# and backfill.py since S4/S5 shipped, but nothing in apps/api has read it until
+# now -- this is the "aggregates-first API" half of S6's own branch name
+# (feat/aggregates-api-sse), proving the read + live-push pattern once on one
+# real slice of data before the feature-module phases (8, 10/16, 11/18, 12/14,
+# 13, 17) each build their own dashboard on top of it.
+# ---------------------------------------------------------------------------
+
+# Same reasoning as _MAX_REPOS_FOR_FEED below: an upper bound on a client-supplied
+# window, not a default -- keeps a mistaken/malicious `days=100000` from summing an
+# unbounded number of daily-count rows.
+_ACTIVITY_SUMMARY_MAX_DAYS = 90
+_ACTIVITY_SUMMARY_DEFAULT_DAYS = 7
+
+# SSE poll cadence and a hard cap on how long a single stream connection stays open
+# (v1: poll-and-diff against the aggregate table, not Postgres LISTEN/NOTIFY or a
+# Redis pub/sub channel -- simplest thing that proves live-push works; a client
+# whose connection hits the cap just reconnects, same as any short-lived SSE
+# gateway timeout would force anyway).
+_SSE_POLL_INTERVAL_SECONDS = 5
+_SSE_MAX_DURATION_SECONDS = 15 * 60
+
+
+def _org_installation_connected(db: Session, org_login: str, ctx: OrgContext) -> bool:
+    # Same installation_id-presence guard as org_events above (see that handler's
+    # comment) -- repo_event_daily_counts is upserted by the same pipeline that
+    # populates repo_events, so it's only ever non-empty for a tenant with a real
+    # connected installation.
+    installation = installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=org_login)
+    return installation is not None and installation.installation_id is not None
+
+
+def _activity_summary_snapshot(db: Session, org_login: str, ctx: OrgContext, days: int) -> ActivitySummaryResponse:
+    connected = _org_installation_connected(db, org_login, ctx)
+    totals: list[ActivitySummaryEntry] = []
+    if connected:
+        cutoff = date.today() - timedelta(days=days - 1)
+        rows = (
+            db.query(RepoEventDailyCount.repo, RepoEventDailyCount.event_type, func.sum(RepoEventDailyCount.count))
+            .filter(RepoEventDailyCount.tenant_id == ctx.org.tenant_id, RepoEventDailyCount.day >= cutoff)
+            .group_by(RepoEventDailyCount.repo, RepoEventDailyCount.event_type)
+            .all()
+        )
+        totals = [ActivitySummaryEntry(repo=repo, event_type=event_type, count=int(count)) for repo, event_type, count in rows]
+    return ActivitySummaryResponse(
+        org=org_login, days=days, connected=connected, generated_at=datetime.now(timezone.utc), totals=totals
+    )
+
+
+def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+    """SSE body generator. Runs in Starlette's threadpool iterator (this route is a plain
+    `def`, matching every other handler in this file, so FastAPI already executes it off
+    the event loop) -- the blocking time.sleep below does not stall other requests.
+
+    Only emits a real `activity_summary` event when the aggregate actually changed since
+    the last poll (comparing on totals/connected, not generated_at, which changes every
+    poll by definition); otherwise emits an SSE comment as a heartbeat, both to keep
+    intermediary proxies from closing an idle-looking connection and to give the client a
+    liveness signal distinct from "no events yet"."""
+    deadline = time.monotonic() + _SSE_MAX_DURATION_SECONDS
+    last_key: tuple | None = None
+    while time.monotonic() < deadline:
+        snapshot = _activity_summary_snapshot(db, org_login, ctx, days)
+        key = (snapshot.connected, tuple(sorted((t.repo, t.event_type, t.count) for t in snapshot.totals)))
+        if key != last_key:
+            yield f"event: activity_summary\ndata: {snapshot.model_dump_json()}\n\n"
+            last_key = key
+        else:
+            yield ": heartbeat\n\n"
+        time.sleep(poll_interval)
+
+
+@router.get("/github/orgs/{org_login}/activity-summary", response_model=ActivitySummaryResponse)
+def org_activity_summary(
+    org_login: str,
+    days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    """Per-repo, per-event-type event counts over a trailing window, read from the
+    pre-computed repo_event_daily_counts rollup -- no live GitHub call, no token. GET (not
+    POST like org_events/failed-runs/release-timeline) because, unlike those, this never
+    takes a client-supplied token in its body -- there is nothing here that needs to avoid
+    a URL/query string.
+
+    Returns connected=False with empty totals (200, not an error) for a legacy PAT-only
+    org that has no GitHub App installation -- repo_event_daily_counts is only ever
+    populated for a tenant with one, same gating as org_events' repo_events path."""
+    days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
+    return _activity_summary_snapshot(db, org_login, ctx, days)
+
+
+@router.get("/github/orgs/{org_login}/activity-summary/stream")
+def org_activity_summary_stream(
+    org_login: str,
+    days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    """SSE channel pushing the same shape org_activity_summary returns, whenever it
+    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream."""
+    days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
+    return StreamingResponse(_activity_summary_stream(db, org_login, ctx, days), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/schemas/github.py
+++ b/apps/api/src/schemas/github.py
@@ -65,3 +65,21 @@ class ReleaseSummary(BaseModel):
 class ReleaseTimelineResponse(BaseModel):
     org: str
     releases: list[ReleaseSummary]
+
+
+class ActivitySummaryEntry(BaseModel):
+    repo: str
+    event_type: str
+    count: int
+
+
+class ActivitySummaryResponse(BaseModel):
+    org: str
+    days: int
+    # False for a legacy PAT-only org (no GitHub App installation -> repo_event_daily_counts
+    # is never populated for its tenant) -- totals is always [] in that case, not an error,
+    # since a dashboard polling this should degrade gracefully rather than treat it as a
+    # failure. See src.routers.github's org_activity_summary docstring.
+    connected: bool
+    generated_at: datetime
+    totals: list[ActivitySummaryEntry]

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -1,0 +1,207 @@
+"""Tests for the S6 aggregates-first activity-summary endpoints (JSON + SSE), the first
+concrete piece of the feat/aggregates-api-sse foundation -- see docs/plan.md's S6 section."""
+
+import json
+from datetime import date, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.routers.github import _activity_summary_stream, router as github_router
+
+_MEMBER = UserOut(id=1, email="member@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    user = User(id=_MEMBER.id, email=_MEMBER.email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    return org
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+@pytest.fixture()
+def client(db, acme_org):
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: _MEMBER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def test_activity_summary_sums_counts_within_the_window(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=3)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today - timedelta(days=1), count=2
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert body["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 5}]
+
+
+def test_activity_summary_excludes_counts_outside_the_window(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=3)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today - timedelta(days=10), count=99
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 7})
+
+    assert resp.json()["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 3}]
+
+
+def test_activity_summary_groups_by_repo_and_event_type(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="issues", day=today, count=2)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/worker", event_type="push", day=today, count=4)
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    totals = {(t["repo"], t["event_type"]): t["count"] for t in resp.json()["totals"]}
+    assert totals == {("acme/api", "push"): 1, ("acme/api", "issues"): 2, ("acme/worker", "push"): 4}
+
+
+def test_activity_summary_days_param_is_clamped_to_max(client, db, acme_org_with_installation):
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 100_000})
+    assert resp.status_code == 200
+    assert resp.json()["days"] == 90
+
+
+def test_activity_summary_days_param_is_clamped_to_min(client, db, acme_org_with_installation):
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 0})
+    assert resp.status_code == 200
+    assert resp.json()["days"] == 1
+
+
+def test_activity_summary_returns_empty_and_unconnected_for_legacy_pat_org(client, acme_org):
+    # acme_org has no installation fixture -- repo_event_daily_counts is never populated
+    # for a tenant without one (same gating as org_events' repo_events path).
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is False
+    assert body["totals"] == []
+
+
+def test_activity_summary_treats_installation_without_installation_id_as_unconnected(client, db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=None, org_id=acme_org.id
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.json()["connected"] is False
+
+
+def test_activity_summary_unknown_org_returns_404(client):
+    resp = client.get("/github/orgs/does-not-exist/activity-summary")
+    assert resp.status_code == 404
+
+
+def test_activity_summary_non_member_forbidden(db, acme_org):
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=99, email="outsider@example.com", name=None, is_workspace_admin=False
+    )
+    app.dependency_overrides[get_db] = lambda: db
+    outsider_client = TestClient(app)
+
+    resp = outsider_client.get("/github/orgs/acme/activity-summary")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# SSE stream -- tested against the generator function directly (not through
+# TestClient's own streaming, which would require a real multi-second wait per
+# poll interval); a tiny poll_interval keeps these tests fast.
+# ---------------------------------------------------------------------------
+
+
+def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme_org_with_installation, rbac_ctx_factory):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    ctx = rbac_ctx_factory(acme_org_with_installation)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    second = next(gen)
+    gen.close()
+
+    assert first.startswith("event: activity_summary\ndata: ")
+    payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
+    assert payload["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 1}]
+    assert second == ": heartbeat\n\n"
+
+
+def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_with_installation, rbac_ctx_factory):
+    today = date.today()
+    ctx = rbac_ctx_factory(acme_org_with_installation)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    second = next(gen)
+    gen.close()
+
+    assert json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())["totals"] == []
+    assert second.startswith("event: activity_summary\ndata: ")
+
+
+def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_factory):
+    ctx = rbac_ctx_factory(acme_org)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    gen.close()
+
+    payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
+    assert payload["connected"] is False
+
+
+@pytest.fixture()
+def rbac_ctx_factory(db):
+    from src.core.rbac import OrgContext, set_tenant_session_context
+    from src.repositories import tenant_repo
+
+    def _make(org):
+        set_tenant_session_context(db, org.tenant_id, _MEMBER.id)
+        membership = tenant_repo.get_membership(db, org.tenant_id, _MEMBER.id)
+        return OrgContext(org=org, membership=membership)
+
+    return _make


### PR DESCRIPTION
## Summary

Child PR 1 of S6, under the new parent/child branching workflow: this PR targets the
`feat/aggregates-api-sse` parent branch (docs/plan.md's own named S6 branch), not `main`.
Once all of S6's feature-module child PRs (Repositories, Security, Collaborators,
Overview, Automation, Activity full feed) have landed on the parent, the parent itself
opens its own PR into `main`.

- Adds `GET /github/orgs/{org_login}/activity-summary`: per-repo, per-event-type event
  counts over a trailing window (default 7 days, clamped to [1, 90]), read from
  `repo_event_daily_counts` -- the materialized aggregate table added by migration 0037
  (S4 PR 2) and upserted by `apps/worker` ever since, but never queried by `apps/api`
  until now. No live GitHub call, no token.
- Adds `GET /github/orgs/{org_login}/activity-summary/stream`: an SSE channel emitting
  the same shape whenever the aggregate actually changes (polls every 5s server-side,
  diffs against the last-sent snapshot, sends an SSE heartbeat comment otherwise; caps a
  single connection at 15 minutes so a client just reconnects rather than holding a
  thread forever). This is the "+ SSE" half of the stage's own branch name.
- Both endpoints reuse `org_events`' existing "connected" gate: `installation_id`
  presence on the org's GitHub App installation, since `repo_event_daily_counts` is only
  ever populated for a tenant with one. A legacy PAT-only org gets `connected: false` and
  an empty `totals` list -- 200, not an error, so a dashboard polling this degrades
  gracefully instead of failing outright.

**Why now:** this is the foundational piece every S6 feature-module phase (8, 10/16,
11/18, 12/14, 13, 17) needs before it can be built -- each re-points a dashboard from a
live synchronous GitHub call to a tenant-aggregate read. Proving the read + live-push
pattern once, on one small real slice of data, means every subsequent phase is "add a
new aggregate query following this shape" instead of inventing the plumbing per phase.

## Not a migration

No schema change -- `repo_event_daily_counts` and its RLS/grants already exist from
migration 0037. No `.env`/config, RBAC, or token-encryption changes either.

## Test plan

- [x] 12 new tests in `apps/api/tests/test_github_activity_summary.py`: JSON endpoint
      (window summation, cross-window exclusion, group-by repo+event_type, days clamping
      both directions, unconnected-org fallback, `installation_id IS NULL` treated as
      unconnected, 404/403), plus the SSE generator tested directly (real event then
      heartbeat when unchanged, a new event when the aggregate changes, unconnected-org
      reporting) with a near-zero `poll_interval` override so the tests run in
      milliseconds rather than waiting on the real 5s cadence.
- [x] Full suite: `759 passed, 3 skipped, 3 xpassed` (`pytest -q`, fresh local Postgres).
- [x] `bun run check` (typecheck + lint + build) clean -- no UI files touched.