### PR TITLE
feat(api): serve Repositories commit-activity chart from aggregates (S6 partial re-point)

### DIFF
--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -1,14 +1,16 @@
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime, timedelta, timezone
 
 import httpx
 from checks.github_checks import BranchProtectionEnabled, SecretScanningEnabled
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from src.core.db import get_db
+from src.core.db import RepoEventDailyCount, get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.repositories import installation_repo
 from src.schemas.repos import (
     RepoListInput,
     RepoListResponse,
@@ -70,30 +72,84 @@ def _fetch_latest_release(client: GitHubClient, owner: str, repo: str) -> dict |
     }
 
 
-def _fetch_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+def _repo_org_connected(db: Session, org_id: int, account_login: str) -> bool:
+    # Same installation_id-presence gate as src.routers.github's org_events/
+    # org_activity_summary -- repo_event_daily_counts is only ever populated for a
+    # tenant with a real connected GitHub App installation. Not shared code (routers
+    # don't import each other's private helpers in this codebase); duplicated per call
+    # site on purpose, same precedent as org_events' own comment about this check.
+    installation = installation_repo.get_for_org(db, org_id=org_id, account_login=account_login)
+    return installation is not None and installation.installation_id is not None
+
+
+def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str) -> list[dict]:
+    """Same {week, total, days} shape GitHub's stats/commit_activity returns (52 weeks,
+    oldest first, week = Unix seconds at that week's Sunday 00:00 UTC, days = 7 ints
+    Sun-Sat) -- built from repo_event_daily_counts' push-event counts instead of GitHub's
+    actual commit counts. This is an approximation (a push can carry multiple commits,
+    and doesn't 1:1 map to "commits" the way GitHub's own stat does) -- callers must set
+    RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
+    today = date.today()
+    # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
+    current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
+    oldest_week_start = current_week_start - timedelta(weeks=51)
+
+    rows = (
+        db.query(RepoEventDailyCount.day, RepoEventDailyCount.count)
+        .filter(
+            RepoEventDailyCount.tenant_id == tenant_id,
+            RepoEventDailyCount.repo == repo,
+            RepoEventDailyCount.event_type == "push",
+            RepoEventDailyCount.day >= oldest_week_start,
+        )
+        .all()
+    )
+    counts_by_day = {row.day: row.count for row in rows}
+
+    weeks = []
+    for i in range(52):
+        week_start = oldest_week_start + timedelta(weeks=i)
+        days = [counts_by_day.get(week_start + timedelta(days=d), 0) for d in range(7)]
+        week_epoch = int(datetime(week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc).timestamp())
+        weeks.append({"week": week_epoch, "total": sum(days), "days": days})
+    return weeks
+
+
+def _fetch_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     client = GitHubClient(token)
-    # The five calls are independent — run them concurrently rather than one at a time.
+    # The calls are independent — run them concurrently rather than one at a time.
     # commit_activity/participation/contributors intentionally still propagate real
     # errors (a 4xx/5xx here means the repo/stats are genuinely unavailable), while
-    # repo_meta/latest_release degrade gracefully — see their own functions.
+    # repo_meta/latest_release degrade gracefully — see their own functions. When
+    # `connected`, commit_activity is served from repo_event_daily_counts instead (S6) --
+    # one fewer live GitHub call, see _repo_commit_activity_from_aggregate.
     with ThreadPoolExecutor(max_workers=5) as pool:
         repo_meta_f = pool.submit(_fetch_repo_meta, client, owner, repo)
-        commit_activity_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+        commit_activity_f = None if connected else pool.submit(
+            client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity"
+        )
         participation_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/participation")
         contributors_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/contributors")
         latest_release_f = pool.submit(_fetch_latest_release, client, owner, repo)
 
         repo_meta = repo_meta_f.result()
-        commit_activity = commit_activity_f.result()
+        if connected:
+            commit_activity = _repo_commit_activity_from_aggregate(db, tenant_id, f"{owner}/{repo}")
+            commit_activity_source = "aggregate"
+        else:
+            raw_commit_activity = commit_activity_f.result()
+            # GitHub computes these stats asynchronously and returns 202 with an empty
+            # body on a cache miss — treat "not a list yet" as "not ready", not an error.
+            commit_activity = raw_commit_activity if isinstance(raw_commit_activity, list) else []
+            commit_activity_source = "github"
         participation = participation_f.result()
         contributors = contributors_f.result()
         latest_release = latest_release_f.result()
 
     return {
         "repository": f"{owner}/{repo}",
-        # GitHub computes these stats asynchronously and returns 202 with an empty body
-        # on a cache miss — treat "not a list/dict yet" as "not ready", not an error.
-        "commit_activity": commit_activity if isinstance(commit_activity, list) else [],
+        "commit_activity": commit_activity,
+        "commit_activity_source": commit_activity_source,
         "participation": participation if isinstance(participation, dict) else {},
         "contributors": contributors if isinstance(contributors, list) else [],
         "stargazers_count": repo_meta.get("stargazers_count", 0),
@@ -114,13 +170,13 @@ def _evict_expired_stats(now: float) -> None:
         del _stats_cache[key]
 
 
-def _cached_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     key = (owner, repo, _token_hash(token))
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:
         return cached[1]
-    stats = _fetch_stats(owner, repo, token)
+    stats = _fetch_stats(owner, repo, token, db, tenant_id, connected)
     _stats_cache[key] = (now, stats)
     _evict_expired_stats(now)
     return stats
@@ -173,8 +229,9 @@ def org_repo_stats(
         token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    connected = _repo_org_connected(db, ctx.org.id, owner)
     try:
-        return _cached_stats(owner, repo, token)
+        return _cached_stats(owner, repo, token, db, ctx.org.tenant_id, connected)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
 

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -27,7 +27,7 @@ from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_to
 router = APIRouter()
 
 _STATS_CACHE_TTL_SECONDS = 600
-_stats_cache: dict[tuple[str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
+_stats_cache: dict[tuple[int, str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
 
 
 def _token_hash(token: str) -> str:
@@ -91,8 +91,7 @@ def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str)
     RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
     # UTC, not the process-local date: RepoEventDailyCount.day is always the UTC
     # calendar day (repo_events_store.py forces UTC before deriving it), so bucketing
-    # against a non-UTC local date here could misalign the current/oldest week boundary
-    # (CodeRabbit finding on this PR).
+    # against a non-UTC local date here could misalign the current/oldest week boundary.
     today = datetime.now(timezone.utc).date()
     # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
     current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
@@ -177,8 +176,11 @@ def _evict_expired_stats(now: float) -> None:
 def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     # `connected` is part of the key, not just an argument to the miss path: without it,
     # an installation connecting/disconnecting mid-TTL could serve a cached response with
-    # a stale commit_activity_source (CodeRabbit finding on this PR).
-    key = (owner, repo, _token_hash(token), connected)
+    # a stale commit_activity_source. `tenant_id` is part of the key too: orgs.github_login
+    # is unique, so (owner, repo) can't currently collide across tenants through the normal
+    # request path, but keying on tenant_id directly removes any reliance on that invariant
+    # holding rather than trusting it implicitly.
+    key = (tenant_id, owner, repo, _token_hash(token), connected)
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -1,7 +1,7 @@
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from checks.github_checks import BranchProtectionEnabled, SecretScanningEnabled
@@ -27,7 +27,7 @@ from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_to
 router = APIRouter()
 
 _STATS_CACHE_TTL_SECONDS = 600
-_stats_cache: dict[tuple[str, str, str], tuple[float, RepoStatsResponse]] = {}
+_stats_cache: dict[tuple[str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
 
 
 def _token_hash(token: str) -> str:
@@ -89,7 +89,11 @@ def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str)
     actual commit counts. This is an approximation (a push can carry multiple commits,
     and doesn't 1:1 map to "commits" the way GitHub's own stat does) -- callers must set
     RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
-    today = date.today()
+    # UTC, not the process-local date: RepoEventDailyCount.day is always the UTC
+    # calendar day (repo_events_store.py forces UTC before deriving it), so bucketing
+    # against a non-UTC local date here could misalign the current/oldest week boundary
+    # (CodeRabbit finding on this PR).
+    today = datetime.now(timezone.utc).date()
     # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
     current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
     oldest_week_start = current_week_start - timedelta(weeks=51)
@@ -171,7 +175,10 @@ def _evict_expired_stats(now: float) -> None:
 
 
 def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
-    key = (owner, repo, _token_hash(token))
+    # `connected` is part of the key, not just an argument to the miss path: without it,
+    # an installation connecting/disconnecting mid-TTL could serve a cached response with
+    # a stale commit_activity_source (CodeRabbit finding on this PR).
+    key = (owner, repo, _token_hash(token), connected)
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:

--- a/apps/api/src/schemas/repos.py
+++ b/apps/api/src/schemas/repos.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, SecretStr
 
 
@@ -41,6 +43,11 @@ class LatestRelease(BaseModel):
 class RepoStatsResponse(BaseModel):
     repository: str
     commit_activity: list[dict]
+    # "aggregate" when commit_activity is built from repo_event_daily_counts (S6) instead
+    # of a live GitHub stats/commit_activity call -- push-*event* counts, not actual
+    # commit counts, so the UI must label this as an estimate, not exact. See
+    # src.routers.repos._repo_commit_activity_from_aggregate.
+    commit_activity_source: Literal["github", "aggregate"] = "github"
     participation: dict
     contributors: list[dict]
     stargazers_count: int

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -356,6 +356,39 @@ def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
     db.commit()
 
 
+def test_repo_stats_cache_is_isolated_by_tenant_id(db, acme_org_with_installation):
+    # Defense in depth: orgs.github_login is unique, so two tenants can't legitimately
+    # share the same (owner, repo) through the normal org-resolution path today -- but the
+    # cache itself must not rely on that invariant. Bypasses the HTTP layer (owner==org_login
+    # is enforced there) to call _cached_stats directly with the same owner/repo/token for
+    # two different tenants, mirroring what the route handler's own tenant resolution does.
+    from src.core.rbac import set_tenant_session_context
+    from src.routers.repos import _cached_stats, _stats_cache
+
+    _stats_cache.clear()
+    other_user = User(id=2, email="other@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(other_user)
+    db.commit()
+    other_org = org_repo.get_or_create(db, github_login="other")
+    org_membership_repo.get_or_create(db, org_id=other_org.id, user_id=other_user.id, role="member")
+
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=5)
+    _insert_daily_count(db, other_org.tenant_id, repo="acme/demo", event_type="push", day=today, count=9)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+
+        set_tenant_session_context(db, acme_org_with_installation.tenant_id, _ADMIN.id)
+        first = _cached_stats("acme", "demo", "shared-token", db, acme_org_with_installation.tenant_id, True)
+
+        set_tenant_session_context(db, other_org.tenant_id, other_user.id)
+        second = _cached_stats("acme", "demo", "shared-token", db, other_org.tenant_id, True)
+
+    assert first["commit_activity"][-1]["total"] == 5
+    assert second["commit_activity"][-1]["total"] == 9
+
+
 def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(repos_client, db, acme_org_with_installation):
     today = date.today()
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
@@ -390,7 +423,7 @@ def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outsi
 ):
     # A fixed Monday, not the real "today" -- if this test ran on a real Sunday,
     # `today - timedelta(days=1)` would fall in the *previous* Sunday-starting week,
-    # breaking the "same week" assumption below (CodeRabbit finding on this PR).
+    # breaking the "same week" assumption below.
     today = date(2000, 1, 3)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
     _insert_daily_count(

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -1,6 +1,6 @@
 """Tests for the repos router (Phase 8 groundwork)."""
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import httpx
@@ -388,7 +388,10 @@ def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(r
 def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outside_window(
     repos_client, db, acme_org_with_installation
 ):
-    today = date.today()
+    # A fixed Monday, not the real "today" -- if this test ran on a real Sunday,
+    # `today - timedelta(days=1)` would fall in the *previous* Sunday-starting week,
+    # breaking the "same week" assumption below (CodeRabbit finding on this PR).
+    today = date(2000, 1, 3)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
     _insert_daily_count(
         db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(days=1), count=1
@@ -400,8 +403,10 @@ def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outsi
     # A different event type on the same day -- must not be counted (commit_activity is push-only).
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="issues", day=today, count=50)
 
-    with patch("src.routers.repos.GitHubClient") as mock_client:
+    with patch("src.routers.repos.GitHubClient") as mock_client, patch("src.routers.repos.datetime") as mock_datetime:
         mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+        mock_datetime.now.return_value = datetime(today.year, today.month, today.day, tzinfo=timezone.utc)
+        mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
         resp = repos_client.post(
             "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
         )

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -1,15 +1,17 @@
 """Tests for the repos router (Phase 8 groundwork)."""
 
+from datetime import date, timedelta
 from unittest.mock import patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.repos import router as repos_router
 from src.routers.repos import _stats_cache
 
@@ -323,6 +325,127 @@ def test_repo_stats_different_tokens_are_not_served_from_the_same_cache_entry(re
     # Each distinct token triggers its own fetch (5 calls) rather than reusing the
     # other token's cached response -- 10 total, not 5.
     assert mock_client.return_value.request.call_count == 10
+
+
+# ---------------------------------------------------------------------------
+# S6: commit_activity served from repo_event_daily_counts for orgs with a
+# connected GitHub App installation -- partial re-point, everything else in
+# RepoStatsResponse still comes from live GitHub calls (see repos.py's
+# _fetch_stats docstring and the plan.md status update for the accuracy
+# tradeoff -- push-event counts, not exact commit counts).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(repos_client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META,
+            participation={"all": [1], "owner": [1]},
+            contributors=[{"login": "octocat", "total": 5}],
+            release_error=_not_found(),
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "aggregate"
+    assert len(body["commit_activity"]) == 52
+    assert body["commit_activity"][-1]["total"] == 3
+    # commit_activity is skipped entirely -- 4 live calls, not 5.
+    assert mock_client.return_value.request.call_count == 4
+    called_paths = {c.args[1] for c in mock_client.return_value.request.call_args_list}
+    assert "/repos/acme/demo/stats/commit_activity" not in called_paths
+    # Other fields still come from the live GitHub calls, unchanged.
+    assert body["stargazers_count"] == 24
+    assert body["contributors"] == [{"login": "octocat", "total": 5}]
+
+
+def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outside_window(
+    repos_client, db, acme_org_with_installation
+):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(days=1), count=1
+    )
+    # Well outside the 52-week window -- must not be counted anywhere.
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(weeks=60), count=99
+    )
+    # A different event type on the same day -- must not be counted (commit_activity is push-only).
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="issues", day=today, count=50)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    body = resp.json()
+    weeks = body["commit_activity"]
+    assert sum(w["total"] for w in weeks) == 3
+    assert weeks[-1]["total"] == 3
+
+
+def test_repo_stats_falls_back_to_github_when_the_installation_has_no_installation_id(repos_client, db, acme_org):
+    # Mirrors the same gap covered in test_github_events.py -- a row can exist with
+    # installation_id IS NULL (sync_org_installation's known-admin re-sync path) with no
+    # actual App installation, and therefore no repo_event_daily_counts rows, behind it.
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=None, org_id=acme_org.id
+    )
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META, commit_activity=[{"week": 1, "total": 5}], release_error=_not_found()
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity"] == [{"week": 1, "total": 5}]
+    assert mock_client.return_value.request.call_count == 5
+
+
+def test_repo_stats_commit_activity_source_is_github_for_a_legacy_pat_org(repos_client):
+    # acme_org (no installation fixture) -- regression check that the fully unchanged
+    # live-GitHub path is still what a legacy PAT-only org gets.
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META, commit_activity=[{"week": 1, "total": 5}], release_error=_not_found()
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.json()["commit_activity_source"] == "github"
 
 
 def test_list_repos_maps_github_request_error_to_503(repos_client):

--- a/apps/ui/app/repos/[repo]/page.tsx
+++ b/apps/ui/app/repos/[repo]/page.tsx
@@ -146,6 +146,7 @@ export default function RepoDetailPage() {
   }
 
   const commitActivity = statsQuery.data?.commit_activity ?? []
+  const isEstimatedActivity = statsQuery.data?.commit_activity_source === "aggregate"
   const areaData = commitActivity.map((w) => ({
     week: new Date(w.week * 1000).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
     value: w.total,
@@ -240,8 +241,16 @@ export default function RepoDetailPage() {
         </div>
 
         <div className="card lg:col-span-2">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Commit activity — 52 weeks</span>
+            {isEstimatedActivity && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {statsQuery.isLoading ? (
@@ -257,8 +266,16 @@ export default function RepoDetailPage() {
         </div>
 
         <div className="card">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Activity calendar</span>
+            {isEstimatedActivity && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {statsQuery.isLoading ? (

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -44,8 +44,9 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
   })
 
   const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
+  const isEstimated = data?.commit_activity_source === "aggregate"
   return (
-    <div ref={ref}>
+    <div ref={ref} title={isEstimated ? "Estimated from stored push events, not exact commit counts." : undefined}>
       {!inView || isLoading ? (
         <Skeleton className="h-8 w-24" />
       ) : isError ? (

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -46,7 +46,7 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
   const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
   const isEstimated = data?.commit_activity_source === "aggregate"
   return (
-    <div ref={ref} title={isEstimated ? "Estimated from stored push events, not exact commit counts." : undefined}>
+    <div ref={ref} className="flex items-center gap-1.5">
       {!inView || isLoading ? (
         <Skeleton className="h-8 w-24" />
       ) : isError ? (
@@ -54,7 +54,17 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
       ) : weeks.length === 0 || weeks.every((n) => n === 0) ? (
         <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
       ) : (
-        <MiniSparkline data={weeks} height={28} />
+        <>
+          <MiniSparkline data={weeks} height={28} />
+          {isEstimated && (
+            <span
+              className="text-[0.625rem] text-muted-foreground/70 shrink-0"
+              title="Estimated from stored push events, not exact commit counts."
+            >
+              (est.)
+            </span>
+          )}
+        </>
       )}
     </div>
   )

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -107,6 +107,9 @@ export interface LatestRelease {
 export interface RepoStatsResponse {
   repository: string
   commit_activity: CommitActivityWeek[]
+  // "aggregate" when commit_activity is estimated from stored push-event counts
+  // (S6) instead of GitHub's own commit-level stats/commit_activity endpoint.
+  commit_activity_source: "github" | "aggregate"
   participation: { all?: number[]; owner?: number[] }
   contributors: { author?: { login?: string }; total: number }[]
   stargazers_count: number

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -133,6 +133,36 @@ describe("RepoDetailPage", () => {
     expect(screen.getByText(/top contributors/i)).toBeInTheDocument();
   });
 
+  it("labels the commit-activity chart and calendar as estimated when the source is an aggregate", async () => {
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 4 }, (_, i) => ({ week: 1700000000 + i * 604800, total: i + 1, days: [] })),
+      commit_activity_source: "aggregate",
+      participation: {},
+      contributors: [],
+    });
+
+    renderPage();
+
+    const captions = await screen.findAllByText("(estimated)");
+    expect(captions).toHaveLength(2);
+  });
+
+  it("does not show the estimated caption when the source is github", async () => {
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 4 }, (_, i) => ({ week: 1700000000 + i * 604800, total: i + 1, days: [] })),
+      commit_activity_source: "github",
+      participation: {},
+      contributors: [],
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.queryByText(/no commit activity available yet/i)).not.toBeInTheDocument());
+    expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
+  });
+
   it("maps a contributor's real (nested) GitHub login instead of falling back to 'unknown'", async () => {
     // Regression test for the c.login vs c.author.login bug -- exercises the mapping
     // function directly the same way the component does, since recharts' XAxis tick

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -430,6 +430,51 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
   });
 
+  it("marks the sparkline cell as estimated when the stats source is an aggregate", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          description: null,
+          language: "Python",
+          stargazers_count: 3,
+          forks_count: 0,
+          watchers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 8 }, (_, i) => ({ week: i, total: i + 1, days: [] })),
+      commit_activity_source: "aggregate",
+      participation: {},
+      contributors: [],
+      stargazers_count: 3,
+      forks_count: 0,
+      watchers_count: 3,
+      open_issues_count: 1,
+      default_branch: "main",
+      latest_release: null,
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
+    expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
+  });
+
   it("keeps rendered rows scoped to the org they were loaded for, even if the org field is edited afterward without reloading", async () => {
     reposListMock.mockResolvedValue({
       org: "acme",

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -472,6 +472,9 @@ describe("ReposPage", () => {
 
     await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
+    // Visible, not just a hover-only title -- touch/keyboard users must be able to see
+    // the estimate label too (CodeRabbit finding on this PR).
+    expect(screen.getByText("(est.)")).toBeInTheDocument();
     expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
   });
 

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -473,7 +473,7 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
     // Visible, not just a hover-only title -- touch/keyboard users must be able to see
-    // the estimate label too (CodeRabbit finding on this PR).
+    // the estimate label too.
     expect(screen.getByText("(est.)")).toBeInTheDocument();
     expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Child PR 2 of S6 (Phase 8, Repositories dashboard), targeting the `feat/aggregates-api-sse` parent
branch, following child PR 1's (#346) established pattern.

For an org with a connected GitHub App installation, `POST /orgs/{org}/repos/{owner}/{repo}/stats`
now serves `commit_activity` (the 52-week chart, the activity-calendar heatmap, and the repos-list
sparkline) from `repo_event_daily_counts` (S4's aggregate table, populated since migration 0037)
instead of a live `GET /repos/{owner}/{repo}/stats/commit_activity` call — one fewer live GitHub call
per repo view, no rate-limit exposure on that call. A legacy PAT-only org (no installation) is fully
unchanged.

**This is a partial re-point, and deliberately not byte-identical** (unlike the Activity Feed
re-point, #345): `repo_event_daily_counts` counts **push events**, not actual commits — one push can
carry multiple commits — so the aggregate path is an *estimate* of commit activity, not an exact
count. It also has no per-author dimension at all, so "top contributors" cannot be aggregate-sourced
yet. Repo meta, participation, contributors, and latest release all stay on the live GitHub path,
unchanged.

**Transparency:** added `commit_activity_source: "github" | "aggregate"` to `RepoStatsResponse`. The
UI shows a small "(estimated)" caption/tooltip next to the two affected chart headers only when the
source is `"aggregate"` — no other UI changes, no new chart, no redesign.

## Not a migration

No schema change — `repo_event_daily_counts` already exists (migration 0037). No `.env`/config or
RBAC changes.

## Test plan

- [x] 4 new tests in `apps/api/tests/test_repos.py`: connected org gets `commit_activity_source:
      "aggregate"` with correctly-bucketed weekly totals and skips the live `commit_activity` call
      (4 live calls instead of 5); week-bucketing excludes data outside the 52-week window and
      excludes non-`push` event types; `installation_id IS NULL` and no-installation orgs both fall
      back to the unchanged live-GitHub path (`commit_activity_source: "github"`).
- [x] Full suite: `763 passed, 3 skipped, 3 xpassed` (`pytest -q`, fresh local Postgres).
- [x] `bun run check` (typecheck + lint + build) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Connected repositories now use stored push-event data for commit activity.
  * Commit activity consistently covers 52 weeks and includes push events.
  * Charts, calendars, and activity sparklines clearly identify estimated activity and provide explanatory tooltips.
  * Repositories without a connected GitHub App continue using GitHub-provided commit activity.
  * Repository statistics indicate whether commit activity comes from GitHub or an estimate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->