### PR TITLE
fix(api,ui,worker): surface degraded/stale Overview data instead of silently faking it

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -365,58 +365,56 @@ def _safe_commit_activity_4w_and_heatmap_52w(
     # commits just don't contribute) rather than zeroing the whole org's aggregate, and the
     # returned `ok` flag tells the caller at least one repo's stats couldn't be fetched, so
     # the resulting totals are a real partial sum, not a silent lie dressed up as "0 commits."
+    # No outer try/except: every future's result() is resolved inside the loop below, so a
+    # per-repo httpx failure is always caught there -- an outer catch here would be dead code.
     client = GitHubClient(token)
     totals_4w = [0, 0, 0, 0]
     totals_52w = [0] * 52
     ok = True
-    try:
-        with ThreadPoolExecutor(max_workers=10) as pool:
-            futures = [
-                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
-                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
-            ]
-            for future in futures:
-                try:
-                    weeks = future.result()
-                except (httpx.HTTPStatusError, httpx.RequestError):
-                    ok = False
-                    continue
-                if not isinstance(weeks, list):
-                    ok = False
-                    continue
-                if len(weeks) >= 4:
-                    for i, week in enumerate(weeks[-4:]):
-                        totals_4w[i] += week.get("total", 0)
-                if len(weeks) >= 52:
-                    for i, week in enumerate(weeks[-52:]):
-                        totals_52w[i] += week.get("total", 0)
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        return [0, 0, 0, 0], [0] * 52, False
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = [
+            pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
+            for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
+        ]
+        for future in futures:
+            try:
+                weeks = future.result()
+            except (httpx.HTTPStatusError, httpx.RequestError):
+                ok = False
+                continue
+            if not isinstance(weeks, list):
+                ok = False
+                continue
+            if len(weeks) >= 4:
+                for i, week in enumerate(weeks[-4:]):
+                    totals_4w[i] += week.get("total", 0)
+            if len(weeks) >= 52:
+                for i, week in enumerate(weeks[-52:]):
+                    totals_52w[i] += week.get("total", 0)
     return totals_4w, totals_52w, ok
 
 
 def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> tuple[int, bool]:
+    # See _safe_commit_activity_4w_and_heatmap_52w's comment -- no outer try/except needed here
+    # either, for the same reason.
     client = GitHubClient(token)
     total = 0
     ok = True
-    try:
-        with ThreadPoolExecutor(max_workers=10) as pool:
-            futures = [
-                pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/actions/caches")
-                for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
-            ]
-            for future in futures:
-                try:
-                    data = future.result()
-                except (httpx.HTTPStatusError, httpx.RequestError):
-                    ok = False
-                    continue
-                if isinstance(data, dict):
-                    total += sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
-                else:
-                    ok = False
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        return 0, False
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = [
+            pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/actions/caches")
+            for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
+        ]
+        for future in futures:
+            try:
+                data = future.result()
+            except (httpx.HTTPStatusError, httpx.RequestError):
+                ok = False
+                continue
+            if isinstance(data, dict):
+                total += sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
+            else:
+                ok = False
     return total, ok
 
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -353,6 +353,16 @@ def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
         return []
 
 
+def _week_total(week: dict) -> int | float:
+    """Raises AttributeError (non-dict week) or TypeError (non-numeric "total") for the caller
+    to treat as a per-repo failure -- a malformed nested record from GitHub must not silently
+    coerce into 0, which would look identical to a real zero-commit week."""
+    total = week.get("total", 0)
+    if not isinstance(total, (int, float)):
+        raise TypeError(f"non-numeric week total: {total!r}")
+    return total
+
+
 def _safe_commit_activity_4w_and_heatmap_52w(
     owner: str, token: str, repo_names: list[str]
 ) -> tuple[list[int], list[int], bool]:
@@ -385,13 +395,32 @@ def _safe_commit_activity_4w_and_heatmap_52w(
             if not isinstance(weeks, list):
                 ok = False
                 continue
-            if len(weeks) >= 4:
-                for i, week in enumerate(weeks[-4:]):
-                    totals_4w[i] += week.get("total", 0)
-            if len(weeks) >= 52:
-                for i, week in enumerate(weeks[-52:]):
-                    totals_52w[i] += week.get("total", 0)
+            # A malformed nested record (a non-dict week, or a non-numeric "total") must not
+            # raise past this point -- an uncaught exception here would escape asyncio.gather
+            # and fail the whole cockpit request instead of just degrading this one repo's
+            # contribution, defeating the whole point of this per-repo isolation. Accumulated
+            # into a local delta first (not directly into totals_4w/52w) so a mid-repo failure
+            # can't leave this one repo's contribution half-applied across the two arrays.
+            try:
+                delta_4w = [_week_total(week) for week in weeks[-4:]] if len(weeks) >= 4 else [0, 0, 0, 0]
+                delta_52w = [_week_total(week) for week in weeks[-52:]] if len(weeks) >= 52 else [0] * 52
+            except (AttributeError, TypeError):
+                ok = False
+                continue
+            for i in range(4):
+                totals_4w[i] += delta_4w[i]
+            for i in range(52):
+                totals_52w[i] += delta_52w[i]
     return totals_4w, totals_52w, ok
+
+
+def _cache_entry_bytes(entry: dict) -> int | float:
+    """Same contract as _week_total: raises for the caller to treat as a per-repo failure
+    instead of silently coercing a malformed entry into 0 bytes."""
+    size = entry.get("size_in_bytes", 0)
+    if not isinstance(size, (int, float)):
+        raise TypeError(f"non-numeric cache entry size: {size!r}")
+    return size
 
 
 def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> tuple[int, bool]:
@@ -411,9 +440,15 @@ def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> tu
             except (httpx.HTTPStatusError, httpx.RequestError):
                 ok = False
                 continue
-            if isinstance(data, dict):
-                total += sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
-            else:
+            if not isinstance(data, dict):
+                ok = False
+                continue
+            # Same non-dict-entry/non-numeric-field guard as the commit-activity helper above --
+            # a malformed cache entry must degrade this one repo, not raise past future.result()
+            # and fail the whole cockpit request.
+            try:
+                total += sum(_cache_entry_bytes(c) for c in data.get("actions_caches", []))
+            except (AttributeError, TypeError):
                 ok = False
     return total, ok
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -353,13 +353,18 @@ def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
         return []
 
 
-def _week_total(week: dict) -> int | float:
-    """Raises AttributeError (non-dict week) or TypeError (non-numeric "total") for the caller
-    to treat as a per-repo failure -- a malformed nested record from GitHub must not silently
-    coerce into 0, which would look identical to a real zero-commit week."""
+def _week_total(week: dict) -> int:
+    """Raises AttributeError (non-dict week) or TypeError (not a real non-negative commit count)
+    for the caller to treat as a per-repo failure -- a malformed nested record from GitHub must
+    not silently coerce into 0, which would look identical to a real zero-commit week. A commit
+    count is always a non-negative plain int on GitHub's side; explicitly excludes bool (`bool`
+    is a subclass of `int` in Python, so `isinstance(True, int)` is True) and rejects fractional/
+    negative values, which CockpitResponse's `commit_activity_4w: list[int]` can't represent
+    faithfully (a fraction would silently truncate on Pydantic coercion; a negative would pass
+    validation but produce a nonsensical metric)."""
     total = week.get("total", 0)
-    if not isinstance(total, (int, float)):
-        raise TypeError(f"non-numeric week total: {total!r}")
+    if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+        raise TypeError(f"invalid week total: {total!r}")
     return total
 
 
@@ -414,12 +419,13 @@ def _safe_commit_activity_4w_and_heatmap_52w(
     return totals_4w, totals_52w, ok
 
 
-def _cache_entry_bytes(entry: dict) -> int | float:
-    """Same contract as _week_total: raises for the caller to treat as a per-repo failure
-    instead of silently coercing a malformed entry into 0 bytes."""
+def _cache_entry_bytes(entry: dict) -> int:
+    """Same contract and non-negative-plain-int rationale as _week_total: raises for the caller
+    to treat as a per-repo failure instead of silently coercing a malformed entry into 0 bytes,
+    accepting a bool, or accepting a negative/fractional size."""
     size = entry.get("size_in_bytes", 0)
-    if not isinstance(size, (int, float)):
-        raise TypeError(f"non-numeric cache entry size: {size!r}")
+    if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+        raise TypeError(f"invalid cache entry size: {size!r}")
     return size
 
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -6,9 +6,10 @@ from datetime import date, datetime, timedelta, timezone
 import anyio
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
+from src.core.app_config import get_config
 from src.core.auth import UserOut, require_auth
 from src.core.db import RepoEventDailyCount, get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role, set_tenant_session_context
@@ -179,12 +180,15 @@ def _safe_list_repos(owner: str, token: str) -> list[dict]:
     return client.request_paginated(f"/orgs/{owner}/repos", params={"type": "all", "sort": "pushed"})
 
 
-def _safe_member_count(owner: str, token: str) -> int:
+def _safe_member_count(owner: str, token: str) -> tuple[int, bool]:
+    """Returns (count, ok) -- ok=False means the call failed and count is a fallback 0, not a real
+    zero. Callers must fold `not ok` into CockpitResponse.degraded rather than trusting the bare
+    count, which previously looked identical to "this org genuinely has zero members." """
     try:
         client = GitHubClient(token)
-        return len(client.request_paginated(f"/orgs/{owner}/members"))
+        return len(client.request_paginated(f"/orgs/{owner}/members")), True
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return 0
+        return 0, False
 
 
 def _cockpit_connected_tenant(db: Session, user_id: int, owner: str) -> int | None:
@@ -217,30 +221,66 @@ def _cockpit_connected_tenant(db: Session, user_id: int, owner: str) -> int | No
     return org.tenant_id
 
 
-def _safe_recent_events(db: Session, owner: str, token: str, tenant_id: int | None) -> list[OrgEventSummary]:
+def _safe_recent_events(
+    db: Session, owner: str, token: str, tenant_id: int | None
+) -> tuple[list[OrgEventSummary], bool]:
+    """Returns (events, ok) -- ok=False means the underlying fetch failed and events is a fallback
+    [], not a real "no activity" answer."""
     try:
         if tenant_id is not None:
             events = _fetch_events_from_repo_events(db, owner, tenant_id, per_page=10).events
         else:
             events = _cached_events(owner, token, per_page=10).events
-        return [OrgEventSummary(**e.model_dump()) for e in events[:5]]
+        return [OrgEventSummary(**e.model_dump()) for e in events[:5]], True
     except (httpx.HTTPStatusError, httpx.RequestError, HTTPException):
-        return []
+        return [], False
+
+
+_ACTIVITY_STALE_HOURS_DEFAULT = 6
+
+
+def _activity_stale_hours() -> int:
+    # Mirrors gap_heal_sweep.py's own _read_stale_hours -- same config key, same clamp -- so
+    # "stale" means the same thing here as it does to the sweep that's supposed to fix it.
+    raw = get_config("gap_heal_stale_hours", str(_ACTIVITY_STALE_HOURS_DEFAULT))
+    try:
+        return max(1, min(168, int(raw)))
+    except ValueError:
+        return _ACTIVITY_STALE_HOURS_DEFAULT
+
+
+def _recent_events_staleness(db: Session, tenant_id: int) -> bool:
+    """True if this tenant's activity ingestion cursor is older than gap_heal_stale_hours (or has
+    never synced at all) -- surfaced to the UI so a stalled pipeline shows old data labeled as old,
+    instead of silently looking current. Tenant session context is already set by
+    _cockpit_connected_tenant before this runs, so this read is correctly RLS-scoped."""
+    row = db.execute(
+        text("SELECT last_synced_at FROM activity_sync_cursors WHERE tenant_id = :tenant_id"),
+        {"tenant_id": tenant_id},
+    ).fetchone()
+    if row is None or row[0] is None:
+        return True
+    last_synced_at = row[0]
+    if last_synced_at.tzinfo is None:
+        last_synced_at = last_synced_at.replace(tzinfo=timezone.utc)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=_activity_stale_hours())
+    return last_synced_at < cutoff
 
 
 def _cockpit_events_and_commit_activity(
     db: Session, owner: str, token: str, tenant_id: int | None, repo_names: list[str]
-) -> tuple[list[OrgEventSummary], tuple[list[int], list[int]]]:
+) -> tuple[list[OrgEventSummary], bool, bool, tuple[list[int], list[int], bool]]:
     # Bundled into one call, not two independent asyncio.gather entries, because both
     # branches below read `db` when tenant_id is set -- a SQLAlchemy Session isn't safe
     # to use concurrently from two threads at once, unlike every other helper in the
     # cockpit's gather, which only ever touches the GitHub token/client.
-    recent_events = _safe_recent_events(db, owner, token, tenant_id)
+    recent_events, recent_events_ok = _safe_recent_events(db, owner, token, tenant_id)
+    recent_events_stale = _recent_events_staleness(db, tenant_id) if tenant_id is not None else False
     if tenant_id is not None:
-        commit_activity = _cockpit_commit_activity_from_aggregate(db, tenant_id)
+        commit_activity = (*_cockpit_commit_activity_from_aggregate(db, tenant_id), True)
     else:
         commit_activity = _safe_commit_activity_4w_and_heatmap_52w(owner, token, repo_names)
-    return recent_events, commit_activity
+    return recent_events, not recent_events_ok, recent_events_stale, commit_activity
 
 
 def _cockpit_commit_activity_from_aggregate(db: Session, tenant_id: int) -> tuple[list[int], list[int]]:
@@ -284,12 +324,12 @@ def _search_count(client: GitHubClient, query: str) -> int:
     return result.get("total_count", 0) if isinstance(result, dict) else 0
 
 
-def _safe_open_pr_count(owner: str, token: str) -> int:
+def _safe_open_pr_count(owner: str, token: str) -> tuple[int, bool]:
     try:
         client = GitHubClient(token)
-        return _search_count(client, f"org:{owner} type:pr state:open")
+        return _search_count(client, f"org:{owner} type:pr state:open"), True
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return 0
+        return 0, False
 
 
 def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
@@ -315,26 +355,34 @@ def _safe_pr_merge_rate_4w(owner: str, token: str) -> list[PrWeekBucket]:
 
 def _safe_commit_activity_4w_and_heatmap_52w(
     owner: str, token: str, repo_names: list[str]
-) -> tuple[list[int], list[int]]:
+) -> tuple[list[int], list[int], bool]:
     # Both windows are slices of the exact same GitHub call
     # (/repos/{owner}/{repo}/stats/commit_activity already returns 52 weeks), so this
     # fetches each repo once and derives both aggregates from it -- fetching twice
     # (once per aggregate) would double this endpoint's GitHub API cost for no reason.
