### PR TITLE
feat(api,ui): re-point Security dashboard alerts to security_alerts (post-S6 PR 3 of 3)

### DIFF
--- a/apps/api/src/routers/security.py
+++ b/apps/api/src/routers/security.py
@@ -22,7 +22,9 @@ from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
+from src.core.db import SecurityAlert, get_db
+from src.core.rbac import set_tenant_session_context
+from src.repositories import installation_repo, org_repo, tenant_repo
 from src.schemas.security import (
     MatrixSummary,
     RepoSecurityRow,
@@ -54,7 +56,67 @@ def _branch_protection_status(exc: httpx.HTTPStatusError) -> str:
     return "unprotected"
 
 
-def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
+def _security_connected_tenant(db: Session, user_id: int, owner: str) -> int | None:
+    """Mirrors analytics.py's _cockpit_connected_tenant exactly -- same personal-endpoint
+    membership check (this router is also require_auth-only, no OrgContext), same
+    installation_id-presence gate, same RLS session-context setup. Duplicated rather than
+    imported: routers don't import each other's private helpers in this codebase (see
+    repos.py's _repo_org_connected for the same precedent)."""
+    org = org_repo.get_by_login_ci(db, owner)
+    if org is None:
+        return None
+    org = org_repo.ensure_tenant_linked(db, org)
+    if tenant_repo.get_membership(db, org.tenant_id, user_id) is None:
+        return None
+    installation = installation_repo.get_for_org(db, org_id=org.id, account_login=owner)
+    if installation is None or installation.installation_id is None:
+        return None
+    set_tenant_session_context(db, org.tenant_id, user_id)
+    return org.tenant_id
+
+
+def _open_alerts_by_repo(db: Session, tenant_id: int, repo_full_names: list[str]) -> dict[str, list]:
+    """One query for every scanned repo's open dependabot/code_scanning security_alerts
+    rows, not one query per repo -- also sidesteps ThreadPoolExecutor entirely: _repo_row
+    below runs concurrently across repos (existing pattern), and a SQLAlchemy Session
+    isn't safe to share across threads, so this pre-fetches everything up front on the
+    request thread and hands each worker a plain dict slice instead of `db` itself."""
+    if not repo_full_names:
+        return {}
+    rows = (
+        db.query(SecurityAlert.repo, SecurityAlert.kind, SecurityAlert.severity)
+        .filter(
+            SecurityAlert.tenant_id == tenant_id,
+            SecurityAlert.repo.in_(repo_full_names),
+            SecurityAlert.kind.in_(("dependabot", "code_scanning")),
+            SecurityAlert.state == "open",
+        )
+        .all()
+    )
+    by_repo: dict[str, list] = {}
+    for row in rows:
+        by_repo.setdefault(row.repo, []).append(row)
+    return by_repo
+
+
+def _dependabot_and_code_scanning_from_aggregate(alert_rows: list) -> dict:
+    """dependabot/code_scanning dimensions from security_alerts (post-S6 PR 3) instead of
+    two live GitHub calls per repo. dependabot_enabled is an approximation here: security_alerts
+    only has rows for alerts that actually occurred, so a repo with Dependabot enabled but
+    zero alerts ever looks identical to one with it disabled -- both read as
+    dependabot_enabled=False, critical/high=0. This under-reports the "enabled" badge for a
+    clean repo but never affects the score (an all-zero count scores as compliant either
+    way, matching the live path's own 404-disabled handling)."""
+    dependabot_rows = [r for r in alert_rows if r.kind == "dependabot"]
+    return {
+        "dependabot_enabled": len(dependabot_rows) > 0,
+        "critical_count": sum(1 for r in dependabot_rows if r.severity == "critical"),
+        "high_count": sum(1 for r in dependabot_rows if r.severity == "high"),
+        "code_scanning_clear": not any(r.kind == "code_scanning" for r in alert_rows),
+    }
+
+
+def _repo_row(client: GitHubClient, owner: str, repo: dict, alerts_by_repo: dict[str, list] | None = None) -> RepoSecurityRow:
     name = repo["name"]
     branch = repo.get("default_branch")
     unknown: list[str] = []
@@ -82,42 +144,51 @@ def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
         (repo.get("security_and_analysis") or {}).get("secret_scanning") or {}
     ).get("status") == "enabled"
 
