### PR TITLE
feat(api,ui): aggregates-first API + SSE foundation, partial dashboard re-point (S6)

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -6,13 +6,14 @@ from datetime import date, datetime, timedelta, timezone
 import anyio
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
-from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.core.db import RepoEventDailyCount, get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role, set_tenant_session_context
 from src.repositories import installation_repo, job_repo, org_repo, scan_results_repo, tenant_repo
-from src.routers.github import _cached_events
+from src.routers.github import _cached_events, _fetch_events_from_repo_events
 from src.schemas.analytics import (
     AnalyticsInput,
     AnalyticsResponse,
@@ -186,12 +187,90 @@ def _safe_member_count(owner: str, token: str) -> int:
         return 0
 
 
-def _safe_recent_events(owner: str, token: str) -> list[OrgEventSummary]:
+def _cockpit_connected_tenant(db: Session, user_id: int, owner: str) -> int | None:
+    # Unlike repos.py/github.py's org-scoped endpoints, the cockpit is a personal
+    # endpoint (require_auth only, no OrgContext/require_org_role) -- `owner` is
+    # whatever GitHub login the caller resolved a token for via resolve_owner_token,
+    # not necessarily a Clevis org the caller is a member of (bring-your-own-token is
+    # allowed here). Mirrors resolve_owner_token's own org-membership+role resolution
+    # (token_resolution.py) deliberately: without this membership check, any caller
+    # could read another org's repo_event_daily_counts/repo_events just by naming its
+    # login, the exact class of bug resolve_owner_token's own docstring says it guards
+    # against for token resolution -- "there exists a connected installation for this
+    # login" alone is not authorization to read its aggregate data.
+    org = org_repo.get_by_login_ci(db, owner)
+    if org is None:
+        return None
+    org = org_repo.ensure_tenant_linked(db, org)
+    if tenant_repo.get_membership(db, org.tenant_id, user_id) is None:
+        return None
+    installation = installation_repo.get_for_org(db, org_id=org.id, account_login=owner)
+    if installation is None or installation.installation_id is None:
+        return None
+    # Sets RLS session context for this connection so the aggregate reads below (repo_events/
+    # repo_event_daily_counts, migrations 0036/0037, both ENABLE ROW LEVEL SECURITY with a
+    # strict tenant_id filter) are correctly tenant-scoped -- resolve_owner_token
+    # itself doesn't set this (a separate, pre-existing gap in that shared helper, out of
+    # scope here; see its own docstring), so this is the first point in the cockpit's
+    # request handling where it's safe to do so, now that real membership is confirmed.
+    set_tenant_session_context(db, org.tenant_id, user_id)
+    return org.tenant_id
+
+
+def _safe_recent_events(db: Session, owner: str, token: str, tenant_id: int | None) -> list[OrgEventSummary]:
     try:
-        events = _cached_events(owner, token, per_page=10).events
+        if tenant_id is not None:
+            events = _fetch_events_from_repo_events(db, owner, tenant_id, per_page=10).events
+        else:
+            events = _cached_events(owner, token, per_page=10).events
         return [OrgEventSummary(**e.model_dump()) for e in events[:5]]
     except (httpx.HTTPStatusError, httpx.RequestError, HTTPException):
         return []
+
+
+def _cockpit_events_and_commit_activity(
+    db: Session, owner: str, token: str, tenant_id: int | None, repo_names: list[str]
+) -> tuple[list[OrgEventSummary], tuple[list[int], list[int]]]:
+    # Bundled into one call, not two independent asyncio.gather entries, because both
+    # branches below read `db` when tenant_id is set -- a SQLAlchemy Session isn't safe
+    # to use concurrently from two threads at once, unlike every other helper in the
+    # cockpit's gather, which only ever touches the GitHub token/client.
+    recent_events = _safe_recent_events(db, owner, token, tenant_id)
+    if tenant_id is not None:
+        commit_activity = _cockpit_commit_activity_from_aggregate(db, tenant_id)
+    else:
+        commit_activity = _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)
+    return recent_events, commit_activity
+
+
+def _cockpit_commit_activity_from_aggregate(db: Session, tenant_id: int) -> tuple[list[int], list[int]]:
+    """Same {4w, 52w} shape _safe_commit_activity_4w_and_heatmap_52w returns, built from
+    repo_event_daily_counts' push-event counts summed across every repo in the tenant
+    (the cockpit's commit_activity_4w/commit_heatmap_52w are org-wide, unlike repos.py's
+    per-repo aggregate) instead of GitHub's actual per-repo commit counts -- an
+    approximation for the same reason repos.py's aggregate is: a push can carry multiple
+    commits. Callers must set CockpitResponse.commit_activity_source="aggregate"."""
+    today = datetime.now(timezone.utc).date()
+    current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
+    oldest_week_start = current_week_start - timedelta(weeks=51)
+
+    rows = (
+        db.query(RepoEventDailyCount.day, func.sum(RepoEventDailyCount.count))
+        .filter(
+            RepoEventDailyCount.tenant_id == tenant_id,
+            RepoEventDailyCount.event_type == "push",
+            RepoEventDailyCount.day >= oldest_week_start,
+        )
+        .group_by(RepoEventDailyCount.day)
+        .all()
+    )
+    counts_by_day = {day: int(count) for day, count in rows}
+
+    totals_52w = [
+        sum(counts_by_day.get(oldest_week_start + timedelta(weeks=i, days=d), 0) for d in range(7))
+        for i in range(52)
+    ]
+    return totals_52w[-4:], totals_52w
 
 
 def _week_start(weeks_ago: int) -> date:
@@ -455,6 +534,7 @@ async def personal_analytics_cockpit(
     latest_score = scans[0]["score"] if scans else None
     score_trend = [s["score"] for s in reversed(scans)]
     cache_job_success_rate = _cache_job_success_rate(db)
+    connected_tenant_id = await anyio.to_thread.run_sync(lambda: _cockpit_connected_tenant(db, user.id, owner))
 
     try:
         repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))