-    # A single failing repo zeroes both aggregates rather than partially summing --
-    # simpler than reconciling "which repos contributed" and consistent with this
-    # function's own all-or-nothing best-effort contract to its caller.
+    #
+    # Each repo's future is resolved individually below: a failing repo is skipped (its
+    # commits just don't contribute) rather than zeroing the whole org's aggregate, and the
+    # returned `ok` flag tells the caller at least one repo's stats couldn't be fetched, so
+    # the resulting totals are a real partial sum, not a silent lie dressed up as "0 commits."
+    client = GitHubClient(token)
+    totals_4w = [0, 0, 0, 0]
+    totals_52w = [0] * 52
+    ok = True
     try:
-        client = GitHubClient(token)
-        totals_4w = [0, 0, 0, 0]
-        totals_52w = [0] * 52
         with ThreadPoolExecutor(max_workers=10) as pool:
             futures = [
                 pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/stats/commit_activity")
                 for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
             ]
             for future in futures:
-                weeks = future.result()
+                try:
+                    weeks = future.result()
+                except (httpx.HTTPStatusError, httpx.RequestError):
+                    ok = False
+                    continue
                 if not isinstance(weeks, list):
+                    ok = False
                     continue
                 if len(weeks) >= 4:
                     for i, week in enumerate(weeks[-4:]):
