### PR TITLE
feat(api): serve Overview cockpit commit activity + recent events from aggregates (S6)

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -6,13 +6,14 @@ from datetime import date, datetime, timedelta, timezone
 import anyio
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
-from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.core.db import RepoEventDailyCount, get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role, set_tenant_session_context
 from src.repositories import installation_repo, job_repo, org_repo, scan_results_repo, tenant_repo
-from src.routers.github import _cached_events
+from src.routers.github import _cached_events, _fetch_events_from_repo_events
 from src.schemas.analytics import (
     AnalyticsInput,
     AnalyticsResponse,
@@ -186,12 +187,90 @@ def _safe_member_count(owner: str, token: str) -> int:
         return 0
 
 
-def _safe_recent_events(owner: str, token: str) -> list[OrgEventSummary]:
+def _cockpit_connected_tenant(db: Session, user_id: int, owner: str) -> int | None:
+    # Unlike repos.py/github.py's org-scoped endpoints, the cockpit is a personal
+    # endpoint (require_auth only, no OrgContext/require_org_role) -- `owner` is
+    # whatever GitHub login the caller resolved a token for via resolve_owner_token,
+    # not necessarily a Clevis org the caller is a member of (bring-your-own-token is
+    # allowed here). Mirrors resolve_owner_token's own org-membership+role resolution
+    # (token_resolution.py) deliberately: without this membership check, any caller
+    # could read another org's repo_event_daily_counts/repo_events just by naming its
+    # login, the exact class of bug resolve_owner_token's own docstring says it guards
+    # against for token resolution -- "there exists a connected installation for this
+    # login" alone is not authorization to read its aggregate data.
+    org = org_repo.get_by_login_ci(db, owner)
+    if org is None:
+        return None
+    org = org_repo.ensure_tenant_linked(db, org)
+    if tenant_repo.get_membership(db, org.tenant_id, user_id) is None:
+        return None
+    installation = installation_repo.get_for_org(db, org_id=org.id, account_login=owner)
+    if installation is None or installation.installation_id is None:
+        return None
+    # Sets RLS session context for this connection so the aggregate reads below (repo_events/
+    # repo_event_daily_counts, migrations 0036/0037, both ENABLE ROW LEVEL SECURITY with a
+    # strict tenant_id filter) are correctly tenant-scoped -- resolve_owner_token
+    # itself doesn't set this (a separate, pre-existing gap in that shared helper, out of
+    # scope here; see its own docstring), so this is the first point in the cockpit's
+    # request handling where it's safe to do so, now that real membership is confirmed.
+    set_tenant_session_context(db, org.tenant_id, user_id)
+    return org.tenant_id
+
+
+def _safe_recent_events(db: Session, owner: str, token: str, tenant_id: int | None) -> list[OrgEventSummary]:
     try:
-        events = _cached_events(owner, token, per_page=10).events
+        if tenant_id is not None:
+            events = _fetch_events_from_repo_events(db, owner, tenant_id, per_page=10).events
+        else:
+            events = _cached_events(owner, token, per_page=10).events
         return [OrgEventSummary(**e.model_dump()) for e in events[:5]]
     except (httpx.HTTPStatusError, httpx.RequestError, HTTPException):
         return []
+
+
+def _cockpit_events_and_commit_activity(
+    db: Session, owner: str, token: str, tenant_id: int | None, repo_names: list[str]
+) -> tuple[list[OrgEventSummary], tuple[list[int], list[int]]]:
+    # Bundled into one call, not two independent asyncio.gather entries, because both
+    # branches below read `db` when tenant_id is set -- a SQLAlchemy Session isn't safe
+    # to use concurrently from two threads at once, unlike every other helper in the
+    # cockpit's gather, which only ever touches the GitHub token/client.
+    recent_events = _safe_recent_events(db, owner, token, tenant_id)
+    if tenant_id is not None:
+        commit_activity = _cockpit_commit_activity_from_aggregate(db, tenant_id)
+    else:
+        commit_activity = _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)
+    return recent_events, commit_activity
+
+
+def _cockpit_commit_activity_from_aggregate(db: Session, tenant_id: int) -> tuple[list[int], list[int]]:
+    """Same {4w, 52w} shape _safe_commit_activity_4w_and_heatmap_52w returns, built from
+    repo_event_daily_counts' push-event counts summed across every repo in the tenant
+    (the cockpit's commit_activity_4w/commit_heatmap_52w are org-wide, unlike repos.py's
+    per-repo aggregate) instead of GitHub's actual per-repo commit counts -- an
+    approximation for the same reason repos.py's aggregate is: a push can carry multiple
+    commits. Callers must set CockpitResponse.commit_activity_source="aggregate"."""
+    today = datetime.now(timezone.utc).date()
+    current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
+    oldest_week_start = current_week_start - timedelta(weeks=51)
+
+    rows = (
+        db.query(RepoEventDailyCount.day, func.sum(RepoEventDailyCount.count))
+        .filter(
+            RepoEventDailyCount.tenant_id == tenant_id,
+            RepoEventDailyCount.event_type == "push",
+            RepoEventDailyCount.day >= oldest_week_start,
+        )
+        .group_by(RepoEventDailyCount.day)
+        .all()
+    )
+    counts_by_day = {day: int(count) for day, count in rows}
+
+    totals_52w = [
+        sum(counts_by_day.get(oldest_week_start + timedelta(weeks=i, days=d), 0) for d in range(7))
+        for i in range(52)
+    ]
+    return totals_52w[-4:], totals_52w
 
 
 def _week_start(weeks_ago: int) -> date:
@@ -455,6 +534,7 @@ async def personal_analytics_cockpit(
     latest_score = scans[0]["score"] if scans else None
     score_trend = [s["score"] for s in reversed(scans)]
     cache_job_success_rate = _cache_job_success_rate(db)
+    connected_tenant_id = await anyio.to_thread.run_sync(lambda: _cockpit_connected_tenant(db, user.id, owner))
 
     try:
         repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))
@@ -464,20 +544,20 @@ async def personal_analytics_cockpit(
 
     (
         member_count,
-        recent_events,
+        (recent_events, (commit_activity_4w, commit_heatmap_52w)),
         open_pr_count,
         pr_merge_rate_4w,
-        (commit_activity_4w, commit_heatmap_52w),
         total_cache_size_bytes,
         (milestones, at_risk_repos),
         pr_cycle_time_8w,
         release_cadence_4w,
     ) = await asyncio.gather(
         anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
-        anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
+        anyio.to_thread.run_sync(
+            lambda: _cockpit_events_and_commit_activity(db, owner, token, connected_tenant_id, repo_names)
+        ),
         anyio.to_thread.run_sync(lambda: _safe_open_pr_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
-        anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_milestones(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_pr_cycle_time_8w(owner, token)),
@@ -500,6 +580,7 @@ async def personal_analytics_cockpit(
         milestones=milestones,
         pr_cycle_time_8w=pr_cycle_time_8w,
         release_cadence_4w=release_cadence_4w,
+        commit_activity_source="aggregate" if connected_tenant_id is not None else "github",
     )
 
 

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -82,6 +82,7 @@ class CockpitResponse(BaseModel):
     milestones: list[MilestoneSummary] = []
     pr_cycle_time_8w: list[PrCycleTimeWeek] = []
     release_cadence_4w: list[int] = []
+    commit_activity_source: Literal["github", "aggregate"] = "github"
 
 
 class PRSummary(BaseModel):

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -7,10 +7,11 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import Job, User, get_db
-from src.repositories import org_repo, scan_results_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo, scan_results_repo
 from src.routers.analytics import router
 
 _HTTP_ERROR = httpx.HTTPStatusError(
@@ -198,6 +199,188 @@ def test_cockpit_falls_back_to_client_supplied_token_header(http, db, mock_user)
         _stop_all(patchers)
 
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# S6: commit_activity_4w/commit_heatmap_52w + recent_events served from
+# repo_event_daily_counts/repo_events (not live GitHub) for an org the caller is
+# a member of with a connected GitHub App installation -- partial re-point,
+# everything else in CockpitResponse still comes from live GitHub calls (see
+# analytics.py's _cockpit_commit_activity_from_aggregate docstring and the
+# plan.md status update for the accuracy tradeoff).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+    return org
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def _insert_repo_event(db, tenant_id, *, delivery_id, event_type, actor, repo, summary, occurred_at):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_events (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at) "
+            "VALUES (:tenant_id, :delivery_id, :event_type, :actor, '', :repo, :summary, :occurred_at)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "delivery_id": delivery_id,
+            "event_type": event_type,
+            "actor": actor,
+            "repo": repo,
+            "summary": summary,
+            "occurred_at": occurred_at,
+        },
+    )
+    db.commit()
+
+
+# Excludes the two helpers this section exercises for real -- every other GitHub-calling
+# helper stays mocked so a connected-org test doesn't also need to fake GitHub responses
+# for member_count/open_pr_count/etc.
+_CONNECTED_SAFE_MOCKS = {
+    target: kwargs
+    for target, kwargs in _DEFAULT_SAFE_MOCKS.items()
+    if target
+    not in (
+        "src.routers.analytics._safe_recent_events",
+        "src.routers.analytics._safe_commit_activity_4w_and_heatmap_52w",
+    )
+}
+
+
+def test_cockpit_connected_org_uses_aggregate_commit_activity(http, db, mock_user, acme_org_with_installation):
+    today = datetime.now(timezone.utc).date()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=4)
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "aggregate"
+    assert len(body["commit_heatmap_52w"]) == 52
+    assert body["commit_heatmap_52w"][-1] == 4
+    assert body["commit_activity_4w"][-1] == 4
+
+
+def test_cockpit_connected_org_sums_commit_activity_across_repos(http, db, mock_user, acme_org_with_installation):
+    today = datetime.now(timezone.utc).date()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/worker", event_type="push", day=today, count=2)
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    assert resp.json()["commit_heatmap_52w"][-1] == 5
+
+
+def test_cockpit_connected_org_uses_repo_events_for_recent_events_not_live_github(
+    http, db, mock_user, acme_org_with_installation
+):
+    _insert_repo_event(
+        db,
+        acme_org_with_installation.tenant_id,
+        delivery_id="d1",
+        event_type="push",
+        actor="octocat",
+        repo="acme/demo",
+        summary="pushed to main",
+        occurred_at=datetime.now(timezone.utc),
+    )
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with (
+            patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+            patch("src.routers.analytics._cached_events") as mock_cached_events,
+        ):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    events = resp.json()["recent_events"]
+    assert len(events) == 1
+    assert events[0]["actor"] == "octocat"
+    mock_cached_events.assert_not_called()
+
+
+def test_cockpit_falls_back_to_github_when_the_installation_has_no_installation_id(
+    http, db, mock_user, acme_org_with_installation
+):
+    # Same sync_org_installation known-admin gap covered elsewhere (org_events,
+    # repos.py's _repo_org_connected): a row can exist with installation_id IS NULL.
+    inst = installation_repo.get_for_org(db, org_id=acme_org_with_installation.id, account_login="acme")
+    inst.installation_id = None
+    db.commit()
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity_4w"] == [1, 2, 3, 4]  # the default GitHub-path mock's value
+
+
+def test_cockpit_does_not_read_aggregate_for_org_the_caller_is_not_a_member_of(http, db, mock_user):
+    # A connected org exists, but mock_user has no membership row in it -- the
+    # bring-your-own-token path must not leak that unrelated org's internal
+    # repo_event_daily_counts just because the `owner` login happens to match.
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+    _insert_daily_count(db, org.tenant_id, repo="acme/demo", event_type="push", day=datetime.now(timezone.utc).date(), count=99)
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity_4w"] == [1, 2, 3, 4]  # default mock's value, not the aggregate's 99
 
 
 # ---------------------------------------------------------------------------

--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -228,8 +228,16 @@ export default function ActivityPage() {
       {hasOrg && (
         <div className="grid gap-4 lg:grid-cols-2 mt-4">
           <div className="card lg:col-span-2">
-            <div className="px-4 py-3 border-b border-border">
+            <div className="px-4 py-3 border-b border-border flex items-center gap-2">
               <span className="section-label">Commit Heatmap (52w)</span>
+              {cockpitQuery.data?.commit_activity_source === "aggregate" && (
+                <span
+                  className="text-[0.6875rem] text-muted-foreground/70"
+                  title="Estimated from stored push events, not GitHub's exact commit count."
+                >
+                  (estimated)
+                </span>
+              )}
             </div>
             <div className="p-4">
               {(cockpitQuery.data?.commit_heatmap_52w ?? []).some((n) => n > 0) ? (

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -195,8 +195,16 @@ export default function OverviewPage() {
 
       <div className="grid gap-4 lg:grid-cols-2 mb-6">
         <div className="card">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Commit Activity (4w)</span>
+            {cockpit?.commit_activity_source === "aggregate" && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {commitActivityData.length > 0 ? (

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -389,6 +389,7 @@ export interface CockpitResponse {
   milestones: MilestoneSummary[]
   pr_cycle_time_8w: PrCycleTimeWeek[]
   release_cadence_4w: number[]
+  commit_activity_source: "github" | "aggregate"
 }
 
 export interface MyViewPRSummary {

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -204,6 +204,22 @@ describe("ActivityPage", () => {
     expect(screen.queryByText("No commit activity in the last year")).not.toBeInTheDocument();
   });
 
+  it("labels the commit heatmap as estimated when the cockpit source is an aggregate", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    analyticsCockpitMock.mockResolvedValue({
+      repo_count: 1, member_count: 1, latest_score: null, score_trend: [], recent_events: [],
+      open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [], total_cache_size_bytes: 0,
+      cache_job_success_rate: 0, commit_heatmap_52w: Array.from({ length: 52 }, (_, i) => (i === 51 ? 5 : 0)),
+      commit_activity_source: "aggregate" as const,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("(estimated)")).toBeInTheDocument();
+  });
+
   it("groups open PRs by author under the PR Board tab", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -46,6 +46,7 @@ const EMPTY_COCKPIT = {
   milestones: [],
   pr_cycle_time_8w: [],
   release_cadence_4w: [],
+  commit_activity_source: "github" as const,
 };
 
 const EMPTY_MY_VIEW = {
@@ -114,6 +115,38 @@ describe("OverviewPage cockpit", () => {
     // A single cockpit call once the token-resolve fetch settles -- not a second
     // waterfalled fetch for jobs/overview like the pre-cockpit page used to do.
     expect(cockpitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels commit activity as estimated when the cockpit source is an aggregate", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      commit_activity_4w: [1, 2, 3, 4],
+      commit_activity_source: "aggregate" as const,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("(estimated)")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the estimated caption when the cockpit source is github", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      commit_activity_4w: [1, 2, 3, 4],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(cockpitMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
   });
 
   it("renders empty states for charts and activity when the org has no data yet", async () => {


### PR DESCRIPTION
## What changed

Child PR 3 of S6 (`feat/aggregates-api-sse`), following the same partial-repoint pattern as PR #347 (Repositories dashboard):

- `GET /me/analytics/cockpit/{owner}`'s `commit_activity_4w`/`commit_heatmap_52w` (previously a live per-repo `stats/commit_activity` fan-out) and `recent_events` (previously a separately-cached live GitHub call, not reusing PR #345's `repo_events`-backed path) are now served from `repo_event_daily_counts`/`repo_events` for an org the caller is a member of with a connected GitHub App installation. Unconnected/legacy-PAT orgs and bring-your-own-token callers with no Clevis membership in the named org are unchanged.
- New `commit_activity_source: "github" | "aggregate"` field on `CockpitResponse` — the UI shows a small "(estimated)" caption on both the Overview page's Commit Activity card and the Activity page's Commit Heatmap card (which reads the same cockpit endpoint) only when aggregate-sourced, mirroring the Repositories page's existing label.
- Contributors, PR volume/cycle-time, cache size, milestones, and release cadence are untouched — still live GitHub calls, no aggregate exists for them yet.

## Why a membership check was added here specifically

The cockpit is a personal endpoint (`/me/*`, `require_auth` only, no `OrgContext`) — `owner` is whatever GitHub login the caller resolved a token for via `resolve_owner_token`, not necessarily a Clevis org they're a member of (bring-your-own-token is intentionally allowed). This is the first place the cockpit reads a tenant-scoped, RLS-protected aggregate table directly, so a new `_cockpit_connected_tenant` helper mirrors `resolve_owner_token`'s own org-membership+role check before treating an org as "connected" — without it, any caller could read another org's `repo_event_daily_counts`/`repo_events` just by naming its login, since "a connected installation exists for this login" alone isn't authorization to read its internal aggregate data. It also sets RLS session context (`set_tenant_session_context`) before the aggregate reads, which `resolve_owner_token` itself doesn't do (a separate, pre-existing gap in that shared helper, out of scope here).

## Tests

- `apps/api/tests/test_analytics_cockpit.py`: 6 new tests covering the connected/aggregate path (single-repo and multi-repo commit-activity summation, `repo_events`-backed recent events not calling live GitHub), the `installation_id IS NULL` fallback gap, and the not-a-member case (proves the aggregate isn't read for an org the caller isn't in, even though it exists and has data).
- `apps/ui/tests/components/overview-page.test.tsx` + `activity-page.test.tsx`: 3 new tests for the "(estimated)" caption's presence/absence.
- Full suite: `769 passed, 3 skipped, 3 xpassed`. `bun run check` clean. Diff coverage 100% on the new UI lines.

## Not a migration

No schema change — reads against tables that already exist (`repo_event_daily_counts`/`repo_events`, migrations 0036/0037).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics now includes recent events, push activity, commit activity, and heatmap data from available aggregate data.
  * Commit activity identifies whether results come from GitHub or aggregate data.
  * Aggregate-based commit activity is clearly labeled “estimated” with explanatory tooltip text.

* **Bug Fixes**
  * Restricted aggregate analytics data to authorized organization members.
  * Preserved GitHub-based results when aggregate data or installation details are unavailable.
  * Combined activity data across multiple repositories for more complete reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->