### PR TITLE
fix(tests): bound session-end truncate lock wait with lock_timeout

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -45,6 +45,13 @@ def _engine():
     # up there; only swallow the expected privilege error, not real bugs.
     try:
         with eng.begin() as conn:
+            # TRUNCATE takes an ACCESS EXCLUSIVE lock on every table involved -- if a stray
+            # connection (e.g. a hung manual dev/E2E session against this same DB) is still
+            # holding a lock on one of them, an unbounded TRUNCATE would hang teardown
+            # indefinitely instead of failing fast. lock_timeout bounds the wait; it's
+            # transaction-scoped (SET LOCAL) so it can't leak onto other users of this
+            # session-scoped connection.
+            conn.execute(text("SET LOCAL lock_timeout = '5s'"))
             # Base.metadata.tables (unordered), not .sorted_tables -- a topological sort isn't
             # needed since TRUNCATE ... CASCADE handles FK ordering itself, and orgs/tenants have
             # a genuine FK cycle between them that makes .sorted_tables raise a SAWarning.
@@ -53,9 +60,10 @@ def _engine():
                 quoted = ", ".join(f'"{name}"' for name in table_names)
                 conn.execute(text(f"TRUNCATE TABLE {quoted} RESTART IDENTITY CASCADE"))
     except DBAPIError as exc:
-        if "InsufficientPrivilege" not in type(exc.orig).__name__:
+        orig_type = type(exc.orig).__name__
+        if orig_type not in ("InsufficientPrivilege", "LockNotAvailable"):
             raise
-        logger.warning("skipping post-session DB truncate: connected role lacks TRUNCATE privilege")
+        logger.warning("skipping post-session DB truncate: %s", orig_type)
 
 
 @pytest.fixture


### PR DESCRIPTION
TRUNCATE takes an ACCESS EXCLUSIVE lock; without a bound, a stray connection holding a lock on one of these tables could hang pytest teardown indefinitely instead of failing fast.

## Summary

<!-- What does this PR change, and why? -->

Closes #<!-- issue number, if any -->

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
- [ ] Relevant `pytest` tests pass (if API/worker changed)
- [ ] Docker images still build, if `Dockerfile`/deps changed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test database cleanup now fails fast when another connection holds a lock, preventing teardown from hanging.
  * Cleanup warnings now accurately reflect different database errors encountered during teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->