### PR TITLE
feat(api): re-point collab.py list_members/inactive_members onto ingested tables (Collaborators PR 3 of 3)

### DIFF
--- a/apps/api/src/routers/collab.py
+++ b/apps/api/src/routers/collab.py
@@ -88,6 +88,37 @@ def _installation_connected(db: Session, ctx: OrgContext) -> bool:
     return installation is not None and installation.installation_id is not None
 
 
+def _org_members_synced(db: Session, ctx: OrgContext) -> bool:
+    """True only once org_membership_sync_cursors has a row for this tenant -- i.e. at least
+    one reconciliation poll has actually completed, not merely that an installation exists.
+    Installation presence alone isn't enough: right after connecting, org_members can still be
+    empty (only the webhook path may have touched it) until the poll's first sweep tick runs
+    (up to membership_reconcile_poll_seconds, default 15 minutes) -- reading org_members as
+    authoritative in that window would show 0 members for an org that actually has some, which
+    is actively misleading rather than merely stale (CodeRabbit finding on PR #355). A cursor
+    row is only ever written in the same transaction as a successful reconcile_org_members call
+    (worker.py's _handle_reconcile_org_membership), so its presence reliably means the table is
+    now trustworthy."""
+    if not _installation_connected(db, ctx):
+        return False
+    row = db.execute(
+        text("SELECT 1 FROM org_membership_sync_cursors WHERE tenant_id = :tenant_id"), {"tenant_id": ctx.org.tenant_id}
+    ).first()
+    return row is not None
+
+
+def _activity_synced(db: Session, ctx: OrgContext) -> bool:
+    """Same reasoning as _org_members_synced, but gates inactive_members' repo_events read on
+    activity_sync_cursors instead -- the S5 backfill/gap-heal cursor, same "row exists only
+    after a successful sync" invariant."""
+    if not _installation_connected(db, ctx):
+        return False
+    row = db.execute(
+        text("SELECT 1 FROM activity_sync_cursors WHERE tenant_id = :tenant_id"), {"tenant_id": ctx.org.tenant_id}
+    ).first()
+    return row is not None
+
+
 def _ingested_org_members(db: Session, tenant_id: int, role: Literal["all", "member", "admin"]) -> list[OrgMemberRow]:
     query = db.query(OrgMemberRow).filter(OrgMemberRow.tenant_id == tenant_id)
     if role != "all":
@@ -103,7 +134,7 @@ def list_members(
     db: Session = Depends(get_db),
     x_github_token: str | None = Header(default=None),
 ):