@@ -342,27 +390,34 @@ def _safe_commit_activity_4w_and_heatmap_52w(
                 if len(weeks) >= 52:
                     for i, week in enumerate(weeks[-52:]):
                         totals_52w[i] += week.get("total", 0)
-        return totals_4w, totals_52w
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return [0, 0, 0, 0], [0] * 52
+        return [0, 0, 0, 0], [0] * 52, False
+    return totals_4w, totals_52w, ok
 
 
-def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> int:
+def _safe_total_cache_bytes(owner: str, token: str, repo_names: list[str]) -> tuple[int, bool]:
+    client = GitHubClient(token)
+    total = 0
+    ok = True
     try:
-        client = GitHubClient(token)
         with ThreadPoolExecutor(max_workers=10) as pool:
             futures = [
                 pool.submit(client.request, "GET", f"/repos/{owner}/{repo}/actions/caches")
                 for repo in repo_names[:_MAX_REPOS_FOR_AGGREGATES]
             ]
-            results = [future.result() for future in futures]
-            return sum(
-                sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
-                for data in results
-                if isinstance(data, dict)
-            )
+            for future in futures:
+                try:
+                    data = future.result()
+                except (httpx.HTTPStatusError, httpx.RequestError):
+                    ok = False
+                    continue
+                if isinstance(data, dict):
+                    total += sum(c.get("size_in_bytes", 0) for c in data.get("actions_caches", []))
+                else:
+                    ok = False
     except (httpx.HTTPStatusError, httpx.RequestError):
-        return 0
+        return 0, False
+    return total, ok
 
 
 def _milestone_state(due_on: str | None, progress_pct: float) -> str:
@@ -543,11 +598,11 @@ async def personal_analytics_cockpit(
     repo_names = [r["name"] for r in repos]
 
     (
-        member_count,
-        (recent_events, (commit_activity_4w, commit_heatmap_52w)),
-        open_pr_count,
+        (member_count, member_count_ok),
+        (recent_events, recent_events_degraded, recent_events_stale, (commit_activity_4w, commit_heatmap_52w, commit_activity_ok)),
+        (open_pr_count, open_pr_count_ok),
         pr_merge_rate_4w,
-        total_cache_size_bytes,
+        (total_cache_size_bytes, cache_bytes_ok),
         (milestones, at_risk_repos),
         pr_cycle_time_8w,
         release_cadence_4w,
@@ -562,6 +617,14 @@ async def personal_analytics_cockpit(
         anyio.to_thread.run_sync(lambda: _safe_milestones(owner, token, repo_names)),
         anyio.to_thread.run_sync(lambda: _safe_pr_cycle_time_8w(owner, token)),
         anyio.to_thread.run_sync(lambda: _safe_release_cadence_4w(owner, token, repo_names)),
+    )
+
+    degraded = (
+        not member_count_ok
+        or not open_pr_count_ok
+        or not cache_bytes_ok
+        or not commit_activity_ok
+        or recent_events_degraded
     )
 
     return CockpitResponse(
@@ -581,6 +644,9 @@ async def personal_analytics_cockpit(
         pr_cycle_time_8w=pr_cycle_time_8w,
         release_cadence_4w=release_cadence_4w,
         commit_activity_source="aggregate" if connected_tenant_id is not None else "github",
+        recent_events_source="aggregate" if connected_tenant_id is not None else "github",
+        recent_events_stale=recent_events_stale,
+        degraded=degraded,
     )
 
 

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -83,6 +83,15 @@ class CockpitResponse(BaseModel):
     pr_cycle_time_8w: list[PrCycleTimeWeek] = []
     release_cadence_4w: list[int] = []
     commit_activity_source: Literal["github", "aggregate"] = "github"
+    recent_events_source: Literal["github", "aggregate"] = "github"
+    # True if a stored aggregate is stale relative to gap_heal_stale_hours -- only ever set when
+    # recent_events_source == "aggregate"; the live "github" path has no ingestion cursor to be
+    # stale against (whatever GitHub returns synchronously is definitionally current).
+    recent_events_stale: bool = False
+    # True if any best-effort live GitHub call underlying this response failed and fell back to a
+    # zero/empty/partial value (see the _safe_* helpers below) -- lets the UI distinguish "this org
+    # genuinely has none" from "we couldn't fully fetch this," which previously rendered identically.
+    degraded: bool = False
 
 
 class PRSummary(BaseModel):

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -50,12 +50,14 @@ def http(app):
 
 _DEFAULT_SAFE_MOCKS = {
     "src.routers.analytics._safe_list_repos": {"return_value": [{"name": "api"}, {"name": "worker"}]},
-    "src.routers.analytics._safe_member_count": {"return_value": 12},
-    "src.routers.analytics._safe_recent_events": {"return_value": []},
-    "src.routers.analytics._safe_open_pr_count": {"return_value": 7},
+    "src.routers.analytics._safe_member_count": {"return_value": (12, True)},
+    "src.routers.analytics._safe_recent_events": {"return_value": ([], True)},
+    "src.routers.analytics._safe_open_pr_count": {"return_value": (7, True)},
     "src.routers.analytics._safe_pr_merge_rate_4w": {"return_value": []},
-    "src.routers.analytics._safe_commit_activity_4w_and_heatmap_52w": {"return_value": ([1, 2, 3, 4], [0] * 52)},
-    "src.routers.analytics._safe_total_cache_bytes": {"return_value": 123456},
+    "src.routers.analytics._safe_commit_activity_4w_and_heatmap_52w": {
+        "return_value": ([1, 2, 3, 4], [0] * 52, True)
+    },
+    "src.routers.analytics._safe_total_cache_bytes": {"return_value": (123456, True)},
     "src.routers.analytics._safe_milestones": {"return_value": ([], [])},
     "src.routers.analytics._safe_pr_cycle_time_8w": {"return_value": []},
     "src.routers.analytics._safe_release_cadence_4w": {"return_value": [0, 0, 0, 0]},
@@ -120,6 +122,7 @@ def test_cockpit_success_all_sources(http, db, mock_user):
     assert body["latest_score"] == 85
     assert body["score_trend"] == [70, 85]
     assert body["cache_job_success_rate"] == 0.75
+    assert body["degraded"] is False
 
 
 def test_cockpit_no_scans_yet(http, db, mock_user):
@@ -151,7 +154,7 @@ def test_cockpit_no_cache_jobs_yet(http, db, mock_user):
 
 
 def test_cockpit_degrades_when_pr_search_fails(http, db, mock_user):
-    patchers = _patch_all({"src.routers.analytics._safe_open_pr_count": {"return_value": 0}})
+    patchers = _patch_all({"src.routers.analytics._safe_open_pr_count": {"return_value": (0, False)}})
     _start_all(patchers)
     try:
         with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
@@ -163,10 +166,11 @@ def test_cockpit_degrades_when_pr_search_fails(http, db, mock_user):
     body = resp.json()
     assert body["open_pr_count"] == 0
     assert body["member_count"] == 12  # other fields unaffected
+    assert body["degraded"] is True  # a failed call must not look identical to a real 0
 
 
 def test_cockpit_degrades_when_events_fetch_fails(http, db, mock_user):
-    patchers = _patch_all({"src.routers.analytics._safe_recent_events": {"return_value": []}})
+    patchers = _patch_all({"src.routers.analytics._safe_recent_events": {"return_value": ([], False)}})
     _start_all(patchers)
     try:
         with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
@@ -175,7 +179,24 @@ def test_cockpit_degrades_when_events_fetch_fails(http, db, mock_user):
         _stop_all(patchers)
 
     assert resp.status_code == 200
-    assert resp.json()["recent_events"] == []
+    body = resp.json()
+    assert body["recent_events"] == []
+    assert body["degraded"] is True
+
+
+def test_cockpit_not_degraded_when_every_safe_call_succeeds_but_returns_empty(http, db, mock_user):
+    """A genuinely empty org (no PRs, no events) must NOT be flagged degraded -- only an actual
+    failed call should set it."""
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    assert resp.json()["degraded"] is False
 
 
 def test_cockpit_fails_when_repo_list_fails(http, db, mock_user):
@@ -384,32 +405,101 @@ def test_cockpit_does_not_read_aggregate_for_org_the_caller_is_not_a_member_of(h
 
 
 # ---------------------------------------------------------------------------
+# recent_events staleness (data-accuracy fix): a connected org's Recent Activity card must
+# say so when the ingestion cursor hasn't advanced recently, instead of silently showing old
+# data as if it were current.
+# ---------------------------------------------------------------------------
+
+
+def _set_cursor(db, tenant_id, *, account_login="acme", account_type="Organization", last_synced_at):
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(
+        text(
+            "INSERT INTO activity_sync_cursors (tenant_id, account_login, account_type, last_synced_at) "
+            "VALUES (:tenant_id, :account_login, :account_type, :last_synced_at)"
+        ),
+        {
+            "tenant_id": tenant_id,
+            "account_login": account_login,
+            "account_type": account_type,
+            "last_synced_at": last_synced_at,
+        },
+    )
+    db.commit()
+
+
+def test_recent_events_staleness_true_when_never_synced(db):
+    from src.routers.analytics import _recent_events_staleness
+
+    assert _recent_events_staleness(db, tenant_id=99999) is True
+
+
+def test_recent_events_staleness_false_when_recently_synced(db, acme_org_with_installation):
+    from src.routers.analytics import _recent_events_staleness
+
+    tenant_id = acme_org_with_installation.tenant_id
+    _set_cursor(db, tenant_id, last_synced_at=datetime.now(timezone.utc) - timedelta(minutes=5))
+    assert _recent_events_staleness(db, tenant_id) is False
+
+
+def test_recent_events_staleness_true_when_synced_long_ago(db, acme_org_with_installation):
+    from src.routers.analytics import _recent_events_staleness
+
+    tenant_id = acme_org_with_installation.tenant_id
+    _set_cursor(db, tenant_id, last_synced_at=datetime.now(timezone.utc) - timedelta(hours=48))
+    assert _recent_events_staleness(db, tenant_id) is True
+
+
+def test_cockpit_connected_org_surfaces_recent_events_staleness(http, db, mock_user, acme_org_with_installation):
+    patchers = [patch(target, **kwargs) for target, kwargs in _CONNECTED_SAFE_MOCKS.items()]
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["recent_events_source"] == "aggregate"
+    assert body["recent_events_stale"] is True  # no cursor row was ever written in this test
+
+
+# ---------------------------------------------------------------------------
 # Unit tests for individual _safe_* helpers' own try/except behavior
 # ---------------------------------------------------------------------------
 
 
-def test_safe_member_count_returns_zero_on_http_error():
+def test_safe_member_count_returns_zero_and_not_ok_on_http_error():
     from src.routers.analytics import _safe_member_count
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request_paginated.side_effect = _HTTP_ERROR
-        assert _safe_member_count("acme", "ghp_test") == 0
+        assert _safe_member_count("acme", "ghp_test") == (0, False)
 
 
-def test_safe_member_count_returns_zero_on_request_error():
+def test_safe_member_count_returns_zero_and_not_ok_on_request_error():
     from src.routers.analytics import _safe_member_count
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request_paginated.side_effect = httpx.RequestError("boom")
-        assert _safe_member_count("acme", "ghp_test") == 0
+        assert _safe_member_count("acme", "ghp_test") == (0, False)
 
 
-def test_safe_open_pr_count_returns_zero_on_http_error():
+def test_safe_member_count_returns_ok_true_on_success():
+    from src.routers.analytics import _safe_member_count
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request_paginated.return_value = [{}] * 3
+        assert _safe_member_count("acme", "ghp_test") == (3, True)
+
+
+def test_safe_open_pr_count_returns_zero_and_not_ok_on_http_error():
     from src.routers.analytics import _safe_open_pr_count
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = _HTTP_ERROR
-        assert _safe_open_pr_count("acme", "ghp_test") == 0
+        assert _safe_open_pr_count("acme", "ghp_test") == (0, False)
 
 
 def test_safe_pr_merge_rate_4w_returns_empty_list_on_error():
@@ -432,14 +522,15 @@ def test_safe_pr_merge_rate_4w_returns_four_chronological_buckets():
     assert all(b.opened == 3 and b.merged == 3 for b in buckets)
 
 
-def test_safe_commit_activity_4w_and_heatmap_52w_returns_zeros_on_error():
+def test_safe_commit_activity_4w_and_heatmap_52w_returns_zeros_and_not_ok_when_every_repo_fails():
     from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = httpx.RequestError("boom")
-        activity, heatmap = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a"])
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a"])
     assert activity == [0, 0, 0, 0]
     assert heatmap == [0] * 52
+    assert ok is False
 
 
 def test_safe_commit_activity_4w_and_heatmap_52w_sums_across_repos_from_one_fetch():
@@ -449,21 +540,45 @@ def test_safe_commit_activity_4w_and_heatmap_52w_sums_across_repos_from_one_fetc
     weeks_b = [{"total": 1} for _ in range(52)]
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = [weeks_a, weeks_b]
-        activity, heatmap = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a", "repo-b"])
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a", "repo-b"])
 
     # Only one request per repo -- not one for the 4w slice and a second for the 52w one.
     assert mock_client.return_value.request.call_count == 2
     assert activity == [49, 50, 51, 52]
     assert len(heatmap) == 52
     assert heatmap[0] == weeks_a[0]["total"] + weeks_b[0]["total"]
+    assert ok is True
 
 
-def test_safe_total_cache_bytes_returns_zero_on_error():
+def test_safe_commit_activity_4w_and_heatmap_52w_one_bad_repo_sums_the_rest_but_flags_not_ok():
+    """A single flaky repo must not zero the whole org's aggregate -- it's excluded from the
+    sum and `ok` is False, so the caller can tell this apart from a real all-zero org."""
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
+
+    weeks_good = [{"total": 2} for _ in range(52)]
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            raise httpx.RequestError("boom")
+        return weeks_good
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w(
+            "acme", "ghp_test", ["repo-bad", "repo-good"]
+        )
+
+    assert activity == [2, 2, 2, 2]  # repo-good's contribution survives
+    assert heatmap[0] == 2
+    assert ok is False  # but the caller still knows this is a partial sum
+
+
+def test_safe_total_cache_bytes_returns_zero_and_not_ok_on_error():
     from src.routers.analytics import _safe_total_cache_bytes
 
     with patch("src.routers.analytics.GitHubClient") as mock_client:
         mock_client.return_value.request.side_effect = httpx.RequestError("boom")
-        assert _safe_total_cache_bytes("acme", "ghp_test", ["repo-a"]) == 0
+        assert _safe_total_cache_bytes("acme", "ghp_test", ["repo-a"]) == (0, False)
 
 
 def test_safe_total_cache_bytes_sums_across_repos():
@@ -474,8 +589,25 @@ def test_safe_total_cache_bytes_sums_across_repos():
             {"actions_caches": [{"size_in_bytes": 100}, {"size_in_bytes": 50}]},
             {"actions_caches": [{"size_in_bytes": 25}]},
         ]
-        total = _safe_total_cache_bytes("acme", "ghp_test", ["repo-a", "repo-b"])
+        total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-a", "repo-b"])
     assert total == 175
+    assert ok is True
+
+
+def test_safe_total_cache_bytes_one_bad_repo_sums_the_rest_but_flags_not_ok():
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            raise httpx.RequestError("boom")
+        return {"actions_caches": [{"size_in_bytes": 50}]}
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-bad", "repo-good"])
+
+    assert total == 50
+    assert ok is False
 
 
 def test_cache_job_success_rate_mixed(db):

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -617,6 +617,59 @@ def test_safe_commit_activity_4w_and_heatmap_52w_one_bad_repo_sums_the_rest_but_
     assert ok is False  # but the caller still knows this is a partial sum
 
 
+def test_safe_commit_activity_4w_and_heatmap_52w_malformed_week_entry_degrades_not_raises():
+    """A non-dict week (or a week whose "total" isn't numeric) must be treated as a per-repo
+    failure, not raise past future.result() and fail the whole cockpit request -- this is
+    exactly the escape-asyncio.gather scenario CodeRabbit flagged on this PR."""
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
+
+    weeks_good = [{"total": 2} for _ in range(52)]
+    weeks_malformed = [{"total": "not-a-number"} for _ in range(52)]  # e.g. a week entry as a bare string
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            return weeks_malformed
+        return weeks_good
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w(
+            "acme", "ghp_test", ["repo-bad", "repo-good"]
+        )
+
+    assert activity == [2, 2, 2, 2]  # repo-good's contribution survives, repo-bad's doesn't
+    assert heatmap[0] == 2
+    assert ok is False
+
+
+def test_safe_commit_activity_4w_and_heatmap_52w_non_dict_week_degrades_not_raises():
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
+
+    weeks_malformed = ["not-a-dict"] * 52
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = weeks_malformed
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a"])
+
+    assert activity == [0, 0, 0, 0]
+    assert ok is False
+
+
+def test_safe_total_cache_bytes_malformed_entry_degrades_not_raises():
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            return {"actions_caches": [{"size_in_bytes": "not-a-number"}]}
+        return {"actions_caches": [{"size_in_bytes": 100}]}
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-bad", "repo-good"])
+
+    assert total == 100  # repo-good's contribution survives
+    assert ok is False
+
+
 def test_safe_total_cache_bytes_returns_zero_and_not_ok_on_error():
     from src.routers.analytics import _safe_total_cache_bytes
 

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -617,6 +617,82 @@ def test_safe_commit_activity_4w_and_heatmap_52w_one_bad_repo_sums_the_rest_but_
     assert ok is False  # but the caller still knows this is a partial sum
 
 
+@pytest.mark.parametrize("bad_total", [True, 1.5, -1])
+def test_week_total_rejects_bool_fractional_and_negative(bad_total):
+    """CodeRabbit finding: a plain isinstance(x, (int, float)) check accepts bool (bool is an
+    int subclass in Python), fractional values, and negatives -- none of which are a real
+    GitHub commit count. Must raise so the caller degrades this repo instead of adding a
+    nonsensical value to the org-wide total."""
+    from src.routers.analytics import _week_total
+
+    with pytest.raises(TypeError):
+        _week_total({"total": bad_total})
+
+
+def test_week_total_accepts_a_real_non_negative_int():
+    from src.routers.analytics import _week_total
+
+    assert _week_total({"total": 7}) == 7
+    assert _week_total({"total": 0}) == 0
+
+
+@pytest.mark.parametrize("bad_size", [True, 1.5, -1])
+def test_cache_entry_bytes_rejects_bool_fractional_and_negative(bad_size):
+    from src.routers.analytics import _cache_entry_bytes
+
+    with pytest.raises(TypeError):
+        _cache_entry_bytes({"size_in_bytes": bad_size})
+
+
+def test_cache_entry_bytes_accepts_a_real_non_negative_int():
+    from src.routers.analytics import _cache_entry_bytes
+
+    assert _cache_entry_bytes({"size_in_bytes": 512}) == 512
+
+
+@pytest.mark.parametrize("bad_total", [True, 1.5, -1])
+def test_safe_commit_activity_4w_and_heatmap_52w_partial_aggregation_rejects_bad_total(bad_total):
+    """End-to-end through the per-repo fan-out: a bool/fractional/negative "total" degrades
+    that one repo (ok=False) instead of corrupting the org-wide sum or raising past
+    future.result()."""
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
+
+    weeks_good = [{"total": 2} for _ in range(52)]
+    weeks_bad = [{"total": bad_total} for _ in range(52)]
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            return weeks_bad
+        return weeks_good
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w(
+            "acme", "ghp_test", ["repo-bad", "repo-good"]
+        )
+
+    assert activity == [2, 2, 2, 2]
+    assert heatmap[0] == 2
+    assert ok is False
+
+
+@pytest.mark.parametrize("bad_size", [True, 1.5, -1])
+def test_safe_total_cache_bytes_partial_aggregation_rejects_bad_size(bad_size):
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    def _side_effect(method, path):
+        if "repo-bad" in path:
+            return {"actions_caches": [{"size_in_bytes": bad_size}]}
+        return {"actions_caches": [{"size_in_bytes": 100}]}
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = _side_effect
+        total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-bad", "repo-good"])
+
+    assert total == 100
+    assert ok is False
+
+
 def test_safe_commit_activity_4w_and_heatmap_52w_malformed_week_entry_degrades_not_raises():
     """A non-dict week (or a week whose "total" isn't numeric) must be treated as a per-repo
     failure, not raise past future.result() and fail the whole cockpit request -- this is

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -428,6 +428,27 @@ def _set_cursor(db, tenant_id, *, account_login="acme", account_type="Organizati
     db.commit()
 
 
+def test_activity_stale_hours_falls_back_to_default_on_unparsable_config():
+    from src.routers.analytics import _activity_stale_hours
+
+    with patch("src.routers.analytics.get_config", return_value="not-a-number"):
+        assert _activity_stale_hours() == 6
+
+
+def test_recent_events_staleness_treats_naive_last_synced_at_as_utc():
+    """activity_sync_cursors.last_synced_at is TIMESTAMP WITH TIME ZONE, so psycopg always
+    returns an aware datetime in practice -- but the naive-datetime branch is a defensive
+    guard, exercised directly here rather than skipped as unreachable."""
+    from unittest.mock import MagicMock
+
+    from src.routers.analytics import _recent_events_staleness
+
+    naive_recent = datetime.now() - timedelta(minutes=5)  # no tzinfo
+    mock_db = MagicMock()
+    mock_db.execute.return_value.fetchone.return_value = (naive_recent,)
+    assert _recent_events_staleness(mock_db, tenant_id=1) is False
+
+
 def test_recent_events_staleness_true_when_never_synced(db):
     from src.routers.analytics import _recent_events_staleness
 
@@ -448,6 +469,29 @@ def test_recent_events_staleness_true_when_synced_long_ago(db, acme_org_with_ins
     tenant_id = acme_org_with_installation.tenant_id
     _set_cursor(db, tenant_id, last_synced_at=datetime.now(timezone.utc) - timedelta(hours=48))
     assert _recent_events_staleness(db, tenant_id) is True
+
+
+def test_safe_recent_events_live_path_returns_empty_and_not_ok_on_error(db):
+    from src.routers.analytics import _safe_recent_events
+
+    with patch("src.routers.analytics._cached_events", side_effect=httpx.RequestError("boom")):
+        events, ok = _safe_recent_events(db, "acme", "ghp_test", tenant_id=None)
+    assert events == []
+    assert ok is False
+
+
+def test_safe_recent_events_aggregate_path_returns_empty_and_not_ok_on_error(db):
+    from fastapi import HTTPException
+
+    from src.routers.analytics import _safe_recent_events
+
+    with patch(
+        "src.routers.analytics._fetch_events_from_repo_events",
+        side_effect=HTTPException(status_code=500, detail="boom"),
+    ):
+        events, ok = _safe_recent_events(db, "acme", "ghp_test", tenant_id=1)
+    assert events == []
+    assert ok is False
 
 
 def test_cockpit_connected_org_surfaces_recent_events_staleness(http, db, mock_user, acme_org_with_installation):
@@ -592,6 +636,32 @@ def test_safe_total_cache_bytes_sums_across_repos():
         total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-a", "repo-b"])
     assert total == 175
     assert ok is True
+
+
+def test_safe_commit_activity_4w_and_heatmap_52w_non_list_response_flags_not_ok():
+    """A malformed (non-list) response body -- e.g. GitHub's error-shaped JSON slipping past
+    status-code checks -- must be treated the same as a failed fetch, not silently summed as
+    zero contribution while still claiming ok."""
+    from src.routers.analytics import _safe_commit_activity_4w_and_heatmap_52w
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {"message": "Not Found"}
+        activity, heatmap, ok = _safe_commit_activity_4w_and_heatmap_52w("acme", "ghp_test", ["repo-a"])
+
+    assert activity == [0, 0, 0, 0]
+    assert heatmap == [0] * 52
+    assert ok is False
+
+
+def test_safe_total_cache_bytes_non_dict_response_flags_not_ok():
+    from src.routers.analytics import _safe_total_cache_bytes
+
+    with patch("src.routers.analytics.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = ["not", "a", "dict"]
+        total, ok = _safe_total_cache_bytes("acme", "ghp_test", ["repo-a"])
+
+    assert total == 0
+    assert ok is False
 
 
 def test_safe_total_cache_bytes_one_bad_repo_sums_the_rest_but_flags_not_ok():

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -165,6 +165,13 @@ export default function OverviewPage() {
         </div>
       )}
 
+      {org && !orgQueryIsError && cockpit?.degraded && (
+        <div className="card mb-6 px-4 py-3 flex items-center gap-2 text-sm text-warning">
+          <Warning size={16} weight="fill" />
+          <span>Some data below may be incomplete — a GitHub call failed while loading this page.</span>
+        </div>
+      )}
+
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-px mb-6 border border-border bg-border">
         <LiveStatCard
           label="Repositories"
@@ -249,8 +256,16 @@ export default function OverviewPage() {
         </div>
 
         <div className="card">
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border flex items-center gap-2">
             <span className="section-label">Recent Activity</span>
+            {cockpit?.recent_events_stale && (
+              <span
+                className="text-[0.6875rem] text-warning"
+                title="Activity ingestion hasn't synced recently — this list may be out of date."
+              >
+                (stale)
+              </span>
+            )}
           </div>
           <EventActivityList
             events={cockpit?.recent_events ?? []}

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -390,6 +390,9 @@ export interface CockpitResponse {
   pr_cycle_time_8w: PrCycleTimeWeek[]
   release_cadence_4w: number[]
   commit_activity_source: "github" | "aggregate"
+  recent_events_source: "github" | "aggregate"
+  recent_events_stale: boolean
+  degraded: boolean
 }
 
 export interface MyViewPRSummary {

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -48,6 +48,9 @@ const EMPTY_COCKPIT = {
   pr_cycle_time_8w: [],
   release_cadence_4w: [],
   commit_activity_source: "github" as const,
+  recent_events_source: "github" as const,
+  recent_events_stale: false,
+  degraded: false,
 };
 
 const EMPTY_MY_VIEW = {
@@ -148,6 +151,64 @@ describe("OverviewPage cockpit", () => {
       expect(queryClient.getQueryState(["analytics.cockpit", "acme"])?.status).toBe("success");
     });
     expect(screen.queryByText("(estimated)")).not.toBeInTheDocument();
+  });
+
+  it("shows a data-may-be-incomplete banner when the cockpit response is degraded", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({ ...EMPTY_COCKPIT, degraded: true });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Some data below may be incomplete/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does not show the degraded banner when the cockpit response is not degraded", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+
+    const { queryClient } = renderPage();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["analytics.cockpit", "acme"])?.status).toBe("success");
+    });
+    expect(screen.queryByText(/Some data below may be incomplete/i)).not.toBeInTheDocument();
+  });
+
+  it("labels recent activity as stale when the cockpit says the ingestion cursor is stale", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      recent_events_source: "aggregate" as const,
+      recent_events_stale: true,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("(stale)")).toBeInTheDocument();
+    });
+  });
+
+  it("does not label recent activity as stale when the cockpit says it's current", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({
+      ...EMPTY_COCKPIT,
+      recent_events_source: "aggregate" as const,
+      recent_events_stale: false,
+    });
+
+    const { queryClient } = renderPage();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(["analytics.cockpit", "acme"])?.status).toBe("success");
+    });
+    expect(screen.queryByText("(stale)")).not.toBeInTheDocument();
   });
 
   it("renders empty states for charts and activity when the org has no data yet", async () => {

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -79,11 +79,10 @@ _BLOCK_MS = 5_000
 _BATCH_SIZE = 10
 
 # Separate heartbeat file from worker.py's HEARTBEAT_FILE -- both threads touch their
-# own file every loop iteration; the docker-compose healthcheck only reads worker.py's
-# HEARTBEAT_FILE today (v1: a hung consumer thread doesn't fail the container
-# healthcheck on its own, same gap as any other purely-Python-level hang would have
-# without a dedicated liveness probe for this specific thread -- flagged, not solved
-# here, since the jobs-table loop staying healthy is still useful signal on its own).
+# own file every loop iteration, and docker-compose.yml's worker healthcheck now checks
+# freshness of both files (Overview data-accuracy fix), so a hung consumer thread fails
+# the container healthcheck on its own instead of hiding behind the jobs-poll-loop
+# thread staying healthy.
 _HEARTBEAT_FILE = Path("/tmp/worker_event_consumer_heartbeat")
 
 _client: redis.Redis | None = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,10 +113,15 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      # worker.py touches HEARTBEAT_FILE once per poll loop iteration -- a hung-but-alive
-      # process (e.g. blocked on a network call) stops updating it, so this catches hangs
-      # that `restart: unless-stopped` alone wouldn't (that only fires on a hard crash).
-      test: ["CMD", "python", "-c", "import time,sys; sys.exit(0 if time.time() - __import__('os').path.getmtime('/tmp/worker_heartbeat') < 60 else 1)"]
+      # worker.py's jobs-poll-loop thread and event_consumer.py's Redis-Streams-consumer
+      # thread each touch their own heartbeat file once per loop iteration -- a hung-but-
+      # alive thread (e.g. blocked on a network call) stops updating its file, so this
+      # catches hangs that `restart: unless-stopped` alone wouldn't (that only fires on a
+      # hard crash). Previously only worker_heartbeat was checked here, so a hung event
+      # consumer (which silently stalls repo_events/repo_event_daily_counts ingestion --
+      # see the Overview data-accuracy fix this accompanies) could report healthy
+      # indefinitely; both threads' files must now be fresh.
+      test: ["CMD", "python", "-c", "import time,sys,os; now=time.time(); sys.exit(0 if all(now - os.path.getmtime(f) < 60 for f in ('/tmp/worker_heartbeat', '/tmp/worker_event_consumer_heartbeat')) else 1)"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

The user reported the Overview dashboard shows data that isn't accurate/up to date. Investigation (code review + running the app) found three real bugs, not a misunderstanding:

1. **Silent zeroing on one flaky GitHub call**: `_safe_commit_activity_4w_and_heatmap_52w` and `_safe_total_cache_bytes` caught exceptions around the *whole* multi-repo fan-out, not per-repo — one rate-limited/flaky call for a single repo zeroed the stat for the entire org, rendering identically to "this org genuinely has zero activity." Fixed by isolating failures per-repo (partial sum survives) and threading a new `degraded: bool` field through `CockpitResponse` so the UI can say "data may be incomplete" instead of silently showing a fake zero. `_safe_member_count`/`_safe_open_pr_count` also now report their own success/failure into the same flag.
2. **No staleness signal on Recent Activity**: unlike `commit_activity_source`'s existing "(estimated)" caption, the Recent Activity card had zero indication when the ingestion pipeline had gone stale. Added `recent_events_stale`, computed from `activity_sync_cursors.last_synced_at` against the existing `gap_heal_stale_hours` config, with a "(stale)" caption in the UI.
3. **Worker healthcheck blind spot**: `event_consumer.py`'s own docstring already documented that a hung consumer thread wouldn't fail the container healthcheck (only the separate jobs-poll-loop heartbeat was checked) — so ingestion could silently stall while the worker reported healthy. `docker-compose.yml`'s worker healthcheck now verifies both heartbeat files.

## Why now

Raised directly by the user, who also flagged connect/disconnect UX and the overall visual design as separate follow-on work (tracked separately, not in this PR — scoped to the data-accuracy bug only). closes #362 

## Test plan
- [x] New regression tests: one bad repo no longer zeros the whole org's commit-activity/cache-bytes aggregate (`test_safe_commit_activity_4w_and_heatmap_52w_one_bad_repo_sums_the_rest_but_flags_not_ok`, `test_safe_total_cache_bytes_one_bad_repo_sums_the_rest_but_flags_not_ok`)
- [x] New tests for `degraded` flag on/off (`test_cockpit_degrades_when_pr_search_fails`, `test_cockpit_degrades_when_events_fetch_fails`, `test_cockpit_not_degraded_when_every_safe_call_succeeds_but_returns_empty`)
- [x] New tests for `_recent_events_staleness` (never-synced, recently-synced, synced-long-ago) and the cockpit endpoint surfacing it
- [x] New UI tests for the degraded banner and stale caption (`apps/ui/tests/components/overview-page.test.tsx`)
- [x] Full suite: `pytest -q` → 881 passed, 3 skipped, 3 xpassed; `bun run check` clean
- [x] Manually verified in a running `docker compose` stack that the Overview page still renders correctly with no account connected

No migration in this PR — `activity_sync_cursors` already existed (migration 0038); this only reads it. No RBAC/auth/token-encryption logic touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added cockpit warnings when data is incomplete or partially unavailable.
  - Recent Activity identifies aggregate data and flags stale event ingestion.

- **Bug Fixes**
  - Analytics totals preserve available information when individual repositories fail or return malformed data.
  - Improved distinction between empty results and unavailable data.

- **Reliability**
  - Worker health monitoring now detects stalled event processing more accurately.
  - Fallback responses report partial data transparently instead of appearing complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->