@@ -464,20 +544,20 @@ async def personal_analytics_cockpit(
 
     (
         member_count,
-        recent_events,
+        (recent_events, (commit_activity_4w, commit_heatmap_52w)),
         open_pr_count,
         pr_merge_rate_4w,
-        (commit_activity_4w, commit_heatmap_52w),
         total_cache_size_bytes,
         (milestones, at_risk_repos),
         pr_cycle_time_8w,
         release_cadence_4w,
     ) = await asyncio.gather(
         anyio.to_thread.run_sync(lambda: _safe_member_count(owner, token)),
-        anyio.to_thread.run_sync(lambda: _safe_recent_events(owner, token)),
+        anyio.to_thread.run_sync(
+            lambda: _cockpit_events_and_commit_activity(db, owner, token, connected_tenant_id, repo_names)
+        ),
         anyio.to_thread.run_sync(lambda: _safe_open_pr_count(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_pr_merge_rate_4w(owner, token)),
-        anyio.to_thread.run_sync(lambda: _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_total_cache_bytes(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_milestones(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_pr_cycle_time_8w(owner, token)),
@@ -500,6 +580,7 @@ async def personal_analytics_cockpit(
         milestones=milestones,
         pr_cycle_time_8w=pr_cycle_time_8w,
         release_cadence_4w=release_cadence_4w,
+        commit_activity_source="aggregate" if connected_tenant_id is not None else "github",
     )
 
 

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -14,16 +14,16 @@ sibling org-scoped router's convention of defining its complete path locally.
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
-from src.core.db import RepoEvent, RepoEventDailyCount, get_db
-from src.core.rbac import OrgContext, require_org_role
+from src.core.db import RepoEvent, RepoEventDailyCount, SessionLocal, get_db
+from src.core.rbac import OrgContext, require_org_role, set_tenant_session_context
 from src.repositories import installation_repo
 from src.schemas.github import (
     ActivitySummaryEntry,
@@ -269,7 +269,7 @@ def _activity_summary_snapshot(db: Session, org_login: str, ctx: OrgContext, day
     connected = _org_installation_connected(db, org_login, ctx)
     totals: list[ActivitySummaryEntry] = []
     if connected:
-        cutoff = date.today() - timedelta(days=days - 1)
+        cutoff = datetime.now(timezone.utc).date() - timedelta(days=days - 1)
         rows = (
             db.query(RepoEventDailyCount.repo, RepoEventDailyCount.event_type, func.sum(RepoEventDailyCount.count))
             .filter(RepoEventDailyCount.tenant_id == ctx.org.tenant_id, RepoEventDailyCount.day >= cutoff)
@@ -325,17 +325,37 @@ def org_activity_summary(
     return _activity_summary_snapshot(db, org_login, ctx, days)
 
 
+def _activity_summary_stream_session(org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+    """Owns a dedicated DB session for the SSE connection's whole lifetime instead of the
+    request-scoped `Depends(get_db)` session: FastAPI 0.116.1 runs a yield-dependency's
+    cleanup as soon as the route handler *returns* the StreamingResponse object, not after
+    this generator finishes streaming its body -- a borrowed request session would already
+    be closed (and its tenant/user SET vars RESET) before this loop's first poll runs."""
+    db = SessionLocal()
+    try:
+        set_tenant_session_context(db, ctx.org.tenant_id, ctx.membership.user_id)
+        yield from _activity_summary_stream(db, org_login, ctx, days, poll_interval)
+    finally:
+        try:
+            db.rollback()
+            db.execute(text("RESET app.tenant_id"))
+            db.execute(text("RESET app.user_id"))
+            db.commit()
+        finally:
+            db.close()
+
+
 @router.get("/github/orgs/{org_login}/activity-summary/stream")
 def org_activity_summary_stream(
     org_login: str,
     days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
-    db: Session = Depends(get_db),
 ):
     """SSE channel pushing the same shape org_activity_summary returns, whenever it
-    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream."""
+    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream
+    and _activity_summary_stream_session."""
     days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
-    return StreamingResponse(_activity_summary_stream(db, org_login, ctx, days), media_type="text/event-stream")
+    return StreamingResponse(_activity_summary_stream_session(org_login, ctx, days), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -14,16 +14,20 @@ sibling org-scoped router's convention of defining its complete path locally.
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from src.core.db import RepoEvent, get_db
+from src.core.db import RepoEvent, RepoEventDailyCount, get_db
 from src.core.rbac import OrgContext, require_org_role
 from src.repositories import installation_repo
 from src.schemas.github import (
+    ActivitySummaryEntry,
+    ActivitySummaryResponse,
     FailedRunsInput,
     FailedRunsResponse,
     FailedRunSummary,
@@ -224,6 +228,114 @@ def org_events(
         return _cached_events(org_login, token, payload.per_page)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
+
+
+# ---------------------------------------------------------------------------
+# S6 foundation: first read path against a pre-computed aggregate table instead
+# of repo_events row-by-row or a live GitHub call. repo_event_daily_counts
+# (migration 0037, S4 PR 2) has been upserted by apps/worker's event_consumer.py
+# and backfill.py since S4/S5 shipped, but nothing in apps/api has read it until
+# now -- this is the "aggregates-first API" half of S6's own branch name
+# (feat/aggregates-api-sse), proving the read + live-push pattern once on one
+# real slice of data before the feature-module phases (8, 10/16, 11/18, 12/14,
+# 13, 17) each build their own dashboard on top of it.
+# ---------------------------------------------------------------------------
+
+# Same reasoning as _MAX_REPOS_FOR_FEED below: an upper bound on a client-supplied
+# window, not a default -- keeps a mistaken/malicious `days=100000` from summing an
+# unbounded number of daily-count rows.
+_ACTIVITY_SUMMARY_MAX_DAYS = 90
+_ACTIVITY_SUMMARY_DEFAULT_DAYS = 7
+
+# SSE poll cadence and a hard cap on how long a single stream connection stays open
+# (v1: poll-and-diff against the aggregate table, not Postgres LISTEN/NOTIFY or a
+# Redis pub/sub channel -- simplest thing that proves live-push works; a client
+# whose connection hits the cap just reconnects, same as any short-lived SSE
+# gateway timeout would force anyway).
+_SSE_POLL_INTERVAL_SECONDS = 5
+_SSE_MAX_DURATION_SECONDS = 15 * 60
+
+
+def _org_installation_connected(db: Session, org_login: str, ctx: OrgContext) -> bool:
+    # Same installation_id-presence guard as org_events above (see that handler's
+    # comment) -- repo_event_daily_counts is upserted by the same pipeline that
+    # populates repo_events, so it's only ever non-empty for a tenant with a real
+    # connected installation.
+    installation = installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=org_login)
+    return installation is not None and installation.installation_id is not None
+
+
+def _activity_summary_snapshot(db: Session, org_login: str, ctx: OrgContext, days: int) -> ActivitySummaryResponse:
+    connected = _org_installation_connected(db, org_login, ctx)
+    totals: list[ActivitySummaryEntry] = []
+    if connected:
+        cutoff = date.today() - timedelta(days=days - 1)
+        rows = (
+            db.query(RepoEventDailyCount.repo, RepoEventDailyCount.event_type, func.sum(RepoEventDailyCount.count))
+            .filter(RepoEventDailyCount.tenant_id == ctx.org.tenant_id, RepoEventDailyCount.day >= cutoff)
+            .group_by(RepoEventDailyCount.repo, RepoEventDailyCount.event_type)
+            .all()
+        )
+        totals = [ActivitySummaryEntry(repo=repo, event_type=event_type, count=int(count)) for repo, event_type, count in rows]
+    return ActivitySummaryResponse(
+        org=org_login, days=days, connected=connected, generated_at=datetime.now(timezone.utc), totals=totals
+    )
+
+
+def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+    """SSE body generator. Runs in Starlette's threadpool iterator (this route is a plain
+    `def`, matching every other handler in this file, so FastAPI already executes it off
+    the event loop) -- the blocking time.sleep below does not stall other requests.
+
+    Only emits a real `activity_summary` event when the aggregate actually changed since
+    the last poll (comparing on totals/connected, not generated_at, which changes every
+    poll by definition); otherwise emits an SSE comment as a heartbeat, both to keep
+    intermediary proxies from closing an idle-looking connection and to give the client a
+    liveness signal distinct from "no events yet"."""
+    deadline = time.monotonic() + _SSE_MAX_DURATION_SECONDS
+    last_key: tuple | None = None
+    while time.monotonic() < deadline:
+        snapshot = _activity_summary_snapshot(db, org_login, ctx, days)
+        key = (snapshot.connected, tuple(sorted((t.repo, t.event_type, t.count) for t in snapshot.totals)))
+        if key != last_key:
+            yield f"event: activity_summary\ndata: {snapshot.model_dump_json()}\n\n"
+            last_key = key
+        else:
+            yield ": heartbeat\n\n"
+        time.sleep(poll_interval)
+
+
+@router.get("/github/orgs/{org_login}/activity-summary", response_model=ActivitySummaryResponse)
+def org_activity_summary(
+    org_login: str,
+    days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    """Per-repo, per-event-type event counts over a trailing window, read from the
+    pre-computed repo_event_daily_counts rollup -- no live GitHub call, no token. GET (not
+    POST like org_events/failed-runs/release-timeline) because, unlike those, this never
+    takes a client-supplied token in its body -- there is nothing here that needs to avoid
+    a URL/query string.
+
+    Returns connected=False with empty totals (200, not an error) for a legacy PAT-only
+    org that has no GitHub App installation -- repo_event_daily_counts is only ever
+    populated for a tenant with one, same gating as org_events' repo_events path."""
+    days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
+    return _activity_summary_snapshot(db, org_login, ctx, days)
+
+
+@router.get("/github/orgs/{org_login}/activity-summary/stream")
+def org_activity_summary_stream(
+    org_login: str,
+    days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    """SSE channel pushing the same shape org_activity_summary returns, whenever it
+    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream."""
+    days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
+    return StreamingResponse(_activity_summary_stream(db, org_login, ctx, days), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -1,14 +1,16 @@
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import date, datetime, timedelta, timezone
 
 import httpx
 from checks.github_checks import BranchProtectionEnabled, SecretScanningEnabled
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from src.core.db import get_db
+from src.core.db import RepoEventDailyCount, get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.repositories import installation_repo
 from src.schemas.repos import (
     RepoListInput,
     RepoListResponse,
@@ -70,30 +72,84 @@ def _fetch_latest_release(client: GitHubClient, owner: str, repo: str) -> dict |
     }
 
 
-def _fetch_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+def _repo_org_connected(db: Session, org_id: int, account_login: str) -> bool:
+    # Same installation_id-presence gate as src.routers.github's org_events/
+    # org_activity_summary -- repo_event_daily_counts is only ever populated for a
+    # tenant with a real connected GitHub App installation. Not shared code (routers
+    # don't import each other's private helpers in this codebase); duplicated per call
+    # site on purpose, same precedent as org_events' own comment about this check.
+    installation = installation_repo.get_for_org(db, org_id=org_id, account_login=account_login)
+    return installation is not None and installation.installation_id is not None
+
+
+def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str) -> list[dict]:
+    """Same {week, total, days} shape GitHub's stats/commit_activity returns (52 weeks,
+    oldest first, week = Unix seconds at that week's Sunday 00:00 UTC, days = 7 ints
+    Sun-Sat) -- built from repo_event_daily_counts' push-event counts instead of GitHub's
+    actual commit counts. This is an approximation (a push can carry multiple commits,
+    and doesn't 1:1 map to "commits" the way GitHub's own stat does) -- callers must set
+    RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
+    today = date.today()
+    # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
+    current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
+    oldest_week_start = current_week_start - timedelta(weeks=51)
+
+    rows = (
+        db.query(RepoEventDailyCount.day, RepoEventDailyCount.count)
+        .filter(
+            RepoEventDailyCount.tenant_id == tenant_id,
+            RepoEventDailyCount.repo == repo,
+            RepoEventDailyCount.event_type == "push",
+            RepoEventDailyCount.day >= oldest_week_start,
+        )
+        .all()
+    )
+    counts_by_day = {row.day: row.count for row in rows}
+
+    weeks = []
+    for i in range(52):
+        week_start = oldest_week_start + timedelta(weeks=i)
+        days = [counts_by_day.get(week_start + timedelta(days=d), 0) for d in range(7)]
+        week_epoch = int(datetime(week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc).timestamp())
+        weeks.append({"week": week_epoch, "total": sum(days), "days": days})
+    return weeks
+
+
+def _fetch_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     client = GitHubClient(token)
-    # The five calls are independent — run them concurrently rather than one at a time.
+    # The calls are independent — run them concurrently rather than one at a time.
     # commit_activity/participation/contributors intentionally still propagate real
     # errors (a 4xx/5xx here means the repo/stats are genuinely unavailable), while
-    # repo_meta/latest_release degrade gracefully — see their own functions.
+    # repo_meta/latest_release degrade gracefully — see their own functions. When
+    # `connected`, commit_activity is served from repo_event_daily_counts instead (S6) --
+    # one fewer live GitHub call, see _repo_commit_activity_from_aggregate.
     with ThreadPoolExecutor(max_workers=5) as pool:
         repo_meta_f = pool.submit(_fetch_repo_meta, client, owner, repo)
-        commit_activity_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+        commit_activity_f = None if connected else pool.submit(
+            client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity"
+        )
         participation_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/participation")
         contributors_f = pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/contributors")
         latest_release_f = pool.submit(_fetch_latest_release, client, owner, repo)
 
         repo_meta = repo_meta_f.result()
-        commit_activity = commit_activity_f.result()
+        if connected:
+            commit_activity = _repo_commit_activity_from_aggregate(db, tenant_id, f"{owner}/{repo}")
+            commit_activity_source = "aggregate"
+        else:
+            raw_commit_activity = commit_activity_f.result()
+            # GitHub computes these stats asynchronously and returns 202 with an empty
+            # body on a cache miss — treat "not a list yet" as "not ready", not an error.
+            commit_activity = raw_commit_activity if isinstance(raw_commit_activity, list) else []
+            commit_activity_source = "github"
         participation = participation_f.result()
         contributors = contributors_f.result()
         latest_release = latest_release_f.result()
 
     return {
         "repository": f"{owner}/{repo}",
-        # GitHub computes these stats asynchronously and returns 202 with an empty body
-        # on a cache miss — treat "not a list/dict yet" as "not ready", not an error.
-        "commit_activity": commit_activity if isinstance(commit_activity, list) else [],
+        "commit_activity": commit_activity,
+        "commit_activity_source": commit_activity_source,
         "participation": participation if isinstance(participation, dict) else {},
         "contributors": contributors if isinstance(contributors, list) else [],
         "stargazers_count": repo_meta.get("stargazers_count", 0),
@@ -114,13 +170,13 @@ def _evict_expired_stats(now: float) -> None:
         del _stats_cache[key]
 
 
-def _cached_stats(owner: str, repo: str, token: str) -> RepoStatsResponse:
+def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     key = (owner, repo, _token_hash(token))
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:
         return cached[1]
-    stats = _fetch_stats(owner, repo, token)
+    stats = _fetch_stats(owner, repo, token, db, tenant_id, connected)
     _stats_cache[key] = (now, stats)
     _evict_expired_stats(now)
     return stats
@@ -173,8 +229,9 @@ def org_repo_stats(
         token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    connected = _repo_org_connected(db, ctx.org.id, owner)
     try:
-        return _cached_stats(owner, repo, token)
+        return _cached_stats(owner, repo, token, db, ctx.org.tenant_id, connected)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
 

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -27,7 +27,7 @@ from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_to
 router = APIRouter()
 
 _STATS_CACHE_TTL_SECONDS = 600
-_stats_cache: dict[tuple[str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
+_stats_cache: dict[tuple[int, str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
 
 
 def _token_hash(token: str) -> str:
@@ -91,8 +91,7 @@ def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str)
     RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
     # UTC, not the process-local date: RepoEventDailyCount.day is always the UTC
     # calendar day (repo_events_store.py forces UTC before deriving it), so bucketing
-    # against a non-UTC local date here could misalign the current/oldest week boundary
-    # (CodeRabbit finding on this PR).
+    # against a non-UTC local date here could misalign the current/oldest week boundary.
     today = datetime.now(timezone.utc).date()
     # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
     current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
@@ -177,8 +176,11 @@ def _evict_expired_stats(now: float) -> None:
 def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
     # `connected` is part of the key, not just an argument to the miss path: without it,
     # an installation connecting/disconnecting mid-TTL could serve a cached response with
-    # a stale commit_activity_source (CodeRabbit finding on this PR).
-    key = (owner, repo, _token_hash(token), connected)
+    # a stale commit_activity_source. `tenant_id` is part of the key too: orgs.github_login
+    # is unique, so (owner, repo) can't currently collide across tenants through the normal
+    # request path, but keying on tenant_id directly removes any reliance on that invariant
+    # holding rather than trusting it implicitly.
+    key = (tenant_id, owner, repo, _token_hash(token), connected)
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:

--- a/apps/api/src/routers/repos.py
+++ b/apps/api/src/routers/repos.py
@@ -1,7 +1,7 @@
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from checks.github_checks import BranchProtectionEnabled, SecretScanningEnabled
@@ -27,7 +27,7 @@ from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_to
 router = APIRouter()
 
 _STATS_CACHE_TTL_SECONDS = 600
-_stats_cache: dict[tuple[str, str, str], tuple[float, RepoStatsResponse]] = {}
+_stats_cache: dict[tuple[str, str, str, bool], tuple[float, RepoStatsResponse]] = {}
 
 
 def _token_hash(token: str) -> str:
@@ -89,7 +89,11 @@ def _repo_commit_activity_from_aggregate(db: Session, tenant_id: int, repo: str)
     actual commit counts. This is an approximation (a push can carry multiple commits,
     and doesn't 1:1 map to "commits" the way GitHub's own stat does) -- callers must set
     RepoStatsResponse.commit_activity_source="aggregate" so the UI can label it as such."""
-    today = date.today()
+    # UTC, not the process-local date: RepoEventDailyCount.day is always the UTC
+    # calendar day (repo_events_store.py forces UTC before deriving it), so bucketing
+    # against a non-UTC local date here could misalign the current/oldest week boundary
+    # (CodeRabbit finding on this PR).
+    today = datetime.now(timezone.utc).date()
     # weekday(): Monday=0..Sunday=6; this finds the Sunday on/before `today`.
     current_week_start = today - timedelta(days=(today.weekday() + 1) % 7)
     oldest_week_start = current_week_start - timedelta(weeks=51)
@@ -171,7 +175,10 @@ def _evict_expired_stats(now: float) -> None:
 
 
 def _cached_stats(owner: str, repo: str, token: str, db: Session, tenant_id: int, connected: bool) -> RepoStatsResponse:
-    key = (owner, repo, _token_hash(token))
+    # `connected` is part of the key, not just an argument to the miss path: without it,
+    # an installation connecting/disconnecting mid-TTL could serve a cached response with
+    # a stale commit_activity_source (CodeRabbit finding on this PR).
+    key = (owner, repo, _token_hash(token), connected)
     now = time.monotonic()
     cached = _stats_cache.get(key)
     if cached and now - cached[0] < _STATS_CACHE_TTL_SECONDS:

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -82,6 +82,7 @@ class CockpitResponse(BaseModel):
     milestones: list[MilestoneSummary] = []
     pr_cycle_time_8w: list[PrCycleTimeWeek] = []
     release_cadence_4w: list[int] = []
+    commit_activity_source: Literal["github", "aggregate"] = "github"
 
 
 class PRSummary(BaseModel):

--- a/apps/api/src/schemas/github.py
+++ b/apps/api/src/schemas/github.py
@@ -65,3 +65,21 @@ class ReleaseSummary(BaseModel):
 class ReleaseTimelineResponse(BaseModel):
     org: str
     releases: list[ReleaseSummary]
+
+
+class ActivitySummaryEntry(BaseModel):
+    repo: str
+    event_type: str
+    count: int
+
+
+class ActivitySummaryResponse(BaseModel):
+    org: str
+    days: int
+    # False for a legacy PAT-only org (no GitHub App installation -> repo_event_daily_counts
+    # is never populated for its tenant) -- totals is always [] in that case, not an error,
+    # since a dashboard polling this should degrade gracefully rather than treat it as a
+    # failure. See src.routers.github's org_activity_summary docstring.
+    connected: bool
+    generated_at: datetime
+    totals: list[ActivitySummaryEntry]

--- a/apps/api/src/schemas/repos.py
+++ b/apps/api/src/schemas/repos.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, SecretStr
 
 
@@ -41,6 +43,11 @@ class LatestRelease(BaseModel):
 class RepoStatsResponse(BaseModel):
     repository: str
     commit_activity: list[dict]
+    # "aggregate" when commit_activity is built from repo_event_daily_counts (S6) instead
+    # of a live GitHub stats/commit_activity call -- push-*event* counts, not actual
+    # commit counts, so the UI must label this as an estimate, not exact. See
+    # src.routers.repos._repo_commit_activity_from_aggregate.
+    commit_activity_source: Literal["github", "aggregate"] = "github"
     participation: dict
     contributors: list[dict]
     stargazers_count: int

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -7,10 +7,11 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import Job, User, get_db
-from src.repositories import org_repo, scan_results_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo, scan_results_repo
 from src.routers.analytics import router
 
 _HTTP_ERROR = httpx.HTTPStatusError(
@@ -198,6 +199,188 @@ def test_cockpit_falls_back_to_client_supplied_token_header(http, db, mock_user)
         _stop_all(patchers)
 
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# S6: commit_activity_4w/commit_heatmap_52w + recent_events served from
+# repo_event_daily_counts/repo_events (not live GitHub) for an org the caller is
+# a member of with a connected GitHub App installation -- partial re-point,
+# everything else in CockpitResponse still comes from live GitHub calls (see
+# analytics.py's _cockpit_commit_activity_from_aggregate docstring and the
+# plan.md status update for the accuracy tradeoff).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+    return org
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def _insert_repo_event(db, tenant_id, *, delivery_id, event_type, actor, repo, summary, occurred_at):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_events (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at) "
+            "VALUES (:tenant_id, :delivery_id, :event_type, :actor, '', :repo, :summary, :occurred_at)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "delivery_id": delivery_id,
+            "event_type": event_type,
+            "actor": actor,
+            "repo": repo,
+            "summary": summary,
+            "occurred_at": occurred_at,
+        },
+    )
+    db.commit()
+
+
+# Excludes the two helpers this section exercises for real -- every other GitHub-calling
+# helper stays mocked so a connected-org test doesn't also need to fake GitHub responses
+# for member_count/open_pr_count/etc.
+_CONNECTED_SAFE_MOCKS = {
+    target: kwargs
+    for target, kwargs in _DEFAULT_SAFE_MOCKS.items()
+    if target
+    not in (
+        "src.routers.analytics._safe_recent_events",
+        "src.routers.analytics._safe_commit_activity_4w_and_heatmap_52w",
+    )
+}
+
+
+def test_cockpit_connected_org_uses_aggregate_commit_activity(http, db, mock_user, acme_org_with_installation):
+    today = datetime.now(timezone.utc).date()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=4)
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "aggregate"
+    assert len(body["commit_heatmap_52w"]) == 52
+    assert body["commit_heatmap_52w"][-1] == 4
+    assert body["commit_activity_4w"][-1] == 4
+
+
+def test_cockpit_connected_org_sums_commit_activity_across_repos(http, db, mock_user, acme_org_with_installation):
+    today = datetime.now(timezone.utc).date()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/worker", event_type="push", day=today, count=2)
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    assert resp.json()["commit_heatmap_52w"][-1] == 5
+
+
+def test_cockpit_connected_org_uses_repo_events_for_recent_events_not_live_github(
+    http, db, mock_user, acme_org_with_installation
+):
+    _insert_repo_event(
+        db,
+        acme_org_with_installation.tenant_id,
+        delivery_id="d1",
+        event_type="push",
+        actor="octocat",
+        repo="acme/demo",
+        summary="pushed to main",
+        occurred_at=datetime.now(timezone.utc),
+    )
+
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with (
+            patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+            patch("src.routers.analytics._cached_events") as mock_cached_events,
+        ):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    events = resp.json()["recent_events"]
+    assert len(events) == 1
+    assert events[0]["actor"] == "octocat"
+    mock_cached_events.assert_not_called()
+
+
+def test_cockpit_falls_back_to_github_when_the_installation_has_no_installation_id(
+    http, db, mock_user, acme_org_with_installation
+):
+    # Same sync_org_installation known-admin gap covered elsewhere (org_events,
+    # repos.py's _repo_org_connected): a row can exist with installation_id IS NULL.
+    inst = installation_repo.get_for_org(db, org_id=acme_org_with_installation.id, account_login="acme")
+    inst.installation_id = None
+    db.commit()
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity_4w"] == [1, 2, 3, 4]  # the default GitHub-path mock's value
+
+
+def test_cockpit_does_not_read_aggregate_for_org_the_caller_is_not_a_member_of(http, db, mock_user):
+    # A connected org exists, but mock_user has no membership row in it -- the
+    # bring-your-own-token path must not leak that unrelated org's internal
+    # repo_event_daily_counts just because the `owner` login happens to match.
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+    _insert_daily_count(db, org.tenant_id, repo="acme/demo", event_type="push", day=datetime.now(timezone.utc).date(), count=99)
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity_4w"] == [1, 2, 3, 4]  # default mock's value, not the aggregate's 99
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -1,0 +1,207 @@
+"""Tests for the S6 aggregates-first activity-summary endpoints (JSON + SSE), the first
+concrete piece of the feat/aggregates-api-sse foundation -- see docs/plan.md's S6 section."""
+
+import json
+from datetime import date, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.routers.github import _activity_summary_stream, router as github_router
+
+_MEMBER = UserOut(id=1, email="member@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    user = User(id=_MEMBER.id, email=_MEMBER.email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    return org
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+@pytest.fixture()
+def client(db, acme_org):
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: _MEMBER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def test_activity_summary_sums_counts_within_the_window(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=3)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today - timedelta(days=1), count=2
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert body["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 5}]
+
+
+def test_activity_summary_excludes_counts_outside_the_window(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=3)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today - timedelta(days=10), count=99
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 7})
+
+    assert resp.json()["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 3}]
+
+
+def test_activity_summary_groups_by_repo_and_event_type(client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="issues", day=today, count=2)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/worker", event_type="push", day=today, count=4)
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    totals = {(t["repo"], t["event_type"]): t["count"] for t in resp.json()["totals"]}
+    assert totals == {("acme/api", "push"): 1, ("acme/api", "issues"): 2, ("acme/worker", "push"): 4}
+
+
+def test_activity_summary_days_param_is_clamped_to_max(client, db, acme_org_with_installation):
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 100_000})
+    assert resp.status_code == 200
+    assert resp.json()["days"] == 90
+
+
+def test_activity_summary_days_param_is_clamped_to_min(client, db, acme_org_with_installation):
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 0})
+    assert resp.status_code == 200
+    assert resp.json()["days"] == 1
+
+
+def test_activity_summary_returns_empty_and_unconnected_for_legacy_pat_org(client, acme_org):
+    # acme_org has no installation fixture -- repo_event_daily_counts is never populated
+    # for a tenant without one (same gating as org_events' repo_events path).
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is False
+    assert body["totals"] == []
+
+
+def test_activity_summary_treats_installation_without_installation_id_as_unconnected(client, db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=None, org_id=acme_org.id
+    )
+
+    resp = client.get("/github/orgs/acme/activity-summary")
+
+    assert resp.json()["connected"] is False
+
+
+def test_activity_summary_unknown_org_returns_404(client):
+    resp = client.get("/github/orgs/does-not-exist/activity-summary")
+    assert resp.status_code == 404
+
+
+def test_activity_summary_non_member_forbidden(db, acme_org):
+    app = FastAPI()
+    app.include_router(github_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=99, email="outsider@example.com", name=None, is_workspace_admin=False
+    )
+    app.dependency_overrides[get_db] = lambda: db
+    outsider_client = TestClient(app)
+
+    resp = outsider_client.get("/github/orgs/acme/activity-summary")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# SSE stream -- tested against the generator function directly (not through
+# TestClient's own streaming, which would require a real multi-second wait per
+# poll interval); a tiny poll_interval keeps these tests fast.
+# ---------------------------------------------------------------------------
+
+
+def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme_org_with_installation, rbac_ctx_factory):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    ctx = rbac_ctx_factory(acme_org_with_installation)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    second = next(gen)
+    gen.close()
+
+    assert first.startswith("event: activity_summary\ndata: ")
+    payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
+    assert payload["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 1}]
+    assert second == ": heartbeat\n\n"
+
+
+def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_with_installation, rbac_ctx_factory):
+    today = date.today()
+    ctx = rbac_ctx_factory(acme_org_with_installation)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
+    second = next(gen)
+    gen.close()
+
+    assert json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())["totals"] == []
+    assert second.startswith("event: activity_summary\ndata: ")
+
+
+def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_factory):
+    ctx = rbac_ctx_factory(acme_org)
+
+    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    first = next(gen)
+    gen.close()
+
+    payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
+    assert payload["connected"] is False
+
+
+@pytest.fixture()
+def rbac_ctx_factory(db):
+    from src.core.rbac import OrgContext, set_tenant_session_context
+    from src.repositories import tenant_repo
+
+    def _make(org):
+        set_tenant_session_context(db, org.tenant_id, _MEMBER.id)
+        membership = tenant_repo.get_membership(db, org.tenant_id, _MEMBER.id)
+        return OrgContext(org=org, membership=membership)
+
+    return _make

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -2,7 +2,7 @@
 concrete piece of the feat/aggregates-api-sse foundation -- see docs/plan.md's S6 section."""
 
 import json
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from fastapi import FastAPI
@@ -81,6 +81,33 @@ def test_activity_summary_excludes_counts_outside_the_window(client, db, acme_or
     resp = client.get("/github/orgs/acme/activity-summary", params={"days": 7})
 
     assert resp.json()["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 3}]
+
+
+def test_activity_summary_cutoff_uses_utc_calendar_not_host_local_time(client, db, acme_org_with_installation, monkeypatch):
+    """Regression test (CodeRabbit finding on PR #349): RepoEventDailyCount.day is always
+    a UTC date, so the cutoff must be derived from the UTC calendar, not date.today()'s
+    host-local one -- a host running behind UTC could otherwise treat the newest UTC day's
+    row as not-yet-arrived and omit it."""
+    import src.routers.github as github_module
+
+    fixed_now = datetime(2026, 1, 10, 0, 30, tzinfo=timezone.utc)
+
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(github_module, "datetime", _FixedDateTime)
+
+    # days=1 -> cutoff must be the UTC date of fixed_now (Jan 10), not Jan 9, which is
+    # what a host running e.g. US-Pacific local time (UTC-8) would compute at this same
+    # instant via date.today().
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=date(2026, 1, 10), count=7)
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=date(2026, 1, 9), count=99)
+
+    resp = client.get("/github/orgs/acme/activity-summary", params={"days": 1})
+
+    assert resp.json()["totals"] == [{"repo": "acme/api", "event_type": "push", "count": 7}]
 
 
 def test_activity_summary_groups_by_repo_and_event_type(client, db, acme_org_with_installation):
@@ -192,6 +219,42 @@ def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_
 
     payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
     assert payload["connected"] is False
+
+
+def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
+    """Regression test (CodeRabbit finding on PR #349): the SSE route must not reuse the
+    request-scoped `Depends(get_db)` session, which FastAPI 0.116.1 closes (and RESETs its
+    tenant/user SET vars on) as soon as the route handler returns the StreamingResponse --
+    before this generator has streamed anything. Verifies the wrapper opens its own
+    session via SessionLocal, sets tenant context on it, and closes it once the stream
+    ends, independent of _activity_summary_stream's own query logic (covered above)."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    import src.routers.github as github_module
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(github_module, "SessionLocal", lambda: fake_db)
+
+    captured: dict = {}
+
+    def _fake_inner_stream(db, org_login, ctx, days, poll_interval):
+        captured["db"] = db
+        yield "event: activity_summary\ndata: {}\n\n"
+
+    monkeypatch.setattr(github_module, "_activity_summary_stream", _fake_inner_stream)
+
+    ctx = SimpleNamespace(org=SimpleNamespace(tenant_id=42), membership=SimpleNamespace(user_id=7))
+    gen = github_module._activity_summary_stream_session("acme", ctx, days=1, poll_interval=0)
+    first = next(gen)
+    gen.close()
+
+    assert first == "event: activity_summary\ndata: {}\n\n"
+    assert captured["db"] is fake_db
+    executed_sql = [c.args[0].text for c in fake_db.execute.call_args_list]
+    assert "SET app.tenant_id = 42" in executed_sql
+    assert "SET app.user_id = 7" in executed_sql
+    fake_db.close.assert_called_once()
 
 
 @pytest.fixture()

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -356,6 +356,39 @@ def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
     db.commit()
 
 
+def test_repo_stats_cache_is_isolated_by_tenant_id(db, acme_org_with_installation):
+    # Defense in depth: orgs.github_login is unique, so two tenants can't legitimately
+    # share the same (owner, repo) through the normal org-resolution path today -- but the
+    # cache itself must not rely on that invariant. Bypasses the HTTP layer (owner==org_login
+    # is enforced there) to call _cached_stats directly with the same owner/repo/token for
+    # two different tenants, mirroring what the route handler's own tenant resolution does.
+    from src.core.rbac import set_tenant_session_context
+    from src.routers.repos import _cached_stats, _stats_cache
+
+    _stats_cache.clear()
+    other_user = User(id=2, email="other@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(other_user)
+    db.commit()
+    other_org = org_repo.get_or_create(db, github_login="other")
+    org_membership_repo.get_or_create(db, org_id=other_org.id, user_id=other_user.id, role="member")
+
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=5)
+    _insert_daily_count(db, other_org.tenant_id, repo="acme/demo", event_type="push", day=today, count=9)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+
+        set_tenant_session_context(db, acme_org_with_installation.tenant_id, _ADMIN.id)
+        first = _cached_stats("acme", "demo", "shared-token", db, acme_org_with_installation.tenant_id, True)
+
+        set_tenant_session_context(db, other_org.tenant_id, other_user.id)
+        second = _cached_stats("acme", "demo", "shared-token", db, other_org.tenant_id, True)
+
+    assert first["commit_activity"][-1]["total"] == 5
+    assert second["commit_activity"][-1]["total"] == 9
+
+
 def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(repos_client, db, acme_org_with_installation):
     today = date.today()
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
@@ -390,7 +423,7 @@ def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outsi
 ):
     # A fixed Monday, not the real "today" -- if this test ran on a real Sunday,
     # `today - timedelta(days=1)` would fall in the *previous* Sunday-starting week,
-    # breaking the "same week" assumption below (CodeRabbit finding on this PR).
+    # breaking the "same week" assumption below.
     today = date(2000, 1, 3)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
     _insert_daily_count(

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -1,6 +1,6 @@
 """Tests for the repos router (Phase 8 groundwork)."""
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import httpx
@@ -388,7 +388,10 @@ def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(r
 def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outside_window(
     repos_client, db, acme_org_with_installation
 ):
-    today = date.today()
+    # A fixed Monday, not the real "today" -- if this test ran on a real Sunday,
+    # `today - timedelta(days=1)` would fall in the *previous* Sunday-starting week,
+    # breaking the "same week" assumption below (CodeRabbit finding on this PR).
+    today = date(2000, 1, 3)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
     _insert_daily_count(
         db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(days=1), count=1
@@ -400,8 +403,10 @@ def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outsi
     # A different event type on the same day -- must not be counted (commit_activity is push-only).
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="issues", day=today, count=50)
 
-    with patch("src.routers.repos.GitHubClient") as mock_client:
+    with patch("src.routers.repos.GitHubClient") as mock_client, patch("src.routers.repos.datetime") as mock_datetime:
         mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+        mock_datetime.now.return_value = datetime(today.year, today.month, today.day, tzinfo=timezone.utc)
+        mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
         resp = repos_client.post(
             "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
         )

--- a/apps/api/tests/test_repos.py
+++ b/apps/api/tests/test_repos.py
@@ -1,15 +1,17 @@
 """Tests for the repos router (Phase 8 groundwork)."""
 
+from datetime import date, timedelta
 from unittest.mock import patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.repos import router as repos_router
 from src.routers.repos import _stats_cache
 
@@ -323,6 +325,127 @@ def test_repo_stats_different_tokens_are_not_served_from_the_same_cache_entry(re
     # Each distinct token triggers its own fetch (5 calls) rather than reusing the
     # other token's cached response -- 10 total, not 5.
     assert mock_client.return_value.request.call_count == 10
+
+
+# ---------------------------------------------------------------------------
+# S6: commit_activity served from repo_event_daily_counts for orgs with a
+# connected GitHub App installation -- partial re-point, everything else in
+# RepoStatsResponse still comes from live GitHub calls (see repos.py's
+# _fetch_stats docstring and the plan.md status update for the accuracy
+# tradeoff -- push-event counts, not exact commit counts).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+def _insert_daily_count(db, tenant_id, *, repo, event_type, day, count):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_event_daily_counts (tenant_id, repo, event_type, day, count) "
+            "VALUES (:tenant_id, :repo, :event_type, :day, :count)"
+        ),
+        {"tenant_id": tenant_id, "repo": repo, "event_type": event_type, "day": day, "count": count},
+    )
+    db.commit()
+
+
+def test_repo_stats_uses_aggregate_commit_activity_when_installation_connected(repos_client, db, acme_org_with_installation):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=3)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META,
+            participation={"all": [1], "owner": [1]},
+            contributors=[{"login": "octocat", "total": 5}],
+            release_error=_not_found(),
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit_activity_source"] == "aggregate"
+    assert len(body["commit_activity"]) == 52
+    assert body["commit_activity"][-1]["total"] == 3
+    # commit_activity is skipped entirely -- 4 live calls, not 5.
+    assert mock_client.return_value.request.call_count == 4
+    called_paths = {c.args[1] for c in mock_client.return_value.request.call_args_list}
+    assert "/repos/acme/demo/stats/commit_activity" not in called_paths
+    # Other fields still come from the live GitHub calls, unchanged.
+    assert body["stargazers_count"] == 24
+    assert body["contributors"] == [{"login": "octocat", "total": 5}]
+
+
+def test_repo_stats_aggregate_commit_activity_buckets_by_week_and_excludes_outside_window(
+    repos_client, db, acme_org_with_installation
+):
+    today = date.today()
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today, count=2)
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(days=1), count=1
+    )
+    # Well outside the 52-week window -- must not be counted anywhere.
+    _insert_daily_count(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="push", day=today - timedelta(weeks=60), count=99
+    )
+    # A different event type on the same day -- must not be counted (commit_activity is push-only).
+    _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/demo", event_type="issues", day=today, count=50)
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(repo_meta=_REPO_META, release_error=_not_found())
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    body = resp.json()
+    weeks = body["commit_activity"]
+    assert sum(w["total"] for w in weeks) == 3
+    assert weeks[-1]["total"] == 3
+
+
+def test_repo_stats_falls_back_to_github_when_the_installation_has_no_installation_id(repos_client, db, acme_org):
+    # Mirrors the same gap covered in test_github_events.py -- a row can exist with
+    # installation_id IS NULL (sync_org_installation's known-admin re-sync path) with no
+    # actual App installation, and therefore no repo_event_daily_counts rows, behind it.
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=None, org_id=acme_org.id
+    )
+
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META, commit_activity=[{"week": 1, "total": 5}], release_error=_not_found()
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    body = resp.json()
+    assert body["commit_activity_source"] == "github"
+    assert body["commit_activity"] == [{"week": 1, "total": 5}]
+    assert mock_client.return_value.request.call_count == 5
+
+
+def test_repo_stats_commit_activity_source_is_github_for_a_legacy_pat_org(repos_client):
+    # acme_org (no installation fixture) -- regression check that the fully unchanged
+    # live-GitHub path is still what a legacy PAT-only org gets.
+    with patch("src.routers.repos.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _stats_side_effect(
+            repo_meta=_REPO_META, commit_activity=[{"week": 1, "total": 5}], release_error=_not_found()
+        )
+        resp = repos_client.post(
+            "/orgs/acme/repos/acme/demo/stats", json={"token": "ghp_testtoken123456789012345678901234"}
+        )
+
+    assert resp.json()["commit_activity_source"] == "github"
 
 
 def test_list_repos_maps_github_request_error_to_503(repos_client):

--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -228,8 +228,16 @@ export default function ActivityPage() {
       {hasOrg && (
         <div className="grid gap-4 lg:grid-cols-2 mt-4">
           <div className="card lg:col-span-2">
-            <div className="px-4 py-3 border-b border-border">
+            <div className="px-4 py-3 border-b border-border flex items-center gap-2">
               <span className="section-label">Commit Heatmap (52w)</span>
+              {cockpitQuery.data?.commit_activity_source === "aggregate" && (
+                <span
+                  className="text-[0.6875rem] text-muted-foreground/70"
+                  title="Estimated from stored push events, not GitHub's exact commit count."
+                >
+                  (estimated)
+                </span>
+              )}
             </div>
             <div className="p-4">
               {(cockpitQuery.data?.commit_heatmap_52w ?? []).some((n) => n > 0) ? (

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -195,8 +195,16 @@ export default function OverviewPage() {
 
       <div className="grid gap-4 lg:grid-cols-2 mb-6">
         <div className="card">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Commit Activity (4w)</span>
+            {cockpit?.commit_activity_source === "aggregate" && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {commitActivityData.length > 0 ? (

--- a/apps/ui/app/repos/[repo]/page.tsx
+++ b/apps/ui/app/repos/[repo]/page.tsx
@@ -146,6 +146,7 @@ export default function RepoDetailPage() {
   }
 
   const commitActivity = statsQuery.data?.commit_activity ?? []
+  const isEstimatedActivity = statsQuery.data?.commit_activity_source === "aggregate"
   const areaData = commitActivity.map((w) => ({
     week: new Date(w.week * 1000).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
     value: w.total,
@@ -240,8 +241,16 @@ export default function RepoDetailPage() {
         </div>
 
         <div className="card lg:col-span-2">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Commit activity — 52 weeks</span>
+            {isEstimatedActivity && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {statsQuery.isLoading ? (
@@ -257,8 +266,16 @@ export default function RepoDetailPage() {
         </div>
 
         <div className="card">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Activity calendar</span>
+            {isEstimatedActivity && (
+              <span
+                className="text-[0.6875rem] text-muted-foreground/70"
+                title="Estimated from stored push events, not GitHub's exact commit count."
+              >
+                (estimated)
+              </span>
+            )}
           </div>
           <div className="p-4">
             {statsQuery.isLoading ? (

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -44,8 +44,9 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
   })
 
   const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
+  const isEstimated = data?.commit_activity_source === "aggregate"
   return (
-    <div ref={ref}>
+    <div ref={ref} title={isEstimated ? "Estimated from stored push events, not exact commit counts." : undefined}>
       {!inView || isLoading ? (
         <Skeleton className="h-8 w-24" />
       ) : isError ? (

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -51,11 +51,13 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
         <Skeleton className="h-8 w-24" />
       ) : isError ? (
         <CellLoadError />
-      ) : weeks.length === 0 || weeks.every((n) => n === 0) ? (
-        <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
       ) : (
         <>
-          <MiniSparkline data={weeks} height={28} />
+          {weeks.length === 0 || weeks.every((n) => n === 0) ? (
+            <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
+          ) : (
+            <MiniSparkline data={weeks} height={28} />
+          )}
           {isEstimated && (
             <span
               className="text-[0.625rem] text-muted-foreground/70 shrink-0"

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -46,7 +46,7 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
   const weeks = (data?.commit_activity ?? []).slice(-8).map((w) => w.total)
   const isEstimated = data?.commit_activity_source === "aggregate"
   return (
-    <div ref={ref} title={isEstimated ? "Estimated from stored push events, not exact commit counts." : undefined}>
+    <div ref={ref} className="flex items-center gap-1.5">
       {!inView || isLoading ? (
         <Skeleton className="h-8 w-24" />
       ) : isError ? (
@@ -54,7 +54,17 @@ function RepoActivityCell({ org, repo, token }: { org: string; repo: string; tok
       ) : weeks.length === 0 || weeks.every((n) => n === 0) ? (
         <span className="text-muted-foreground text-[0.6875rem]">— no recent activity</span>
       ) : (
-        <MiniSparkline data={weeks} height={28} />
+        <>
+          <MiniSparkline data={weeks} height={28} />
+          {isEstimated && (
+            <span
+              className="text-[0.625rem] text-muted-foreground/70 shrink-0"
+              title="Estimated from stored push events, not exact commit counts."
+            >
+              (est.)
+            </span>
+          )}
+        </>
       )}
     </div>
   )

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -389,6 +389,7 @@ export interface CockpitResponse {
   milestones: MilestoneSummary[]
   pr_cycle_time_8w: PrCycleTimeWeek[]
   release_cadence_4w: number[]
+  commit_activity_source: "github" | "aggregate"
 }
 
 export interface MyViewPRSummary {

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -107,6 +107,9 @@ export interface LatestRelease {
 export interface RepoStatsResponse {
   repository: string
   commit_activity: CommitActivityWeek[]
+  // "aggregate" when commit_activity is estimated from stored push-event counts
+  // (S6) instead of GitHub's own commit-level stats/commit_activity endpoint.
+  commit_activity_source: "github" | "aggregate"
   participation: { all?: number[]; owner?: number[] }
   contributors: { author?: { login?: string }; total: number }[]
   stargazers_count: number

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -204,6 +204,22 @@ describe("ActivityPage", () => {
     expect(screen.queryByText("No commit activity in the last year")).not.toBeInTheDocument();
   });
 
+  it("labels the commit heatmap as estimated when the cockpit source is an aggregate", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
+    analyticsCockpitMock.mockResolvedValue({
+      repo_count: 1, member_count: 1, latest_score: null, score_trend: [], recent_events: [],
+      open_pr_count: 0, pr_merge_rate_4w: [], commit_activity_4w: [], total_cache_size_bytes: 0,
+      cache_job_success_rate: 0, commit_heatmap_52w: Array.from({ length: 52 }, (_, i) => (i === 51 ? 5 : 0)),
+      commit_activity_source: "aggregate" as const,
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("(estimated)")).toBeInTheDocument();
+  });
+
   it("groups open PRs by author under the PR Board tab", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -24,11 +24,12 @@ function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <OverviewPage />
     </QueryClientProvider>,
   );
+  return { ...result, queryClient };
 }
 
 const EMPTY_COCKPIT = {
@@ -141,10 +142,10 @@ describe("OverviewPage cockpit", () => {
       commit_activity_4w: [1, 2, 3, 4],
     });
 
-    renderPage();
+    const { queryClient } = renderPage();
 
     await waitFor(() => {
-      expect(cockpitMock).toHaveBeenCalled();
+      expect(queryClient.getQueryState(["analytics.cockpit", "acme"])?.status).toBe("success");
     });
     expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
   });

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -46,6 +46,7 @@ const EMPTY_COCKPIT = {
   milestones: [],
   pr_cycle_time_8w: [],
   release_cadence_4w: [],
+  commit_activity_source: "github" as const,
 };
 
 const EMPTY_MY_VIEW = {
@@ -114,6 +115,38 @@ describe("OverviewPage cockpit", () => {
     // A single cockpit call once the token-resolve fetch settles -- not a second
     // waterfalled fetch for jobs/overview like the pre-cockpit page used to do.
     expect(cockpitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels commit activity as estimated when the cockpit source is an aggregate", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      commit_activity_4w: [1, 2, 3, 4],
+      commit_activity_source: "aggregate" as const,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("(estimated)")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the estimated caption when the cockpit source is github", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      commit_activity_4w: [1, 2, 3, 4],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(cockpitMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
   });
 
   it("renders empty states for charts and activity when the org has no data yet", async () => {

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -53,6 +53,7 @@ function renderPage() {
   );
   return {
     ...utils,
+    queryClient,
     rerenderSamePage: () =>
       utils.rerender(
         <QueryClientProvider client={queryClient}>
@@ -157,9 +158,11 @@ describe("RepoDetailPage", () => {
       contributors: [],
     });
 
-    renderPage();
+    const { queryClient } = renderPage();
 
-    await waitFor(() => expect(screen.queryByText(/no commit activity available yet/i)).not.toBeInTheDocument());
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["repo-detail-stats", "acme", "demo", ""])?.status).toBe("success");
+    });
     expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
   });
 

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -133,6 +133,36 @@ describe("RepoDetailPage", () => {
     expect(screen.getByText(/top contributors/i)).toBeInTheDocument();
   });
 
+  it("labels the commit-activity chart and calendar as estimated when the source is an aggregate", async () => {
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 4 }, (_, i) => ({ week: 1700000000 + i * 604800, total: i + 1, days: [] })),
+      commit_activity_source: "aggregate",
+      participation: {},
+      contributors: [],
+    });
+
+    renderPage();
+
+    const captions = await screen.findAllByText("(estimated)");
+    expect(captions).toHaveLength(2);
+  });
+
+  it("does not show the estimated caption when the source is github", async () => {
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 4 }, (_, i) => ({ week: 1700000000 + i * 604800, total: i + 1, days: [] })),
+      commit_activity_source: "github",
+      participation: {},
+      contributors: [],
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.queryByText(/no commit activity available yet/i)).not.toBeInTheDocument());
+    expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
+  });
+
   it("maps a contributor's real (nested) GitHub login instead of falling back to 'unknown'", async () => {
     // Regression test for the c.login vs c.author.login bug -- exercises the mapping
     // function directly the same way the component does, since recharts' XAxis tick

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -478,6 +478,51 @@ describe("ReposPage", () => {
     expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
   });
 
+  it("still marks the cell as estimated when the aggregate source has zero recent activity", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          description: null,
+          language: "Python",
+          stargazers_count: 3,
+          forks_count: 0,
+          watchers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 8 }, () => ({ week: 0, total: 0, days: [] })),
+      commit_activity_source: "aggregate",
+      participation: {},
+      contributors: [],
+      stargazers_count: 3,
+      forks_count: 0,
+      watchers_count: 3,
+      open_issues_count: 1,
+      default_branch: "main",
+      latest_release: null,
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/no recent activity/i)).toBeInTheDocument());
+    expect(screen.getByText("(est.)")).toBeInTheDocument();
+  });
+
   it("keeps rendered rows scoped to the org they were loaded for, even if the org field is edited afterward without reloading", async () => {
     reposListMock.mockResolvedValue({
       org: "acme",

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -430,6 +430,51 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
   });
 
+  it("marks the sparkline cell as estimated when the stats source is an aggregate", async () => {
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [
+        {
+          name: "demo",
+          full_name: "acme/demo",
+          private: false,
+          description: null,
+          language: "Python",
+          stargazers_count: 3,
+          forks_count: 0,
+          watchers_count: 3,
+          open_issues_count: 1,
+          pushed_at: "2026-07-01T00:00:00Z",
+          default_branch: "main",
+          html_url: "https://github.com/acme/demo",
+        },
+      ],
+    });
+    reposStatsMock.mockResolvedValue({
+      repository: "acme/demo",
+      commit_activity: Array.from({ length: 8 }, (_, i) => ({ week: i, total: i + 1, days: [] })),
+      commit_activity_source: "aggregate",
+      participation: {},
+      contributors: [],
+      stargazers_count: 3,
+      forks_count: 0,
+      watchers_count: 3,
+      open_issues_count: 1,
+      default_branch: "main",
+      latest_release: null,
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /load repositories/i }));
+
+    await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
+    expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
+  });
+
   it("keeps rendered rows scoped to the org they were loaded for, even if the org field is edited afterward without reloading", async () => {
     reposListMock.mockResolvedValue({
       org: "acme",

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -472,6 +472,9 @@ describe("ReposPage", () => {
 
     await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
+    // Visible, not just a hover-only title -- touch/keyboard users must be able to see
+    // the estimate label too (CodeRabbit finding on this PR).
+    expect(screen.getByText("(est.)")).toBeInTheDocument();
     expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
   });
 

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -473,7 +473,7 @@ describe("ReposPage", () => {
     await waitFor(() => expect(screen.getByText("demo")).toBeInTheDocument());
     await waitFor(() => expect(screen.queryByText(/no recent activity/i)).not.toBeInTheDocument());
     // Visible, not just a hover-only title -- touch/keyboard users must be able to see
-    // the estimate label too (CodeRabbit finding on this PR).
+    // the estimate label too.
     expect(screen.getByText("(est.)")).toBeInTheDocument();
     expect(screen.getByTitle(/estimated from stored push events/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Closes S6 (Aggregates-first API + SSE) from the Migration Roadmap. This is the parent branch's own PR into `main`, bundling three child PRs already reviewed and merged into `feat/aggregates-api-sse`:

- **#346** — Aggregates-first read + SSE foundation: first endpoints reading `repo_events`/`repo_event_daily_counts` directly instead of live GitHub API calls, plus an SSE stream for real-time updates.
- **#347** — Repositories page's commit-activity chart re-pointed to `repo_event_daily_counts` when the org is a connected GitHub App installation the caller is a member of; falls back to the live GitHub API otherwise.
- **#348** — Overview cockpit's commit-activity/heatmap and recent-events feed re-pointed the same way, plus an `(estimated)` UI caption when the data is aggregate-sourced (aggregates are eventually-consistent, unlike a live API call).

**Why aggregates first, not the whole dashboard:** research this stage (3 parallel investigations) found that only these two dashboard slices could be cleanly re-pointed against the aggregate tables that already exist (`repo_events`, `repo_event_daily_counts`, migrations 0036/0037). Security, Collaborators, and Automation dashboards need brand-new tables/migrations and new webhook event types to repoint anything meaningful — that's real, named future work, deliberately scoped out of S6 rather than dropped. See `docs/plan.md`'s S6 status sections for the full research writeup (not committed — local planning doc).

**Why one parent PR instead of three straight to `main`:** S6 unlocks several feature-module phases off one shared foundation (the SSE/aggregates-read layer from #346). Integrating child PRs against each other on a shared branch first catches cross-phase conflicts earlier than three independent PRs each racing to rebase onto a moving `main`.

## Notable design decisions carried in from the child PRs

- Both re-pointed endpoints gate on the caller having an active membership in the connected org (not just "an org with this login is connected") — an authorization bug caught and fixed during #348's implementation, with a regression test proving a non-member can't read another org's aggregate data by naming its login.
- Aggregate-sourced commit-activity data is now tenant-session-scoped via `set_tenant_session_context` before the RLS-protected read, matching the pattern `resolve_owner_token` should eventually adopt too (left out of scope here).
- No new migrations — every re-pointed read uses tables that already exist.

## Test plan

- [x] Full `pytest -q` suite green (769 passed, 3 skipped, 3 xpassed) against a freshly reset local Postgres
- [x] `bun run check` (typecheck + lint + build) clean
- [x] New backend tests for both re-pointed endpoints, including the not-a-member authorization regression test
- [x] New UI tests for the `(estimated)` caption's presence/absence
- [x] Each child PR already passed CI + CodeRabbit review individually before merging into this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization activity summaries with date filtering and live streaming updates.
  * Connected GitHub App installations now provide activity and commit trends from stored event data.
  * Added clear source indicators for commit activity data.

* **Improvements**
  * Commit charts, calendars, heatmaps, and repository sparklines now display “estimated” labels when based on push-event totals.
  * Legacy connections continue using GitHub data, while disconnected organizations receive graceful empty results.
  * Enhanced tenant access controls protect organization activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->