-    if _installation_connected(db, ctx):
+    if _org_members_synced(db, ctx):
         rows = _ingested_org_members(db, ctx.org.tenant_id, role)
         members = [
             OrgMember(
@@ -121,11 +152,14 @@ def list_members(
         return OrgMembersResponse(
             org=org_login,
             members=members,
-            # True iff at least one member has an actual (non-None) 2FA reading -- a brand-new
-            # org-kind tenant can have org_members rows from the webhook path before its first
-            # reconciliation poll tick has run, so two_factor_enabled may still be NULL on every
-            # row for a short window after connecting.
-            two_factor_overlay_available=any(m.two_factor_enabled is not None for m in members),
+            # True only if EVERY member has an actual (non-None) 2FA reading -- the UI's
+            # "Members without 2FA: N" footer (members/page.tsx) is gated on this flag and
+            # counts strictly `two_factor_enabled is False`, so a partial reading (some members
+            # polled, some not -- possible here since COALESCE preserves a per-member value
+            # across reconciliation runs, unlike the live path's single all-or-nothing overlay
+            # call) would silently undercount rather than honestly report "not fully known"
+            # (CodeRabbit finding on PR #355).
+            two_factor_overlay_available=bool(members) and all(m.two_factor_enabled is not None for m in members),
         )
 
     token = _resolve_token(db, ctx, org_login, x_github_token)
@@ -443,7 +477,10 @@ def inactive_members(
     db: Session = Depends(get_db),
     x_github_token: str | None = Header(default=None),
 ):
-    if _installation_connected(db, ctx):
+    # Needs both cursors: the member/role list comes from org_members (_org_members_synced),
+    # last-activity comes from repo_events (_activity_synced) -- either one not yet having
+    # completed its first sync means this endpoint can't yet trust the ingested tables.
+    if _org_members_synced(db, ctx) and _activity_synced(db, ctx):
         return _inactive_members_from_ingested(db, ctx, org_login, days)
 
     token = _resolve_token(db, ctx, org_login, x_github_token)

--- a/apps/api/src/routers/collab.py
+++ b/apps/api/src/routers/collab.py
@@ -19,11 +19,14 @@ from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 from typing import Literal
 
 from src.core.db import get_db
+from src.core.db import OrgMember as OrgMemberRow
 from src.core.rbac import OrgContext, require_org_role
+from src.repositories import installation_repo
 from src.schemas.collab import (
     CollaboratorPermission,
     InactiveMember,
@@ -63,6 +66,35 @@ def _resolve_token(db: Session, ctx: OrgContext, org_login: str, client_token: s
         raise HTTPException(status_code=400, detail=str(exc))
 
 
+def _installation_connected(db: Session, ctx: OrgContext) -> bool:
+    """True if this org has a live GitHub App installation -- gates whether list_members and
+    inactive_members can read from the ingested org_members/repo_events tables (kept fresh by
+    the reconciliation poll and the webhook/backfill pipeline, respectively) instead of calling
+    GitHub live. Mirrors security.py's _security_connected_tenant / analytics.py's
+    _cockpit_connected_tenant installation_id-presence gate -- but require_org_role's own
+    dependency (unlike those two personal-scoped routers' require_auth) already resolved
+    membership and set the RLS tenant-session-context for this request, so this only needs the
+    installation check itself.
+
+    Deliberately NOT used to gate list_outside_collaborators or permission_audit's per-repo
+    collaborator enumeration: repo_collaborators only has rows for grants the `member` webhook
+    event has observed since this org connected (migration 0040's own docstring) -- there was
+    never a backfill job for pre-existing direct grants, unlike repo_events (S5 install-time
+    backfill + gap-heal) or org_members (this reconciliation poll's own full-roster fetch). Re-
+    pointing those two endpoints today would silently under-report real outside collaborators/
+    permissions for any org connected before Clevis started listening. Left fully live until a
+    repo_collaborators backfill exists -- a separate design decision, not this PR's job."""
+    installation = installation_repo.get_for_org(db, org_id=ctx.org.id, account_login=ctx.org.github_login)
+    return installation is not None and installation.installation_id is not None
+
+
+def _ingested_org_members(db: Session, tenant_id: int, role: Literal["all", "member", "admin"]) -> list[OrgMemberRow]:
+    query = db.query(OrgMemberRow).filter(OrgMemberRow.tenant_id == tenant_id)
+    if role != "all":
+        query = query.filter(OrgMemberRow.role == role)
+    return query.order_by(OrgMemberRow.login).all()
+
+
 @router.get("/github/orgs/{org_login}/members", response_model=OrgMembersResponse)
 def list_members(
     org_login: str,
@@ -71,6 +103,31 @@ def list_members(
     db: Session = Depends(get_db),
     x_github_token: str | None = Header(default=None),
 ):
+    if _installation_connected(db, ctx):
+        rows = _ingested_org_members(db, ctx.org.tenant_id, role)
+        members = [
+            OrgMember(
+                login=r.login,
+                avatar_url=r.avatar_url,
+                role=r.role,
+                # Not captured by any ingestion path (org_members has no site_admin column) --
+                # this flag is GitHub-instance-wide, not org-scoped, and rarely true; the live
+                # path below still reports it accurately for an unconnected org.
+                site_admin=False,
+                two_factor_enabled=r.two_factor_enabled,
+            )
+            for r in rows
+        ]
+        return OrgMembersResponse(
+            org=org_login,
+            members=members,
+            # True iff at least one member has an actual (non-None) 2FA reading -- a brand-new
+            # org-kind tenant can have org_members rows from the webhook path before its first
+            # reconciliation poll tick has run, so two_factor_enabled may still be NULL on every
+            # row for a short window after connecting.
+            two_factor_overlay_available=any(m.two_factor_enabled is not None for m in members),
+        )
+
     token = _resolve_token(db, ctx, org_login, x_github_token)
     client = GitHubClient(token)
     try:
@@ -326,6 +383,58 @@ def _last_commit_for_author(client: GitHubClient, org_login: str, repo_name: str
     return date, True
 
 
+def _inactive_members_from_ingested(db: Session, ctx: OrgContext, org_login: str, days: int) -> InactiveMembersResponse:
+    """Re-points both halves of this endpoint onto ingested tables for a connected org:
+    org_members for the member/role list (complete -- see _installation_connected's docstring)
+    and repo_events for last-push-per-member (S5's install-time backfill + gap-heal keep it
+    fresh, same as the Activity page). Strictly more accurate than the live path below, which
+    only samples _MAX_REPOS_SAMPLED_FOR_ACTIVITY repos per member via N live GitHub calls each --
+    this checks every repo with an ingested push event for the tenant in one query, and every
+    member gets a real verified answer (no per-repo GitHub call to fail)."""
+    members = _ingested_org_members(db, ctx.org.tenant_id, "all")
+    logins = [m.login for m in members]
+    now = datetime.now(timezone.utc)
+
+    last_push_by_login: dict[str, tuple[str, datetime]] = {}
+    if logins:
+        rows = db.execute(
+            text(
+                "SELECT DISTINCT ON (actor) actor, repo, occurred_at FROM repo_events "
+                "WHERE tenant_id = :tenant_id AND event_type = 'push' AND actor = ANY(:logins) "
+                "ORDER BY actor, occurred_at DESC"
+            ),
+            {"tenant_id": ctx.org.tenant_id, "logins": logins},
+        ).fetchall()
+        last_push_by_login = {row.actor: (row.repo, row.occurred_at) for row in rows}
+
+    inactive: list[InactiveMember] = []
+    for member in members:
+        last = last_push_by_login.get(member.login)
+        repo_name, days_ago = None, None
+        if last is not None:
+            repo_name, occurred_at = last
+            days_ago = (now - occurred_at).days
+        if days_ago is None or days_ago >= days:
+            inactive.append(
+                InactiveMember(
+                    login=member.login,
+                    avatar_url=member.avatar_url,
+                    role=member.role,
+                    last_commit_repo=repo_name,
+                    last_commit_days_ago=days_ago,
+                )
+            )
+
+    return InactiveMembersResponse(
+        org=org_login,
+        # Not a bounded sample here (unlike the live path) -- every repo with an ingested push
+        # event for this tenant was considered; this lists which ones actually contributed a
+        # member's most recent activity.
+        sampled_repos=sorted({repo for repo, _ in last_push_by_login.values()}),
+        members=inactive,
+    )
+
+
 @router.get("/github/orgs/{org_login}/inactive-members", response_model=InactiveMembersResponse)
 def inactive_members(
     org_login: str,
@@ -334,6 +443,9 @@ def inactive_members(
     db: Session = Depends(get_db),
     x_github_token: str | None = Header(default=None),
 ):
+    if _installation_connected(db, ctx):
+        return _inactive_members_from_ingested(db, ctx, org_login, days)
+
     token = _resolve_token(db, ctx, org_login, x_github_token)
     client = GitHubClient(token)
     try:

--- a/apps/api/tests/test_collab.py
+++ b/apps/api/tests/test_collab.py
@@ -65,6 +65,18 @@ def collab_client(db, acme_org):
     return TestClient(app)
 
 
+def _seed_membership_cursor(db, tenant_id, org_login="acme"):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO org_membership_sync_cursors (tenant_id, org_login, last_synced_at) "
+            "VALUES (:tenant_id, :org_login, :last_synced_at)"
+        ),
+        {"tenant_id": tenant_id, "org_login": org_login, "last_synced_at": datetime.now(timezone.utc)},
+    )
+    db.commit()
+
+
 def _insert_org_member(db, tenant_id, *, login, avatar_url="", role="member", two_factor_enabled=None):
     db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
     db.execute(
@@ -229,6 +241,7 @@ def test_members_2fa_overlay_degrades_gracefully_on_network_error(collab_client)
 
 
 def test_members_reads_from_ingested_org_members_when_connected(db, acme_org_with_installation):
+    _seed_membership_cursor(db, acme_org_with_installation.tenant_id)
     _insert_org_member(
         db, acme_org_with_installation.tenant_id, login="alice", role="admin", two_factor_enabled=True
     )
@@ -255,6 +268,7 @@ def test_members_reads_from_ingested_org_members_when_connected(db, acme_org_wit
 
 
 def test_members_from_ingested_db_respects_role_filter(db, acme_org_with_installation):
+    _seed_membership_cursor(db, acme_org_with_installation.tenant_id)
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="admin")
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="bob", role="member")
     app = FastAPI()
@@ -272,6 +286,7 @@ def test_members_from_ingested_db_respects_role_filter(db, acme_org_with_install
 def test_members_from_ingested_db_overlay_unavailable_when_never_polled(db, acme_org_with_installation):
     # two_factor_enabled is NULL on every row until the reconciliation poll's first tick --
     # a brand-new installation whose only org_members rows came from the webhook path.
+    _seed_membership_cursor(db, acme_org_with_installation.tenant_id)
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member", two_factor_enabled=None)
     app = FastAPI()
     app.include_router(collab_router)
@@ -284,6 +299,48 @@ def test_members_from_ingested_db_overlay_unavailable_when_never_polled(db, acme
     body = resp.json()
     assert body["two_factor_overlay_available"] is False
     assert body["members"][0]["two_factor_enabled"] is None
+
+
+def test_members_from_ingested_db_overlay_unavailable_when_partially_polled(db, acme_org_with_installation):
+    # CodeRabbit finding on PR #355: one member with a known 2FA reading and another with NULL
+    # (e.g. added via webhook after the last successful reconciliation run) must report the
+    # overlay as unavailable overall, not merely "some data exists" -- the UI's "Members without
+    # 2FA: N" footer would otherwise undercount without any indication the count is incomplete.
+    _seed_membership_cursor(db, acme_org_with_installation.tenant_id)
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member", two_factor_enabled=False)
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="bob", role="member", two_factor_enabled=None)
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/members")
+
+    assert resp.status_code == 200
+    assert resp.json()["two_factor_overlay_available"] is False
+
+
+def test_members_falls_back_to_live_when_installation_connected_but_never_synced(db, acme_org_with_installation):
+    # CodeRabbit finding on PR #355: installation_id presence alone doesn't prove the
+    # reconciliation poll has ever completed -- org_members could still be empty (or stale)
+    # right after connecting. Must fall back to the live path until org_membership_sync_cursors
+    # actually has a row, not just because an installation exists.
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    with patch("src.routers.collab.resolve_org_token", return_value="ghp_test"), patch(
+        "src.routers.collab.GitHubClient"
+    ) as mock_client:
+        mock_client.return_value.request_paginated.side_effect = [[_BOB], [_BOB, _CAROL], []]
+        resp = TestClient(app).get("/github/orgs/acme/members")
+
+    assert resp.status_code == 200
+    mock_client.assert_called_once()
+    logins = {m["login"] for m in resp.json()["members"]}
+    assert logins == {"bob", "carol"}
 
 
 def test_members_falls_back_to_client_supplied_token_header_when_no_installation(collab_client):

--- a/apps/api/tests/test_collab.py
+++ b/apps/api/tests/test_collab.py
@@ -1,15 +1,17 @@
 """Tests for the read-only GitHub org roster router (Phase 11 — Collaborators)."""
 
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.collab import router as collab_router
 
 _ADMIN = UserOut(id=1, email="admin@example.com", name=None, is_workspace_admin=False)
@@ -47,12 +49,39 @@ def acme_org(db):
 
 
 @pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+@pytest.fixture()
 def collab_client(db, acme_org):
     app = FastAPI()
     app.include_router(collab_router)
     app.dependency_overrides[require_auth] = lambda: _ADMIN
     app.dependency_overrides[get_db] = lambda: db
     return TestClient(app)
+
+
+def _insert_org_member(db, tenant_id, *, login, avatar_url="", role="member", two_factor_enabled=None):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO org_members (tenant_id, login, avatar_url, role, two_factor_enabled, added_at) "
+            "VALUES (:tenant_id, :login, :avatar_url, :role, :two_factor_enabled, :added_at)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "login": login,
+            "avatar_url": avatar_url,
+            "role": role,
+            "two_factor_enabled": two_factor_enabled,
+            "added_at": datetime.now(timezone.utc),
+        },
+    )
+    db.commit()
 
 
 def _unknown_org_client(db):
@@ -197,6 +226,64 @@ def test_members_2fa_overlay_degrades_gracefully_on_network_error(collab_client)
         resp = collab_client.get("/github/orgs/acme/members")
     assert resp.status_code == 200
     assert resp.json()["two_factor_overlay_available"] is False
+
+
+def test_members_reads_from_ingested_org_members_when_connected(db, acme_org_with_installation):
+    _insert_org_member(
+        db, acme_org_with_installation.tenant_id, login="alice", role="admin", two_factor_enabled=True
+    )
+    _insert_org_member(
+        db, acme_org_with_installation.tenant_id, login="bob", role="member", two_factor_enabled=False
+    )
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        resp = TestClient(app).get("/github/orgs/acme/members")
+
+    assert resp.status_code == 200
+    mock_client.assert_not_called()
+    body = resp.json()
+    members = {m["login"]: m for m in body["members"]}
+    assert members["alice"]["role"] == "admin"
+    assert members["alice"]["two_factor_enabled"] is True
+    assert members["bob"]["role"] == "member"
+    assert members["bob"]["two_factor_enabled"] is False
+    assert body["two_factor_overlay_available"] is True
+
+
+def test_members_from_ingested_db_respects_role_filter(db, acme_org_with_installation):
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="admin")
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="bob", role="member")
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/members?role=admin")
+
+    assert resp.status_code == 200
+    logins = [m["login"] for m in resp.json()["members"]]
+    assert logins == ["alice"]
+
+
+def test_members_from_ingested_db_overlay_unavailable_when_never_polled(db, acme_org_with_installation):
+    # two_factor_enabled is NULL on every row until the reconciliation poll's first tick --
+    # a brand-new installation whose only org_members rows came from the webhook path.
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member", two_factor_enabled=None)
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/members")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["two_factor_overlay_available"] is False
+    assert body["members"][0]["two_factor_enabled"] is None
 
 
 def test_members_falls_back_to_client_supplied_token_header_when_no_installation(collab_client):

--- a/apps/api/tests/test_collab_access.py
+++ b/apps/api/tests/test_collab_access.py
@@ -56,6 +56,35 @@ def _insert_org_member(db, tenant_id, *, login, avatar_url="", role="member"):
     db.commit()
 
 
+def _seed_membership_cursor(db, tenant_id, org_login="acme"):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO org_membership_sync_cursors (tenant_id, org_login, last_synced_at) "
+            "VALUES (:tenant_id, :org_login, :last_synced_at)"
+        ),
+        {"tenant_id": tenant_id, "org_login": org_login, "last_synced_at": datetime.now(timezone.utc)},
+    )
+    db.commit()
+
+
+def _seed_activity_cursor(db, tenant_id, account_login="acme", account_type="Organization"):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO activity_sync_cursors (tenant_id, account_login, account_type, last_synced_at) "
+            "VALUES (:tenant_id, :account_login, :account_type, :last_synced_at)"
+        ),
+        {"tenant_id": tenant_id, "account_login": account_login, "account_type": account_type, "last_synced_at": datetime.now(timezone.utc)},
+    )
+    db.commit()
+
+
+def _seed_both_cursors(db, tenant_id):
+    _seed_membership_cursor(db, tenant_id)
+    _seed_activity_cursor(db, tenant_id)
+
+
 def _insert_push_event(db, tenant_id, *, repo, actor, occurred_at, delivery_id):
     db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
     db.execute(
@@ -166,6 +195,7 @@ def test_permission_audit_outsider_forbidden(db):
 
 
 def test_inactive_members_from_ingested_db_flags_member_with_no_push_events(db, acme_org_with_installation):
+    _seed_both_cursors(db, acme_org_with_installation.tenant_id)
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
     app = FastAPI()
     app.include_router(collab_router)
@@ -185,6 +215,7 @@ def test_inactive_members_from_ingested_db_flags_member_with_no_push_events(db, 
 
 
 def test_inactive_members_from_ingested_db_excludes_recently_active_member(db, acme_org_with_installation):
+    _seed_both_cursors(db, acme_org_with_installation.tenant_id)
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
     _insert_push_event(
         db,
@@ -206,6 +237,7 @@ def test_inactive_members_from_ingested_db_excludes_recently_active_member(db, a
 
 
 def test_inactive_members_from_ingested_db_flags_member_with_only_stale_push(db, acme_org_with_installation):
+    _seed_both_cursors(db, acme_org_with_installation.tenant_id)
     _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
     _insert_push_event(
         db,
@@ -235,6 +267,7 @@ def test_inactive_members_from_ingested_db_uses_most_recent_push_across_all_repo
     # considers every repo with a push event -- a recent push to a second repo must still
     # exclude the member even though their first/older repo alone would flag them.
     tenant_id = acme_org_with_installation.tenant_id
+    _seed_both_cursors(db, tenant_id)
     _insert_org_member(db, tenant_id, login="alice", role="member")
     _insert_push_event(
         db, tenant_id, repo="acme/old-repo", actor="alice", occurred_at=datetime.now(timezone.utc) - timedelta(days=90), delivery_id="d3"
@@ -251,6 +284,38 @@ def test_inactive_members_from_ingested_db_uses_most_recent_push_across_all_repo
 
     assert resp.status_code == 200
     assert resp.json()["members"] == []
+
+
+def test_inactive_members_falls_back_to_live_when_only_one_cursor_has_synced(db, acme_org_with_installation):
+    # CodeRabbit finding on PR #355: this endpoint needs BOTH org_members (membership cursor)
+    # and repo_events (activity cursor) to be trustworthy -- seeding only one must still fall
+    # back to the live path rather than serve a half-ingested answer.
+    _seed_membership_cursor(db, acme_org_with_installation.tenant_id)
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
+
+    def _paginated_side_effect(path, params=None):
+        if path == "/orgs/acme/members" and params == {"role": "admin"}:
+            return []
+        if path == "/orgs/acme/members":
+            return [{"login": "alice", "avatar_url": ""}]
+        if path == "/orgs/acme/repos":
+            return [{"name": "api"}]
+        return []
+
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    with patch("src.routers.collab.resolve_org_token", return_value="ghp_test"), patch(
+        "src.routers.collab.GitHubClient"
+    ) as mock_client:
+        mock_client.return_value.request_paginated.side_effect = _paginated_side_effect
+        mock_client.return_value.request.return_value = []
+        resp = TestClient(app).get("/github/orgs/acme/inactive-members?days=30")
+
+    assert resp.status_code == 200
+    mock_client.return_value.request_paginated.assert_any_call("/orgs/acme/members", params={"role": "admin"})
 
 
 def test_inactive_members_no_token_returns_400(client):

--- a/apps/api/tests/test_collab_access.py
+++ b/apps/api/tests/test_collab_access.py
@@ -1,15 +1,17 @@
 """Tests for permission-audit and inactive-members routes (docs/plan.md Phase 18)."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.collab import router as collab_router
 
 _ADMIN = UserOut(id=1, email="admin@example.com", name=None, is_workspace_admin=False)
@@ -26,12 +28,44 @@ def acme_org(db):
 
 
 @pytest.fixture()
+def acme_org_with_installation(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=7, org_id=acme_org.id
+    )
+    return acme_org
+
+
+@pytest.fixture()
 def client(db, acme_org):
     app = FastAPI()
     app.include_router(collab_router)
     app.dependency_overrides[require_auth] = lambda: _ADMIN
     app.dependency_overrides[get_db] = lambda: db
     return TestClient(app)
+
+
+def _insert_org_member(db, tenant_id, *, login, avatar_url="", role="member"):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO org_members (tenant_id, login, avatar_url, role, added_at) "
+            "VALUES (:tenant_id, :login, :avatar_url, :role, :added_at)"
+        ),
+        {"tenant_id": tenant_id, "login": login, "avatar_url": avatar_url, "role": role, "added_at": datetime.now(timezone.utc)},
+    )
+    db.commit()
+
+
+def _insert_push_event(db, tenant_id, *, repo, actor, occurred_at, delivery_id):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO repo_events (tenant_id, delivery_id, event_type, actor, actor_avatar, repo, summary, occurred_at) "
+            "VALUES (:tenant_id, :delivery_id, 'push', :actor, '', :repo, 'pushed 1 commit', :occurred_at)"
+        ),
+        {"tenant_id": tenant_id, "delivery_id": delivery_id, "actor": actor, "repo": repo, "occurred_at": occurred_at},
+    )
+    db.commit()
 
 
 def test_permission_audit_no_token_returns_400(client):
@@ -129,6 +163,94 @@ def test_permission_audit_outsider_forbidden(db):
     app.dependency_overrides[get_db] = lambda: db
     resp = TestClient(app).get("/github/orgs/acme/permission-audit")
     assert resp.status_code == 403
+
+
+def test_inactive_members_from_ingested_db_flags_member_with_no_push_events(db, acme_org_with_installation):
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    with patch("src.routers.collab.GitHubClient") as mock_client:
+        resp = TestClient(app).get("/github/orgs/acme/inactive-members?days=30")
+
+    assert resp.status_code == 200
+    mock_client.assert_not_called()
+    body = resp.json()
+    assert len(body["members"]) == 1
+    assert body["members"][0]["login"] == "alice"
+    assert body["members"][0]["last_commit_days_ago"] is None
+    assert body["members"][0]["last_commit_repo"] is None
+
+
+def test_inactive_members_from_ingested_db_excludes_recently_active_member(db, acme_org_with_installation):
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
+    _insert_push_event(
+        db,
+        acme_org_with_installation.tenant_id,
+        repo="acme/api",
+        actor="alice",
+        occurred_at=datetime.now(timezone.utc) - timedelta(days=1),
+        delivery_id="d1",
+    )
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/inactive-members?days=30")
+
+    assert resp.status_code == 200
+    assert resp.json()["members"] == []
+
+
+def test_inactive_members_from_ingested_db_flags_member_with_only_stale_push(db, acme_org_with_installation):
+    _insert_org_member(db, acme_org_with_installation.tenant_id, login="alice", role="member")
+    _insert_push_event(
+        db,
+        acme_org_with_installation.tenant_id,
+        repo="acme/api",
+        actor="alice",
+        occurred_at=datetime.now(timezone.utc) - timedelta(days=60),
+        delivery_id="d2",
+    )
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/inactive-members?days=30")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["members"][0]["login"] == "alice"
+    assert body["members"][0]["last_commit_repo"] == "acme/api"
+    assert body["members"][0]["last_commit_days_ago"] >= 59
+    assert body["sampled_repos"] == ["acme/api"]
+
+
+def test_inactive_members_from_ingested_db_uses_most_recent_push_across_all_repos(db, acme_org_with_installation):
+    # Unlike the live path's bounded _MAX_REPOS_SAMPLED_FOR_ACTIVITY sample, the ingested path
+    # considers every repo with a push event -- a recent push to a second repo must still
+    # exclude the member even though their first/older repo alone would flag them.
+    tenant_id = acme_org_with_installation.tenant_id
+    _insert_org_member(db, tenant_id, login="alice", role="member")
+    _insert_push_event(
+        db, tenant_id, repo="acme/old-repo", actor="alice", occurred_at=datetime.now(timezone.utc) - timedelta(days=90), delivery_id="d3"
+    )
+    _insert_push_event(
+        db, tenant_id, repo="acme/new-repo", actor="alice", occurred_at=datetime.now(timezone.utc) - timedelta(days=1), delivery_id="d4"
+    )
+    app = FastAPI()
+    app.include_router(collab_router)
+    app.dependency_overrides[require_auth] = lambda: _ADMIN
+    app.dependency_overrides[get_db] = lambda: db
+
+    resp = TestClient(app).get("/github/orgs/acme/inactive-members?days=30")
+
+    assert resp.status_code == 200
+    assert resp.json()["members"] == []
 
 
 def test_inactive_members_no_token_returns_400(client):


### PR DESCRIPTION
## Summary

Collaborators PR 3 of 3 — re-points `apps/api/src/routers/collab.py`'s `list_members` and `inactive_members` endpoints onto the tables PR 1 (ingestion) and PR 2 (reconciliation poll) built, for orgs with a live GitHub App installation. `list_outside_collaborators`, `permission_audit`'s per-repo enumeration, `get_membership`, and `list_github_invitations` stay live — see "Scope decision" below for why.

## Why (scope decision, not a blanket re-point)

Before touching anything, I checked what each ingested table actually covers, since a naive "re-point everything" would have introduced a silent correctness regression:

- `org_members` is **complete and authoritative** for a connected org — PR 2's reconciliation poll does a full `/orgs/{org}/members` roster fetch + upsert + delete-what's-missing every poll cycle.
- `repo_events` is **complete for its ingested window** — S4's webhook ingestion plus S5's install-time backfill + gap-heal sweep.
- `repo_collaborators` is **not complete** — it only has rows for grants the `member` webhook event has observed *since the org connected*. There was never a backfill job for pre-existing direct repo grants (unlike the other two tables).

Re-pointing `list_outside_collaborators` or `permission_audit`'s per-repo collaborator enumeration today would silently under-report real outside collaborators/permissions for any org connected before this feature existed — a real correctness regression, not just staleness. Both stay fully live. `get_membership` (single-user point lookup, no efficiency gain from re-pointing) and `list_github_invitations` (no ingestion path exists for org invitations at all) also stay live.

## What changed

- **`list_members`**: full re-point for a connected org (gated on `installation_id` presence via a new `_installation_connected` helper, mirroring `security.py`/`analytics.py`'s existing cockpit-connected-tenant pattern). Role, avatar, and `two_factor_enabled` now come straight from `org_members` instead of three live GitHub calls (admin-filtered members, all members, 2FA-disabled filter). `two_factor_overlay_available` is now `any(member.two_factor_enabled is not None)` rather than "did the live overlay call succeed" — a brand-new installation can have `org_members` rows (from the webhook path) before its first reconciliation-poll tick has populated 2FA.
- **`inactive_members`**: full re-point. Member/role list from `org_members`; last-activity from one `SELECT DISTINCT ON (actor) ... FROM repo_events WHERE event_type = 'push'` query instead of the live path's `O(members × _MAX_REPOS_SAMPLED_FOR_ACTIVITY)` GitHub API fan-out (a ThreadPoolExecutor hitting the commits endpoint per member per sampled repo). This is **strictly more accurate**, not just faster: the live path only samples the 3 most-recently-pushed repos per member and can return "unverified" on a transient API failure; the DB path checks every repo with an ingested push event for the tenant in one query, and every member gets a real answer since there's no per-repo GitHub call left to fail. `sampled_repos` in the DB-backed response now lists the repos that actually contributed a result, not a bounded sample.

## Tests

7 new tests: 3 for `list_members`'s DB path (role-annotated read with no GitHub calls made, role filter, `two_factor_overlay_available=false` when never polled) and 4 for `inactive_members`'s (flags a member with no push events, excludes a recently-active member, flags a member with only a stale push, and — specifically exercising the "not just 3 sampled repos" improvement — correctly excludes a member whose most recent push landed in a *different* repo than their oldest one).

All existing `test_collab.py`/`test_collab_access.py` tests pass unchanged, since none of their fixtures create a GitHub App installation — they continue to exercise the live fallback path exactly as before.

Full suite: `861 passed, 3 skipped, 3 xpassed` (up from 854 before this PR).

No schema/migration changes, no `.env`/RBAC/token-encryption changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Organization member lists and inactive-member results can load from synchronized ingested data, reducing reliance on live GitHub requests.
  * Inactive-member activity is calculated using consolidated activity data.

* **Reliability**
  * Results now use ingested data only after synchronization is complete and trustworthy; otherwise, the live GitHub path is used.
  * Two-factor authentication overlays are unavailable when any member’s status is unknown.

* **Bug Fixes**
  * Improved accuracy for member roster, inactivity, and two-factor authentication results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->