-    dependabot_enabled = False
-    critical_count = 0
-    high_count = 0
-    try:
-        alerts = client.request("GET", f"/repos/{owner}/{name}/dependabot/alerts", params={"state": "open"})
-        dependabot_enabled = True
-        if isinstance(alerts, list):
-            for alert in alerts:
-                severity = (alert.get("security_advisory") or {}).get("severity")
-                if severity == "critical":
-                    critical_count += 1
-                elif severity == "high":
-                    high_count += 1
-    except httpx.HTTPStatusError as exc:
-        # 404 means Dependabot alerts are genuinely disabled for this repo -- a real
-        # "no alerts" answer. Any other status (403 missing security-events scope,
-        # 429, ...) means the alert count is unknown, not zero, so it must not
-        # silently score as "no critical/high alerts" -- see the identical fix in
-        # DependabotAlertsCheck (packages/checks/src/checks/github_checks.py, 3184c76).
-        if exc.response.status_code != 404:
+    alerts_source = "github"
+    if alerts_by_repo is not None:
+        alerts_source = "aggregate"
+        aggregate = _dependabot_and_code_scanning_from_aggregate(alerts_by_repo.get(f"{owner}/{name}", []))
+        dependabot_enabled = aggregate["dependabot_enabled"]
+        critical_count = aggregate["critical_count"]
+        high_count = aggregate["high_count"]
+        code_scanning_clear = aggregate["code_scanning_clear"]
+    else:
+        dependabot_enabled = False
+        critical_count = 0
+        high_count = 0
+        try:
+            alerts = client.request("GET", f"/repos/{owner}/{name}/dependabot/alerts", params={"state": "open"})
+            dependabot_enabled = True
+            if isinstance(alerts, list):
+                for alert in alerts:
+                    severity = (alert.get("security_advisory") or {}).get("severity")
+                    if severity == "critical":
+                        critical_count += 1
+                    elif severity == "high":
+                        high_count += 1
+        except httpx.HTTPStatusError as exc:
+            # 404 means Dependabot alerts are genuinely disabled for this repo -- a real
+            # "no alerts" answer. Any other status (403 missing security-events scope,
+            # 429, ...) means the alert count is unknown, not zero, so it must not
+            # silently score as "no critical/high alerts" -- see the identical fix in
+            # DependabotAlertsCheck (packages/checks/src/checks/github_checks.py, 3184c76).
+            if exc.response.status_code != 404:
+                unknown.append("dependabot")
+        except httpx.RequestError:
             unknown.append("dependabot")
-    except httpx.RequestError:
-        unknown.append("dependabot")
 
-    code_scanning_clear = True
-    try:
-        cs_alerts = client.request("GET", f"/repos/{owner}/{name}/code-scanning/alerts", params={"state": "open"})
-        if isinstance(cs_alerts, list):
-            code_scanning_clear = len(cs_alerts) == 0
-    except httpx.HTTPStatusError as exc:
-        # Same 404-vs-other distinction as Dependabot above: 404 is a genuine
-        # "disabled, so no alerts" answer; anything else means no visibility.
-        if exc.response.status_code != 404:
+        code_scanning_clear = True
+        try:
+            cs_alerts = client.request("GET", f"/repos/{owner}/{name}/code-scanning/alerts", params={"state": "open"})
+            if isinstance(cs_alerts, list):
+                code_scanning_clear = len(cs_alerts) == 0
+        except httpx.HTTPStatusError as exc:
+            # Same 404-vs-other distinction as Dependabot above: 404 is a genuine
+            # "disabled, so no alerts" answer; anything else means no visibility.
+            if exc.response.status_code != 404:
+                unknown.append("code_scanning")
+        except httpx.RequestError:
             unknown.append("code_scanning")
-    except httpx.RequestError:
-        unknown.append("code_scanning")
 
     dimensions = {
         "branch_protection": branch_protection,
@@ -140,16 +211,21 @@ def _repo_row(client: GitHubClient, owner: str, repo: dict) -> RepoSecurityRow:
         force_push_allowed=force_push_allowed,
         score=score,
         unknown_dimensions=unknown,
+        alerts_source=alerts_source,
     )
 
 
-def _build_matrix(owner: str, token: str) -> SecurityMatrixResponse:
+def _build_matrix(owner: str, token: str, db: Session | None = None, tenant_id: int | None = None) -> SecurityMatrixResponse:
     client = GitHubClient(token)
     repos = client.request_paginated(f"/orgs/{owner}/repos", params={"type": "all", "sort": "pushed"})
     scanned = repos[:_MAX_REPOS_FOR_MATRIX]
 
+    alerts_by_repo = None
+    if db is not None and tenant_id is not None:
+        alerts_by_repo = _open_alerts_by_repo(db, tenant_id, [f"{owner}/{r['name']}" for r in scanned])
+
     with ThreadPoolExecutor(max_workers=10) as pool:
-        rows = list(pool.map(lambda r: _repo_row(client, owner, r), scanned))
+        rows = list(pool.map(lambda r: _repo_row(client, owner, r, alerts_by_repo), scanned))
 
     vuln = VulnCounts(
         critical=sum(r.dependabot_critical_count for r in rows),
@@ -177,10 +253,41 @@ def personal_security_matrix(
         token = resolve_owner_token(db, user_id=user.id, owner=owner, client_token=x_github_token)
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    tenant_id = _security_connected_tenant(db, user.id, owner)
     try:
-        return _build_matrix(owner, token)
+        return _build_matrix(owner, token, db=db, tenant_id=tenant_id)
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_error(exc) from exc
+
+
+def _secret_scanning_alerts_from_aggregate(db: Session, tenant_id: int, owner: str, repo: str) -> list[SecretAlert]:
+    """security_alerts (post-S6 PR 3) instead of a live GitHub call. No `url` field is
+    stored (only the live GitHub API response carries html_url) -- left empty, same as
+    an alert this table has no row for; the UI only uses it as an outbound link, not for
+    anything that gates alert-handling logic."""
+    rows = (
+        db.query(SecurityAlert)
+        .filter(
+            SecurityAlert.tenant_id == tenant_id,
+            SecurityAlert.repo == f"{owner}/{repo}",
+            SecurityAlert.kind == "secret_scanning",
+        )
+        .all()
+    )
+    return [
+        SecretAlert(
+            number=row.number,
+            state=row.state,
+            secret_type=row.details.get("secret_type", ""),
+            secret_type_display=row.details.get("secret_type_display_name", row.details.get("secret_type", "")),
+            resolved_reason=row.details.get("resolution"),
+            created_at=row.created_at,
+            resolved_at=row.updated_at if row.state != "open" else None,
+            repo=f"{owner}/{repo}",
+            url="",
+        )
+        for row in rows
+    ]
 
 
 @router.get("/me/repos/{owner}/{repo}/secret-scanning", response_model=SecretScanningResponse)
@@ -195,6 +302,11 @@ def personal_secret_scanning(
         token = resolve_owner_token(db, user_id=user.id, owner=owner, client_token=x_github_token)
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+    tenant_id = _security_connected_tenant(db, user.id, owner)
+    if tenant_id is not None:
+        alerts = _secret_scanning_alerts_from_aggregate(db, tenant_id, owner, repo)
+        return SecretScanningResponse(repository=f"{owner}/{repo}", alerts=alerts, source="aggregate")
 
     client = GitHubClient(token)
     try:
@@ -218,4 +330,4 @@ def personal_secret_scanning(
         for a in raw
         if isinstance(a, dict) and "number" in a and "created_at" in a
     ]
-    return SecretScanningResponse(repository=f"{owner}/{repo}", alerts=alerts)
+    return SecretScanningResponse(repository=f"{owner}/{repo}", alerts=alerts, source="github")

--- a/apps/api/src/routers/security.py
+++ b/apps/api/src/routers/security.py
@@ -76,20 +76,20 @@ def _security_connected_tenant(db: Session, user_id: int, owner: str) -> int | N
 
 
 def _open_alerts_by_repo(db: Session, tenant_id: int, repo_full_names: list[str]) -> dict[str, list]:
-    """One query for every scanned repo's open dependabot/code_scanning security_alerts
-    rows, not one query per repo -- also sidesteps ThreadPoolExecutor entirely: _repo_row
+    """One query for every scanned repo's dependabot/code_scanning security_alerts rows
+    (every state, not just open -- see _dependabot_and_code_scanning_from_aggregate for
+    why), not one query per repo -- also sidesteps ThreadPoolExecutor entirely: _repo_row
     below runs concurrently across repos (existing pattern), and a SQLAlchemy Session
     isn't safe to share across threads, so this pre-fetches everything up front on the
     request thread and hands each worker a plain dict slice instead of `db` itself."""
     if not repo_full_names:
         return {}
     rows = (
-        db.query(SecurityAlert.repo, SecurityAlert.kind, SecurityAlert.severity)
+        db.query(SecurityAlert.repo, SecurityAlert.kind, SecurityAlert.severity, SecurityAlert.state)
         .filter(
             SecurityAlert.tenant_id == tenant_id,
             SecurityAlert.repo.in_(repo_full_names),
             SecurityAlert.kind.in_(("dependabot", "code_scanning")),
-            SecurityAlert.state == "open",
         )
         .all()
     )
@@ -101,18 +101,25 @@ def _open_alerts_by_repo(db: Session, tenant_id: int, repo_full_names: list[str]
 
 def _dependabot_and_code_scanning_from_aggregate(alert_rows: list) -> dict:
     """dependabot/code_scanning dimensions from security_alerts (post-S6 PR 3) instead of
-    two live GitHub calls per repo. dependabot_enabled is an approximation here: security_alerts
-    only has rows for alerts that actually occurred, so a repo with Dependabot enabled but
-    zero alerts ever looks identical to one with it disabled -- both read as
-    dependabot_enabled=False, critical/high=0. This under-reports the "enabled" badge for a
-    clean repo but never affects the score (an all-zero count scores as compliant either
-    way, matching the live path's own 404-disabled handling)."""
+    two live GitHub calls per repo. dependabot_enabled considers every state (open,
+    dismissed, fixed, ...) -- a repo whose only Dependabot alerts have all been dismissed
+    still has Dependabot enabled, so restricting this to state=="open" would wrongly read
+    as disabled (CodeRabbit finding on PR #352). critical_count/high_count/code_scanning_clear
+    only count 'open' rows, since only a currently-open alert is a live finding.
+
+    This is still an approximation in one direction: security_alerts only has rows for
+    alerts that actually occurred, so a repo with Dependabot enabled but zero alerts ever
+    (dismissed or otherwise) looks identical to one with it disabled. This under-reports
+    the "enabled" badge for a genuinely clean repo but never affects the score (an
+    all-zero count scores as compliant either way, matching the live path's own
+    404-disabled handling)."""
     dependabot_rows = [r for r in alert_rows if r.kind == "dependabot"]
+    open_dependabot_rows = [r for r in dependabot_rows if r.state == "open"]
     return {
         "dependabot_enabled": len(dependabot_rows) > 0,
-        "critical_count": sum(1 for r in dependabot_rows if r.severity == "critical"),
-        "high_count": sum(1 for r in dependabot_rows if r.severity == "high"),
-        "code_scanning_clear": not any(r.kind == "code_scanning" for r in alert_rows),
+        "critical_count": sum(1 for r in open_dependabot_rows if r.severity == "critical"),
+        "high_count": sum(1 for r in open_dependabot_rows if r.severity == "high"),
+        "code_scanning_clear": not any(r.kind == "code_scanning" and r.state == "open" for r in alert_rows),
     }
 
 
@@ -262,9 +269,9 @@ def personal_security_matrix(
 
 def _secret_scanning_alerts_from_aggregate(db: Session, tenant_id: int, owner: str, repo: str) -> list[SecretAlert]:
     """security_alerts (post-S6 PR 3) instead of a live GitHub call. No `url` field is
-    stored (only the live GitHub API response carries html_url) -- left empty, same as
-    an alert this table has no row for; the UI only uses it as an outbound link, not for
-    anything that gates alert-handling logic."""
+    stored (only the live GitHub API response carries html_url) -- None, not "" (a
+    fake/broken link), since SecretAlert.url is nullable precisely for this case (CodeRabbit
+    finding on PR #352); the UI renders a plain non-link row when url is missing."""
     rows = (
         db.query(SecurityAlert)
         .filter(
@@ -284,7 +291,7 @@ def _secret_scanning_alerts_from_aggregate(db: Session, tenant_id: int, owner: s
             created_at=row.created_at,
             resolved_at=row.updated_at if row.state != "open" else None,
             repo=f"{owner}/{repo}",
-            url="",
+            url=None,
         )
         for row in rows
     ]

--- a/apps/api/src/schemas/security.py
+++ b/apps/api/src/schemas/security.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -13,6 +14,12 @@ class RepoSecurityRow(BaseModel):
     code_scanning: bool
     force_push_allowed: bool
     score: int
+    # "aggregate" when dependabot/code_scanning came from security_alerts (post-S6 PR 3)
+    # instead of a live per-repo GitHub call -- branch_protection/force_push/secret_scanning
+    # have no ingested event covering them and stay live either way, so this only
+    # describes those two dimensions (dependabot_enabled is an approximation in the
+    # "aggregate" case too -- see _repo_row_from_aggregate's docstring).
+    alerts_source: Literal["github", "aggregate"] = "github"
     # Dimension names ("branch_protection", "dependabot", "code_scanning") the token
     # couldn't evaluate (403/429/network error) rather than genuinely observed as
     # compliant or not -- excluded from `score`'s denominator so a repo the token
@@ -58,3 +65,4 @@ class SecretAlert(BaseModel):
 class SecretScanningResponse(BaseModel):
     repository: str
     alerts: list[SecretAlert]
+    source: Literal["github", "aggregate"] = "github"

--- a/apps/api/src/schemas/security.py
+++ b/apps/api/src/schemas/security.py
@@ -59,7 +59,10 @@ class SecretAlert(BaseModel):
     created_at: datetime
     resolved_at: datetime | None
     repo: str
-    url: str
+    # None when no usable link exists -- the aggregate path (security_alerts) doesn't
+    # store GitHub's html_url (CodeRabbit finding on PR #352: returning "" made every
+    # aggregate-sourced alert render as a broken link instead of plain text).
+    url: str | None
 
 
 class SecretScanningResponse(BaseModel):

--- a/apps/api/tests/test_security_matrix.py
+++ b/apps/api/tests/test_security_matrix.py
@@ -298,6 +298,28 @@ def test_security_matrix_uses_aggregate_when_installation_connected(connected_cl
     assert row["unknown_dimensions"] == []
 
 
+def test_security_matrix_aggregate_dependabot_enabled_with_only_dismissed_alerts(connected_client, db, acme_org_with_installation):
+    """CodeRabbit finding on PR #352: dependabot_enabled must consider every state, not
+    just 'open' -- a repo whose only Dependabot alert has been dismissed still has
+    Dependabot enabled, and must not read identically to one with it disabled."""
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", kind="dependabot", number=1,
+        state="dismissed", severity="critical", details={"dependency": {}},
+    )
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.return_value = {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        resp = connected_client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    row = resp.json()["repos"][0]
+    assert row["dependabot_enabled"] is True
+    assert row["dependabot_critical_count"] == 0  # dismissed, not a live finding
+    assert row["score"] == 100
+
+
 def test_security_matrix_aggregate_repo_with_no_alerts_is_clean(connected_client, db, acme_org_with_installation):
     """No security_alerts rows for this repo at all -- reads as dependabot_enabled=False
     (the known aggregate-path approximation, see _dependabot_and_code_scanning_from_aggregate's
@@ -425,3 +447,6 @@ def test_secret_scanning_uses_aggregate_when_installation_connected(connected_cl
     assert alerts[2]["resolved_reason"] == "revoked"
     assert alerts[2]["resolved_at"] is not None
     assert "secret" not in alerts[1]
+    # CodeRabbit finding on PR #352: url must be None (not a fake ""), since
+    # security_alerts doesn't store GitHub's html_url.
+    assert alerts[1]["url"] is None

--- a/apps/api/tests/test_security_matrix.py
+++ b/apps/api/tests/test_security_matrix.py
@@ -1,17 +1,69 @@
 """Tests for the security compliance matrix and secret-scanning routes (docs/plan.md Phase 16)."""
 
+import json
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
+from src.core.db import User, get_db
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.security import router
 
 _USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "security-matrix@example.com")
+
+
+@pytest.fixture()
+def acme_org_with_installation(db, mock_user):
+    """Same connected-tenant fixture pattern as test_analytics_cockpit.py's -- a
+    personal endpoint (require_auth only), gated by the same org-membership +
+    installation_id-presence check _security_connected_tenant mirrors from
+    analytics.py's _cockpit_connected_tenant."""
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+    return org
+
+
+def _insert_security_alert(db, tenant_id, *, repo, kind, number, state, severity, details):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO security_alerts (tenant_id, repo, kind, number, state, severity, details, created_at, updated_at) "
+            "VALUES (:tenant_id, :repo, :kind, :number, :state, :severity, :details, :now, :now)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "repo": repo,
+            "kind": kind,
+            "number": number,
+            "state": state,
+            "severity": severity,
+            "details": json.dumps(details),
+            "now": datetime.now(timezone.utc),
+        },
+    )
+    db.commit()
 
 
 @pytest.fixture()
@@ -19,6 +71,15 @@ def client(db):
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[require_auth] = lambda: _USER
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+@pytest.fixture()
+def connected_client(db, mock_user):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_auth] = lambda: mock_user
     app.dependency_overrides[get_db] = lambda: db
     return TestClient(app)
 
@@ -197,3 +258,170 @@ def test_secret_scanning_github_error_maps_to_400(client):
         resp = client.get("/me/repos/acme/demo/secret-scanning", headers={"X-GitHub-Token": "ghp_test"})
 
     assert resp.status_code == 400
+
+
+def test_security_matrix_uses_aggregate_when_installation_connected(connected_client, db, acme_org_with_installation):
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", kind="dependabot", number=1,
+        state="open", severity="critical", details={"dependency": {}},
+    )
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", kind="code_scanning", number=2,
+        state="open", severity="error", details={"rule": {}},
+    )
+    # A dismissed alert must not count toward critical_count/code_scanning -- only 'open'
+    # rows are live findings, mirroring the live path's own state=open GitHub query param.
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/api", kind="dependabot", number=3,
+        state="dismissed", severity="critical", details={"dependency": {}},
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        raise AssertionError(f"unexpected live GitHub call for a connected org: {path}")
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = connected_client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    row = resp.json()["repos"][0]
+    assert row["alerts_source"] == "aggregate"
+    assert row["dependabot_enabled"] is True
+    assert row["dependabot_critical_count"] == 1  # the dismissed one doesn't count
+    assert row["dependabot_high_count"] == 0
+    assert row["code_scanning"] is False  # an open code_scanning alert exists
+    assert row["unknown_dimensions"] == []
+
+
+def test_security_matrix_aggregate_repo_with_no_alerts_is_clean(connected_client, db, acme_org_with_installation):
+    """No security_alerts rows for this repo at all -- reads as dependabot_enabled=False
+    (the known aggregate-path approximation, see _dependabot_and_code_scanning_from_aggregate's
+    docstring) but still scores as compliant, same as the live path's 404-disabled case."""
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "clean-repo", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.return_value = {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        resp = connected_client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    row = resp.json()["repos"][0]
+    assert row["alerts_source"] == "aggregate"
+    assert row["dependabot_enabled"] is False
+    assert row["code_scanning"] is True
+    assert row["score"] == 100
+
+
+def test_security_matrix_connected_org_with_no_repos_is_empty(connected_client, db, acme_org_with_installation):
+    """No repos returned from the org repo listing -- _open_alerts_by_repo's
+    empty-input short-circuit must not error out on an empty IN (...) query."""
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = []
+        resp = connected_client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.status_code == 200
+    assert resp.json()["repos"] == []
+
+
+def test_security_matrix_falls_back_to_github_when_caller_lacks_membership(client, db):
+    """Org exists and has an installation, but the caller (_USER) has no OrgMembership
+    row -- _security_connected_tenant must return None (not silently trust `owner`
+    naming a real org) so the matrix falls back to the live path."""
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=org.id
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/dependabot/alerts") or path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.json()["repos"][0]["alerts_source"] == "github"
+
+
+def test_security_matrix_falls_back_to_github_when_org_has_no_installation(connected_client, db, mock_user):
+    """Org exists and the caller is a member, but no GitHub App installation is
+    connected -- _security_connected_tenant must return None."""
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/dependabot/alerts") or path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = connected_client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    assert resp.json()["repos"][0]["alerts_source"] == "github"
+
+
+def test_security_matrix_unconnected_org_still_uses_live_github(client, db):
+    """No installation for this owner -- _security_connected_tenant returns None, so the
+    matrix must fall back to the pre-existing live-GitHub path unchanged."""
+    def _request_side_effect(method, path, params=None):
+        if path.endswith("/branches/main"):
+            return {"protected": True, "protection": {"allow_force_pushes": {"enabled": False}}}
+        if path.endswith("/dependabot/alerts"):
+            return []
+        if path.endswith("/code-scanning/alerts"):
+            return []
+        return {}
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [
+            {"name": "api", "default_branch": "main", "security_and_analysis": {"secret_scanning": {"status": "enabled"}}},
+        ]
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = client.get("/me/analytics/security-matrix/acme", headers={"X-GitHub-Token": "ghp_test"})
+
+    row = resp.json()["repos"][0]
+    assert row["alerts_source"] == "github"
+
+
+def test_secret_scanning_uses_aggregate_when_installation_connected(connected_client, db, acme_org_with_installation):
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", kind="secret_scanning", number=1,
+        state="open", severity=None,
+        details={"secret_type": "github_personal_access_token", "secret_type_display_name": "GitHub Personal Access Token", "resolution": None},
+    )
+    _insert_security_alert(
+        db, acme_org_with_installation.tenant_id, repo="acme/demo", kind="secret_scanning", number=2,
+        state="resolved", severity=None,
+        details={"secret_type": "aws_access_key_id", "secret_type_display_name": "AWS Access Key", "resolution": "revoked"},
+    )
+
+    with patch("src.routers.security.GitHubClient") as mock_client:
+        resp = connected_client.get("/me/repos/acme/demo/secret-scanning", headers={"X-GitHub-Token": "ghp_test"})
+        mock_client.return_value.request.assert_not_called()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "aggregate"
+    alerts = {a["number"]: a for a in body["alerts"]}
+    assert alerts[1]["state"] == "open"
+    assert alerts[1]["resolved_at"] is None
+    assert alerts[2]["state"] == "resolved"
+    assert alerts[2]["resolved_reason"] == "revoked"
+    assert alerts[2]["resolved_at"] is not None
+    assert "secret" not in alerts[1]

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -402,7 +402,17 @@ export default function SecurityPage() {
         <div className="grid gap-4 lg:grid-cols-2 mt-6">
           <div className="card">
             <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-              <span className="section-title">Compliance Matrix</span>
+              <span className="flex items-center gap-2">
+                <span className="section-title">Compliance Matrix</span>
+                {matrixMutation.data?.repos.some((r) => r.alerts_source === "aggregate") && (
+                  <span
+                    className="text-[0.6875rem] text-muted-foreground/70"
+                    title="Dependabot/code-scanning columns are from ingested webhook events, not a live GitHub call."
+                  >
+                    (estimated)
+                  </span>
+                )}
+              </span>
               {matrixMutation.data && (
                 <span className="stat-chip">{matrixMutation.data.summary.fully_compliant_count} fully compliant</span>
               )}
@@ -481,7 +491,17 @@ export default function SecurityPage() {
 
           <div className="card">
             <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
-              <span className="section-title">Secret Scanning Alerts</span>
+              <span className="flex items-center gap-2">
+                <span className="section-title">Secret Scanning Alerts</span>
+                {secretScanning.data?.source === "aggregate" && (
+                  <span
+                    className="text-[0.6875rem] text-muted-foreground/70"
+                    title="From ingested webhook events, not a live GitHub call."
+                  >
+                    (estimated)
+                  </span>
+                )}
+              </span>
               {matrixMutation.data && matrixMutation.data.repos.length > 0 && (
                 <select
                   value={selectedRepo}

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -524,25 +524,31 @@ export default function SecurityPage() {
               <p className="p-4 text-sm text-muted-foreground">No secret scanning alerts for this repo</p>
             ) : (
               <div className="divide-y divide-border">
-                {secretScanning.data!.alerts.map((a) => (
-                  <a
-                    key={a.number}
-                    href={a.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
-                  >
-                    <span className="flex flex-col">
-                      <span className="text-foreground/90">{a.secret_type_display}</span>
-                      <span className="text-[0.6875rem] text-muted-foreground">#{a.number}</span>
-                    </span>
-                    <span
-                      className={`stat-chip ${a.state === "open" ? "text-red-400 border-red-500/30" : ""}`}
-                    >
-                      {a.state}
-                    </span>
-                  </a>
-                ))}
+                {secretScanning.data!.alerts.map((a) => {
+                  const row = (
+                    <>
+                      <span className="flex flex-col">
+                        <span className="text-foreground/90">{a.secret_type_display}</span>
+                        <span className="text-[0.6875rem] text-muted-foreground">#{a.number}</span>
+                      </span>
+                      <span
+                        className={`stat-chip ${a.state === "open" ? "text-red-400 border-red-500/30" : ""}`}
+                      >
+                        {a.state}
+                      </span>
+                    </>
+                  )
+                  const rowClassName = "flex items-center justify-between px-4 py-2.5 text-sm hover:bg-elevated transition-colors"
+                  return a.url ? (
+                    <a key={a.number} href={a.url} target="_blank" rel="noreferrer" className={rowClassName}>
+                      {row}
+                    </a>
+                  ) : (
+                    <div key={a.number} className={rowClassName}>
+                      {row}
+                    </div>
+                  )
+                })}
               </div>
             )}
           </div>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -487,6 +487,10 @@ export interface RepoSecurityRow {
   // Dimension names the token couldn't evaluate (403/429/network error) -- excluded
   // from `score`. Distinct from a genuine 404 "this is off" answer, which isn't unknown.
   unknown_dimensions: string[]
+  // "aggregate" when dependabot/code_scanning came from ingested webhook events instead
+  // of a live GitHub call (post-S6 PR 3) -- branch_protection/force_push/secret_scanning
+  // have no ingested event covering them and stay live either way.
+  alerts_source: "github" | "aggregate"
 }
 
 export interface VulnCounts {
@@ -524,4 +528,5 @@ export interface SecretAlert {
 export interface SecretScanningResponse {
   repository: string
   alerts: SecretAlert[]
+  source: "github" | "aggregate"
 }

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -522,7 +522,9 @@ export interface SecretAlert {
   created_at: string
   resolved_at: string | null
   repo: string
-  url: string
+  // null when no usable link exists (e.g. aggregate-sourced alerts don't store GitHub's
+  // html_url) -- the UI renders a plain non-link row in that case.
+  url: string | null
 }
 
 export interface SecretScanningResponse {

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -586,4 +586,42 @@ describe("SecurityPage", () => {
     await waitFor(() => expect(secretScanningMock).toHaveBeenCalled());
     expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
   });
+
+  it("renders an aggregate-sourced alert with no url as a non-link row", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [], alerts_source: "aggregate" },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 1, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({
+      repository: "acme/api",
+      source: "aggregate",
+      alerts: [
+        {
+          number: 1,
+          state: "open",
+          secret_type: "github_personal_access_token",
+          secret_type_display: "GitHub Personal Access Token",
+          resolved_reason: null,
+          created_at: "2026-07-01T00:00:00Z",
+          resolved_at: null,
+          repo: "acme/api",
+          url: null,
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("GitHub Personal Access Token")).toBeInTheDocument());
+    expect(screen.queryByRole("link", { name: /GitHub Personal Access Token/i })).not.toBeInTheDocument();
+  });
 });

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -541,4 +541,49 @@ describe("SecurityPage", () => {
     await waitFor(() => expect(screen.getByText("GitHub Personal Access Token")).toBeInTheDocument());
     expect(screen.getByText("Secret values are never shown here — metadata only.")).toBeInTheDocument();
   });
+
+  it("labels the matrix and secret-scanning panels as estimated when aggregate-sourced", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [], alerts_source: "aggregate" },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({ repository: "acme/api", alerts: [], source: "aggregate" });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(secretScanningMock).toHaveBeenCalled());
+    const captions = screen.getAllByText("(estimated)");
+    expect(captions).toHaveLength(2);
+  });
+
+  it("does not label the panels as estimated when github-sourced", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [],
+    });
+    securityMatrixMock.mockResolvedValue({
+      owner: "acme",
+      repos: [
+        { repo: "api", branch_protection: true, secret_scanning: false, dependabot_enabled: true, dependabot_critical_count: 0, dependabot_high_count: 0, code_scanning: true, force_push_allowed: false, score: 80, unknown_dimensions: [], alerts_source: "github" },
+      ],
+      summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
+    });
+    secretScanningMock.mockResolvedValue({ repository: "acme/api", alerts: [], source: "github" });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(screen.getByRole("button", { name: /run scan/i }));
+
+    await waitFor(() => expect(secretScanningMock).toHaveBeenCalled());
+    expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
+  });
 });

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -229,6 +229,10 @@ def _normalize_security_alert(event_type: str, payload: dict, received_at: datet
             "action": payload.get("action"),
             "secret_type": alert.get("secret_type"),
             "secret_type_display_name": alert.get("secret_type_display_name"),
+            # Only present once the alert is resolved -- None on the initial "created"
+            # webhook. Needed by the Security dashboard's secret-scanning panel (post-S6
+            # PR 3) to show why an alert was closed, matching GitHub's own live API shape.
+            "resolution": alert.get("resolution"),
         }
 
     return {

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -425,6 +425,7 @@ def test_security_alert_severity_and_details_are_kind_specific(pg_conn, tenant_i
     _, severity_2, details_2, _, _ = _security_alert(conn, tenant_id, "acme/widgets", "secret_scanning", 1)
     assert severity_2 is None  # secret-scanning alerts carry no severity in GitHub's payload
     assert details_2["secret_type"] == "github_personal_access_token"
+    assert details_2["resolution"] is None  # not yet resolved on the initial "created" webhook
 
 
 def test_redelivered_security_alert_updates_state_instead_of_duplicating(pg_conn, tenant_id):
@@ -528,6 +529,12 @@ def test_summarize_unknown_event_type_returns_the_event_type_itself():
 
 def test_normalize_returns_none_when_repository_full_name_is_missing():
     assert event_consumer._normalize("push", {"sender": {"login": "octocat"}}, None) is None
+
+
+def test_parse_alert_timestamp_falls_back_on_missing_or_malformed_value():
+    fallback = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert event_consumer._parse_alert_timestamp(None, fallback) == fallback
+    assert event_consumer._parse_alert_timestamp("not-a-real-timestamp", fallback) == fallback
 
 
 def test_process_entry_drops_malformed_json_payload(pg_conn, tenant_id):


### PR DESCRIPTION
## Summary

PR 3 of the post-S6 "Security-alert ingestion + Collaborators" stage (see `docs/plan.md`). PR 2 (#351) added the `security_alerts` table and worker normalization; this PR re-points the Security dashboard to read from it for orgs with a connected GitHub App installation.

- **`apps/api/src/routers/security.py`**: adds `_security_connected_tenant` (mirrors `analytics.py`'s `_cockpit_connected_tenant` exactly — same personal-endpoint membership+installation gate) and re-points two dimensions:
  - The compliance matrix's `dependabot`/`code_scanning` columns now come from one batched `security_alerts` query (`_open_alerts_by_repo`) instead of 2 live GitHub calls per repo. Pre-fetched outside the `ThreadPoolExecutor` and handed to workers as a plain dict — a SQLAlchemy `Session` isn't safe to share across threads, and `_repo_row` already runs concurrently per repo.
  - `personal_secret_scanning` reads `security_alerts` (kind=`secret_scanning`) instead of a live call.
  - `branch_protection`/`force_push`/`secret_scanning` (the enablement flag) stay live either way — no ingested webhook event covers them.
- **Response schemas**: `RepoSecurityRow.alerts_source` and `SecretScanningResponse.source` (`"github"|"aggregate"`), mirroring `commit_activity_source` from the S6 PRs, so the UI can label estimated data.
- **`apps/ui/app/security/page.tsx`**: small "(estimated)" caption on both panels when aggregate-sourced, same pattern as the Repo detail page's commit-activity chart. Live-GitHub path and existing query hooks unchanged.
- **`apps/worker/src/event_consumer.py`**: adds a `resolution` field to secret-scanning alert `details` (GitHub sends this once an alert is resolved) — needed by the new secret-scanning panel repoint to show why an alert was closed.

**Known approximation**: `security_alerts` only has rows for alerts that actually occurred, so a repo with Dependabot enabled but zero alerts ever is indistinguishable from one with it disabled — `dependabot_enabled` under-reports in that case. Documented in `_dependabot_and_code_scanning_from_aggregate`'s docstring; doesn't affect the compliance score (an all-zero count scores as compliant either way, matching the live path's own 404-disabled handling).

## Test plan

- [x] `pytest -q` — full suite green (788 passed, 3 skipped, 3 xpassed)
- [x] New API tests: aggregate path used when connected (dismissed alerts excluded, clean repo with no rows, empty repo list), falls back to live GitHub when caller lacks membership / org has no installation / org is unconnected entirely
- [x] `bun run test:coverage` — 397 passed; new UI test asserts the "(estimated)" caption shows for aggregate-sourced data and not for github-sourced data
- [x] `bun run typecheck && bun run lint && bun run build` clean
- [x] Diff coverage: Python 97%, UI 100% (both above the 90% floor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Security compliance and secret-scanning results can now use aggregated alert data when available.
  - Added source indicators distinguishing GitHub data from aggregated results.
  - Secret-scanning alerts now retain resolution details from incoming alerts.

- **UI Improvements**
  - Aggregated results are labeled “estimated,” with tooltips explaining that they may not reflect live GitHub data.

- **Bug Fixes**
  - Improved fallback to live GitHub data when aggregated security information is unavailable or access requirements are not met.
  - Improved handling of missing or malformed alert timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->