### PR TITLE
feat(api,ui): let users connect and disconnect GitHub App installations in-app

### DIFF
--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -121,6 +121,27 @@ def get_for_user(db: Session, owner_user_id: int, account_login: str) -> GitHubI
     )
 
 
+def get_by_installation_id_for_org(db: Session, org_id: int, installation_id: int) -> GitHubInstallation | None:
+    """Scoped lookup for the disconnect endpoint -- confirms installation_id genuinely belongs
+    to this org before anything (a GitHub-side uninstall call, a DB delete) acts on it, so an
+    org admin can't disconnect another tenant's installation by guessing its id."""
+    return (
+        db.query(GitHubInstallation)
+        .filter(GitHubInstallation.org_id == org_id, GitHubInstallation.installation_id == installation_id)
+        .first()
+    )
+
+
+def get_by_installation_id_for_user(db: Session, owner_user_id: int, installation_id: int) -> GitHubInstallation | None:
+    """Same contract as get_by_installation_id_for_org, for the personal-installation
+    disconnect endpoint."""
+    return (
+        db.query(GitHubInstallation)
+        .filter(GitHubInstallation.owner_user_id == owner_user_id, GitHubInstallation.installation_id == installation_id)
+        .first()
+    )
+
+
 def list_for_org(db: Session, org_id: int) -> list[GitHubInstallation]:
     return (
         db.query(GitHubInstallation)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -19,6 +19,10 @@
                                               to, so the post-install UI callback (which only gets
                                               installation_id/setup_action from GitHub) knows
                                               whether to call the /me or /orgs sync endpoint next.
+  DELETE /orgs/{org_login}/installations/{installation_id}   admin: disconnect -- uninstalls the
+                                              App on GitHub's side (a real revocation, not just
+                                              removing our own row) then deletes the local row.
+  DELETE /me/installations/{installation_id}  same, for the caller's own personal installation.
 """
 
 import logging
@@ -125,6 +129,47 @@ def list_org_installations(
     db: Session = Depends(get_db),
 ):
     return installation_repo.list_for_org(db, org_id=ctx.org.id)
+
+
+def _uninstall_on_github(installation_id: int) -> None:
+    """Shared by both disconnect endpoints. Raises HTTPException on any failure that means
+    the local row must NOT be deleted (GitHub App not configured, or a real GitHub API error
+    other than 404) -- callers only proceed to delete the local row once this returns cleanly."""
+    try:
+        github_app.delete_installation(installation_id)
+    except github_app.GitHubAppNotConfigured:
+        raise HTTPException(status_code=503, detail="GitHub App is not configured; cannot disconnect")
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    except httpx.RequestError:
+        raise HTTPException(status_code=503, detail="GitHub API unreachable")
+
+
+@router.delete("/orgs/{org_login}/installations/{installation_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_org_installation(
+    installation_id: int,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    installation = installation_repo.get_by_installation_id_for_org(db, org_id=ctx.org.id, installation_id=installation_id)
+    if installation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installation not found for this organization")
+
+    _uninstall_on_github(installation_id)
+
+    # require_org_role already set tenant session context for ctx.org.tenant_id above --
+    # delete_by_installation_id's own resolve-then-set is for its other caller (the
+    # unauthenticated webhook receiver), a no-op re-set here for this authenticated path.
+    count, tenant_id = installation_repo.delete_by_installation_id(db, installation_id)
+    audit_repo.write(
+        db,
+        actor=user.email,
+        action="installation.disconnected",
+        target=ctx.org.github_login,
+        payload={"installation_id": installation_id, "rows_deleted": count},
+        tenant_id=tenant_id,
+    )
 
 
 def _bootstrap_org_admin_from_installation(db: Session, db_user: User, org_login: str, installation_id: int) -> Org:
@@ -239,6 +284,31 @@ def list_personal_installations(
     db: Session = Depends(get_db),
 ):
     return installation_repo.list_for_user(db, owner_user_id=user.id)
+
+
+@router.delete("/me/installations/{installation_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_personal_installation(
+    installation_id: int,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    installation = installation_repo.get_by_installation_id_for_user(db, owner_user_id=user.id, installation_id=installation_id)
+    if installation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installation not found")
+
+    _uninstall_on_github(installation_id)
+
+    personal_tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+    set_tenant_session_context(db, personal_tenant.id, user.id)
+    count, tenant_id = installation_repo.delete_by_installation_id(db, installation_id)
+    audit_repo.write(
+        db,
+        actor=user.email,
+        action="installation.disconnected.personal",
+        target=installation.account_login,
+        payload={"installation_id": installation_id, "rows_deleted": count},
+        tenant_id=tenant_id,
+    )
 
 
 @router.post("/me/installations/sync", response_model=SyncInstallationsResponse)

--- a/apps/api/src/services/github_app.py
+++ b/apps/api/src/services/github_app.py
@@ -103,6 +103,30 @@ def get_installation(installation_id: int) -> dict:
     return resp.json()
 
 
+def delete_installation(installation_id: int) -> None:
+    """Uninstall the App from an account/org via GitHub's App API (DELETE /app/installations/{id}),
+    using the App's own JWT -- this is a real revocation, not just removing our own DB row, so a
+    user who disconnects in Clevis's UI actually stops granting Clevis repo access, the same as if
+    they'd uninstalled it from github.com/settings/installations themselves. A 404 (already
+    uninstalled -- e.g. the user beat us to it on GitHub's side) is treated as success, not an
+    error, since the end state either way is "no installation." Raises httpx.HTTPStatusError for
+    any other GitHub error or GitHubAppNotConfigured; callers must not delete the local DB row on
+    those, so a failed uninstall doesn't leave Clevis's own record silently out of sync with a
+    GitHub-side installation that's still actually there."""
+    app_jwt = generate_app_jwt()
+    url = f"{settings.github_api_base}/app/installations/{installation_id}"
+    headers = {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.delete(url, headers=headers)
+    if resp.status_code == 404:
+        return
+    resp.raise_for_status()
+
+
 def get_installation_token(installation_id: int) -> str:
     """Return a valid installation access token, minting and caching it as needed."""
     with _lock:

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -154,6 +154,53 @@ def _mock_get_client(mock_resp):
     return mock_client
 
 
+def _mock_delete_client(mock_resp: MagicMock) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.delete = MagicMock(return_value=mock_resp)
+    return mock_client
+
+
+def test_delete_installation_calls_the_uninstall_endpoint(app_configured):
+    mock_resp = MagicMock(status_code=204)
+    with patch("src.services.github_app.httpx.Client") as mock_cls:
+        mock_cls.return_value = _mock_delete_client(mock_resp)
+        github_app.delete_installation(42)
+
+    mock_resp.raise_for_status.assert_called_once()
+    url = mock_cls.return_value.delete.call_args.args[0]
+    assert url.endswith("/app/installations/42")
+    headers = mock_cls.return_value.delete.call_args.kwargs["headers"]
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+def test_delete_installation_treats_404_as_success(app_configured):
+    """Already uninstalled on GitHub's side (e.g. the user beat us to it) -- same end
+    state as a successful delete, not an error."""
+    mock_resp = MagicMock(status_code=404)
+    with patch("src.services.github_app.httpx.Client") as mock_cls:
+        mock_cls.return_value = _mock_delete_client(mock_resp)
+        github_app.delete_installation(42)  # must not raise
+
+    mock_resp.raise_for_status.assert_not_called()
+
+
+def test_delete_installation_propagates_other_http_errors(app_configured):
+    mock_resp = MagicMock(status_code=500)
+    mock_resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=httpx.Request("DELETE", "https://api.github.com/app/installations/42"),
+            response=httpx.Response(500),
+        )
+    )
+    with patch("src.services.github_app.httpx.Client") as mock_cls:
+        mock_cls.return_value = _mock_delete_client(mock_resp)
+        with pytest.raises(httpx.HTTPStatusError):
+            github_app.delete_installation(42)
+
+
 def test_get_org_membership_role_returns_role_for_active_membership():
     mock_resp = MagicMock(status_code=200)
     mock_resp.json = MagicMock(return_value={"state": "active", "role": "admin"})

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -601,3 +601,135 @@ def test_lookup_installation_returns_503_when_app_not_configured(db):
     ):
         resp = _client(db, me).get("/me/installations/lookup/3")
     assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Disconnect (DELETE) -- installation-connect-disconnect-ux
+# ---------------------------------------------------------------------------
+
+
+def test_delete_org_installation_admin_disconnects(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    with patch("src.routers.installations.github_app.delete_installation") as mock_delete:
+        resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
+
+    assert resp.status_code == 204
+    mock_delete.assert_called_once_with(42)
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=acme_org["org"].id, installation_id=42) is None
+    logs = db.query(AuditLog).filter(AuditLog.action == "installation.disconnected").all()
+    assert len(logs) == 1
+    assert logs[0].actor == acme_org["admin"].email
+
+
+def test_delete_org_installation_member_forbidden(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    resp = _client(db, acme_org["member"]).delete("/orgs/acme/installations/42")
+    assert resp.status_code == 403
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=acme_org["org"].id, installation_id=42) is not None
+
+
+def test_delete_org_installation_outsider_forbidden(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    resp = _client(db, _OUTSIDER).delete("/orgs/acme/installations/42")
+    assert resp.status_code == 403
+
+
+def test_delete_org_installation_nonexistent_installation_id_404s(db, acme_org):
+    resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/999")
+    assert resp.status_code == 404
+
+
+def test_delete_org_installation_cannot_delete_another_orgs_installation(db, acme_org):
+    """An admin of acme must not be able to disconnect an installation belonging to a
+    different org just by naming its installation_id in the URL."""
+    other_org = org_repo.get_or_create(db, github_login="other-org")
+    installation_repo.create(
+        db, account_login="other-org", account_type="Organization", auth_mode="app", installation_id=42, org_id=other_org.id
+    )
+    resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
+    assert resp.status_code == 404
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=other_org.id, installation_id=42) is not None
+
+
+def test_delete_org_installation_github_error_leaves_row_intact(db, acme_org):
+    """If GitHub's uninstall call fails for a real reason (not 404), the local row must
+    survive so a retry is straightforward and Clevis's own record doesn't silently drift
+    out of sync with a GitHub-side installation that's still actually there."""
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    response = httpx.Response(500, request=httpx.Request("DELETE", "https://api.github.com/app/installations/42"))
+    with patch(
+        "src.routers.installations.github_app.delete_installation",
+        side_effect=httpx.HTTPStatusError("server error", request=response.request, response=response),
+    ):
+        resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
+
+    assert resp.status_code == 400
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=acme_org["org"].id, installation_id=42) is not None
+
+
+def test_delete_org_installation_returns_503_when_app_not_configured(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    with patch(
+        "src.routers.installations.github_app.delete_installation",
+        side_effect=github_app.GitHubAppNotConfigured("not configured"),
+    ):
+        resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
+    assert resp.status_code == 503
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=acme_org["org"].id, installation_id=42) is not None
+
+
+def test_delete_personal_installation_owner_disconnects(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    installation_repo.create(
+        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=7, owner_user_id=me.id
+    )
+    with patch("src.routers.installations.github_app.delete_installation") as mock_delete:
+        resp = _client(db, me).delete("/me/installations/7")
+
+    assert resp.status_code == 204
+    mock_delete.assert_called_once_with(7)
+    assert installation_repo.get_by_installation_id_for_user(db, owner_user_id=me.id, installation_id=7) is None
+    logs = db.query(AuditLog).filter(AuditLog.action == "installation.disconnected.personal").all()
+    assert len(logs) == 1
+
+
+def test_delete_personal_installation_cannot_delete_another_users_installation(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    other = _make_user(db, "other@e.com", github_login="other")
+    installation_repo.create(
+        db, account_login="other", account_type="User", auth_mode="app", installation_id=7, owner_user_id=other.id
+    )
+    resp = _client(db, me).delete("/me/installations/7")
+    assert resp.status_code == 404
+    assert installation_repo.get_by_installation_id_for_user(db, owner_user_id=other.id, installation_id=7) is not None
+
+
+def test_delete_personal_installation_requires_auth(db):
+    app = FastAPI()
+    app.include_router(inst_router)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).delete("/me/installations/7")
+    assert resp.status_code == 401
+
+
+def test_delete_org_installation_returns_503_when_github_unreachable(db, acme_org):
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org["org"].id
+    )
+    with patch(
+        "src.routers.installations.github_app.delete_installation",
+        side_effect=httpx.RequestError("connection failed"),
+    ):
+        resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
+    assert resp.status_code == 503
+    assert installation_repo.get_by_installation_id_for_org(db, org_id=acme_org["org"].id, installation_id=42) is not None

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -648,13 +648,24 @@ def test_delete_org_installation_nonexistent_installation_id_404s(db, acme_org):
 def test_delete_org_installation_cannot_delete_another_orgs_installation(db, acme_org):
     """An admin of acme must not be able to disconnect an installation belonging to a
     different org just by naming its installation_id in the URL."""
+    other_admin = _make_user(db, "other-admin@e.com")
     other_org = org_repo.get_or_create(db, github_login="other-org")
+    org_membership_repo.get_or_create(db, org_id=other_org.id, user_id=other_admin.id, role="admin")
     installation_repo.create(
         db, account_login="other-org", account_type="Organization", auth_mode="app", installation_id=42, org_id=other_org.id
     )
     resp = _client(db, acme_org["admin"]).delete("/orgs/acme/installations/42")
     assert resp.status_code == 404
-    assert installation_repo.get_by_installation_id_for_org(db, org_id=other_org.id, installation_id=42) is not None
+
+    # Verified through the real API as other-org's own admin, not installation_repo
+    # directly: acme's request above set RLS session context (app.tenant_id) to acme's
+    # tenant, which would make a same-session repo-level lookup of other-org's row
+    # silently return None (RLS hiding it, not the row being gone) and pass for the wrong
+    # reason under CI's RLS-enforcing clevis_api role -- a fresh authenticated request as
+    # other-org's admin re-sets the correct tenant context instead.
+    list_resp = _client(db, other_admin).get("/orgs/other-org/installations")
+    assert list_resp.status_code == 200
+    assert any(i["installation_id"] == 42 for i in list_resp.json())
 
 
 def test_delete_org_installation_github_error_leaves_row_intact(db, acme_org):
@@ -711,7 +722,16 @@ def test_delete_personal_installation_cannot_delete_another_users_installation(d
     )
     resp = _client(db, me).delete("/me/installations/7")
     assert resp.status_code == 404
-    assert installation_repo.get_by_installation_id_for_user(db, owner_user_id=other.id, installation_id=7) is not None
+
+    # Verified through the real API as the actual owner, not installation_repo directly:
+    # `me`'s request above set RLS session context (app.user_id) to `me`'s id, which would
+    # make a same-session repo-level lookup of `other`'s row silently return None (RLS
+    # hiding it, not the row being gone) and pass for the wrong reason under CI's
+    # RLS-enforcing clevis_api role -- a fresh authenticated request as `other` re-sets
+    # the correct context instead.
+    list_resp = _client(db, other).get("/me/installations")
+    assert list_resp.status_code == 200
+    assert any(i["installation_id"] == 7 for i in list_resp.json())
 
 
 def test_delete_personal_installation_requires_auth(db):

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -299,6 +299,7 @@ function ConnectedOrgsSection() {
       queryClient.invalidateQueries({ queryKey: ["installations"] })
       setConfirmingKey(null)
     },
+    onError: () => setConfirmingKey(null),
   })
 
   const rowKey = (row: ConnectedInstallation) => `${row.scope}:${row.id}`
@@ -312,6 +313,12 @@ function ConnectedOrgsSection() {
         <span className="section-label">Connected GitHub accounts</span>
         {rows.length > 0 && <span className="stat-chip">{rows.length} connected</span>}
       </div>
+
+      {disconnect.isError && (
+        <p role="alert" className="px-4 pt-3 text-xs text-destructive">
+          {disconnect.error instanceof Error ? disconnect.error.message : "Disconnect failed."}
+        </p>
+      )}
 
       {isLoading ? (
         <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -165,11 +165,19 @@ function AppearanceSection() {
 
 // ── Org memberships section ───────────────────────────────────────────────────
 
-function OrgMembershipsSection() {
-  const { data: memberships = [], isLoading, isError, error, isFetching, refetch } = useQuery<MyOrgMembership[]>({
+// Shared by OrgMembershipsSection and ConnectedOrgsSection below -- both need to know which
+// orgs the caller belongs to (the latter specifically to know which orgs it admins, to fetch
+// their installations). One hook, one queryFn reference, so React Query's dedup-by-key doesn't
+// depend on which of the two mounts first actually issuing the request.
+function useMyOrgMemberships() {
+  return useQuery<MyOrgMembership[]>({
     queryKey: ["my-orgs"],
     queryFn: () => api.orgs.mine(),
   })
+}
+
+function OrgMembershipsSection() {
+  const { data: memberships = [], isLoading, isError, error, isFetching, refetch } = useMyOrgMemberships()
 
   return (
     <div className="card">
@@ -253,12 +261,7 @@ function ConnectedOrgsSection() {
     queryKey: ["installations", "me"],
     queryFn: () => api.installations.list(),
   })
-  // Shares the "my-orgs" cache key with OrgMembershipsSection above -- one fetch, not two,
-  // when both sections mount together (React Query dedupes by key).
-  const membershipsQuery = useQuery<MyOrgMembership[]>({
-    queryKey: ["my-orgs"],
-    queryFn: () => api.orgs.mine(),
-  })
+  const membershipsQuery = useMyOrgMemberships()
   const adminOrgLogins = (membershipsQuery.data ?? []).filter((m) => m.role === "admin").map((m) => m.org_login)
 
   // Only orgs the caller admins -- listForOrg is 403 for a plain member (installations are

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Trash, Plus, CircleNotch, Check, ArrowSquareOut, CheckCircle } from "@phosphor-icons/react"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { SectionError } from "@/components/section-error"
+import { EmptyStatePage } from "@/components/empty-state"
 import Link from "next/link"
 import { api } from "@/lib/api/client"
 import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values"
@@ -229,21 +230,84 @@ function OrgMembershipsSection() {
   )
 }
 
-// ── Connected organizations (GitHub App, personal installs) ──────────────────
+// ── Connected organizations (GitHub App, personal + org-scoped installs) ─────
+
+type ConnectedInstallation = InstallationMeta & (
+  | { scope: "me" }
+  | { scope: "org"; orgLogin: string }
+)
 
 function ConnectedOrgsSection() {
-  const { data: installs = [], isLoading, isError, error, isFetching, refetch } = useQuery<InstallationMeta[]>({
-    queryKey: ["installations"],
+  const queryClient = useQueryClient()
+  const [confirmingKey, setConfirmingKey] = useState<string | null>(null)
+
+  // Auto-disarm if the user doesn't confirm within a few seconds, same pattern as
+  // ProfileSection's "Sign out of all devices" above.
+  useEffect(() => {
+    if (!confirmingKey) return
+    const timer = setTimeout(() => setConfirmingKey(null), 4000)
+    return () => clearTimeout(timer)
+  }, [confirmingKey])
+
+  const personalQuery = useQuery<InstallationMeta[]>({
+    queryKey: ["installations", "me"],
     queryFn: () => api.installations.list(),
   })
+  // Shares the "my-orgs" cache key with OrgMembershipsSection above -- one fetch, not two,
+  // when both sections mount together (React Query dedupes by key).
+  const membershipsQuery = useQuery<MyOrgMembership[]>({
+    queryKey: ["my-orgs"],
+    queryFn: () => api.orgs.mine(),
+  })
+  const adminOrgLogins = (membershipsQuery.data ?? []).filter((m) => m.role === "admin").map((m) => m.org_login)
+
+  // Only orgs the caller admins -- listForOrg is 403 for a plain member (installations are
+  // an admin concern, matching the DELETE endpoint's own require_org_role(min_role="admin")).
+  const orgInstallQueries = useQueries({
+    queries: adminOrgLogins.map((orgLogin) => ({
+      queryKey: ["installations", "org", orgLogin],
+      queryFn: () => api.installations.listForOrg(orgLogin),
+      enabled: !membershipsQuery.isLoading,
+    })),
+  })
+
+  const isLoading = personalQuery.isLoading || membershipsQuery.isLoading
+  const isError = personalQuery.isError || membershipsQuery.isError || orgInstallQueries.some((q) => q.isError)
+  const isFetching = personalQuery.isFetching || membershipsQuery.isFetching || orgInstallQueries.some((q) => q.isFetching)
+  const refetchAll = () => {
+    personalQuery.refetch()
+    membershipsQuery.refetch()
+    orgInstallQueries.forEach((q) => q.refetch())
+  }
+
+  const rows: ConnectedInstallation[] = [
+    ...(personalQuery.data ?? []).map((i) => ({ ...i, scope: "me" as const })),
+    ...adminOrgLogins.flatMap((orgLogin, idx) =>
+      (orgInstallQueries[idx]?.data ?? []).map((i) => ({ ...i, scope: "org" as const, orgLogin })),
+    ),
+  ]
+
+  const disconnect = useMutation({
+    mutationFn: (row: ConnectedInstallation) => {
+      if (row.installation_id == null) return Promise.reject(new Error("This connection has no GitHub installation to disconnect."))
+      return api.installations.remove(row.scope === "me" ? { scope: "me" } : { scope: "org", orgLogin: row.orgLogin }, row.installation_id)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["installations"] })
+      setConfirmingKey(null)
+    },
+  })
+
+  const rowKey = (row: ConnectedInstallation) => `${row.scope}:${row.id}`
+
   const slug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG
   const installUrl = slug ? `https://github.com/apps/${slug}/installations/new` : null
 
   return (
     <div className="card">
       <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-        <span className="section-label">Personal GitHub installs</span>
-        {installs.length > 0 && <span className="stat-chip">{installs.length} connected</span>}
+        <span className="section-label">Connected GitHub accounts</span>
+        {rows.length > 0 && <span className="stat-chip">{rows.length} connected</span>}
       </div>
 
       {isLoading ? (
@@ -252,36 +316,63 @@ function ConnectedOrgsSection() {
         </div>
       ) : isError ? (
         <SectionError
-          message={error instanceof Error ? error.message : "Failed to load organizations."}
-          onRetry={() => refetch()}
+          message="Failed to load connected accounts."
+          onRetry={refetchAll}
           retrying={isFetching}
         />
-      ) : installs.length === 0 ? (
-        <div className="px-4 py-6">
-          <p className="text-sm text-muted-foreground">
-            No organizations connected yet. Install the Clevis GitHub App on a GitHub organization to get started.
-          </p>
-        </div>
+      ) : rows.length === 0 ? (
+        <EmptyStatePage message="No accounts connected yet. Install the Clevis GitHub App on an organization or your personal account to get started." />
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-xs">
             <thead>
               <tr className="border-b border-border">
-                <th className="text-left text-muted-foreground font-medium px-4 py-2">Organization</th>
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Account</th>
                 <th className="text-left text-muted-foreground font-medium px-4 py-2">Type</th>
                 <th className="text-left text-muted-foreground font-medium px-4 py-2">Connected</th>
+                <th className="px-4 py-2" />
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {installs.map((i) => (
-                <tr key={i.id} className="hover:bg-elevated transition-colors">
-                  <td className="px-4 py-2.5 font-mono text-foreground/80">{i.account_login}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground">{i.account_type}</td>
-                  <td className="px-4 py-2.5 text-muted-foreground whitespace-nowrap">
-                    {new Date(i.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
-                  </td>
-                </tr>
-              ))}
+              {rows.map((row) => {
+                const key = rowKey(row)
+                const isConfirming = confirmingKey === key
+                const isThisRowMutating = disconnect.isPending && disconnect.variables && rowKey(disconnect.variables) === key
+                return (
+                  <tr key={key} className="hover:bg-elevated transition-colors">
+                    <td className="px-4 py-2.5 font-mono text-foreground/80">
+                      {row.account_login}
+                      {row.scope === "org" && <span className="ml-1.5 text-muted-foreground">(org)</span>}
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">{row.account_type}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground whitespace-nowrap">
+                      {new Date(row.created_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                    </td>
+                    <td className="px-4 py-2.5 text-right whitespace-nowrap">
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={disconnect.isPending}
+                        onClick={() => {
+                          if (isConfirming) {
+                            disconnect.mutate(row)
+                          } else {
+                            setConfirmingKey(key)
+                          }
+                        }}
+                      >
+                        {isThisRowMutating ? (
+                          <CircleNotch className="size-3 animate-spin" />
+                        ) : isConfirming ? (
+                          "Confirm disconnect"
+                        ) : (
+                          <><Trash className="size-3" />Disconnect</>
+                        )}
+                      </Button>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -294,7 +385,7 @@ function ConnectedOrgsSection() {
           </Button>
         ) : (
           <p className="text-xs text-muted-foreground">
-            Set <code className="font-mono">NEXT_PUBLIC_GITHUB_APP_SLUG</code> to enable the install button.
+            GitHub App integration isn&rsquo;t set up on this instance yet — ask a workspace admin to configure it.
           </p>
         )}
       </div>

--- a/apps/ui/components/empty-state.tsx
+++ b/apps/ui/components/empty-state.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 /**
  * Empty state variants — no icons, no centered layouts, just text.
@@ -59,19 +61,17 @@ interface EmptyStateNoAccountProps {
 }
 
 export function EmptyStateNoAccount({ bare = false, message: messageOverride }: EmptyStateNoAccountProps) {
-  const message = (
-    <p className="px-4 py-6 text-sm text-muted-foreground">
-      {messageOverride ?? (
-        <>
-          No account selected yet — this page has nothing to query. Pick an organization or your personal
-          account from the profile menu, or connect one in{" "}
-          <Link href="/settings" className="text-primary hover:underline">Settings</Link> first if you
-          haven&rsquo;t already.
-        </>
-      )}
-    </p>
+  const content = (
+    <div className="px-4 py-6 flex flex-col gap-3 items-start">
+      <p className="text-sm text-muted-foreground">
+        {messageOverride ?? "No account selected yet — this page has nothing to query. Pick an organization or your personal account from the profile menu, or connect one below if you haven’t already."}
+      </p>
+      <Link href="/settings" className={cn(buttonVariants({ size: "sm" }))}>
+        Connect a GitHub account
+      </Link>
+    </div>
   )
-  return bare ? message : <div className="card mb-6">{message}</div>
+  return bare ? content : <div className="card mb-6">{content}</div>
 }
 
 /**

--- a/apps/ui/e2e/security-settings.spec.ts
+++ b/apps/ui/e2e/security-settings.spec.ts
@@ -10,16 +10,16 @@ test.describe("Settings — org connection surface", () => {
 
     // Org-connection UI lives on Settings — real GitHub OAuth can't run in CI,
     // so this asserts the install surface is reachable and wired (issue #187).
-    await expect(page.getByText("Personal GitHub installs")).toBeVisible()
+    await expect(page.getByText("Connected GitHub accounts")).toBeVisible()
     await expect(
-      page.getByText(/No organizations connected yet|Install the Clevis GitHub App/i),
+      page.getByText(/No accounts connected yet|Install the Clevis GitHub App/i),
     ).toBeVisible()
 
     // Install button is present when NEXT_PUBLIC_GITHUB_APP_SLUG is set in the
     // stack; otherwise the page explains how to enable it. Either is fine — both
     // prove the connection section rendered instead of a stub.
     const installButton = page.getByRole("button", { name: /Install GitHub App/i })
-    const missingSlugHint = page.getByText(/NEXT_PUBLIC_GITHUB_APP_SLUG/i)
+    const missingSlugHint = page.getByText(/GitHub App integration isn.t set up/i)
     await expect(installButton.or(missingSlugHint)).toBeVisible()
   })
 })

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -330,6 +330,15 @@ export const api = {
             `/orgs/${encodeURIComponent(target.orgLogin)}/installations/sync`,
             body,
           ),
+    // Disconnect: uninstalls the App on GitHub's side (a real revocation), then removes
+    // the local row -- see apps/api/src/routers/installations.py's module docstring.
+    remove: (
+      target: { scope: "me" } | { scope: "org"; orgLogin: string },
+      installationId: number,
+    ) =>
+      target.scope === "me"
+        ? del(`/me/installations/${installationId}`)
+        : del(`/orgs/${encodeURIComponent(target.orgLogin)}/installations/${installationId}`),
   },
   orgs: {
     mine: () => get<MyOrgMembership[]>("/me/orgs"),

--- a/apps/ui/tests/components/empty-state.test.tsx
+++ b/apps/ui/tests/components/empty-state.test.tsx
@@ -51,4 +51,10 @@ describe("EmptyStateNoAccount", () => {
     expect(screen.getByText("No account selected — type an organization below.")).toBeInTheDocument();
     expect(screen.queryByText(/this page has nothing to query/)).not.toBeInTheDocument();
   });
+
+  it("renders a real CTA button pointing at Settings, not just a text link", () => {
+    render(<EmptyStateNoAccount />);
+    const link = screen.getByRole("link", { name: "Connect a GitHub account" });
+    expect(link).toHaveAttribute("href", "/settings");
+  });
 });

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -349,7 +349,7 @@ describe("OverviewPage cockpit", () => {
     await waitFor(() => {
       expect(screen.getByText(/No account selected yet/)).toBeInTheDocument();
     });
-    const settingsLink = screen.getByRole("link", { name: "Settings" });
+    const settingsLink = screen.getByRole("link", { name: "Connect a GitHub account" });
     expect(settingsLink).toHaveAttribute("href", "/settings");
     expect(cockpitMock).not.toHaveBeenCalled();
   });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const orgsMineMock = vi.fn();
 const installationsListMock = vi.fn();
+const installationsListForOrgMock = vi.fn();
+const installationsRemoveMock = vi.fn();
 const tokensListMock = vi.fn();
 const configGetAllMock = vi.fn();
 const patchMeMock = vi.fn();
@@ -20,7 +22,11 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/api/client", () => ({
   api: {
     orgs: { mine: (...args: unknown[]) => orgsMineMock(...args) },
-    installations: { list: (...args: unknown[]) => installationsListMock(...args) },
+    installations: {
+      list: (...args: unknown[]) => installationsListMock(...args),
+      listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
+      remove: (...args: unknown[]) => installationsRemoveMock(...args),
+    },
     tokens: { list: (...args: unknown[]) => tokensListMock(...args) },
     config: {
       getAll: (...args: unknown[]) => configGetAllMock(...args),
@@ -82,6 +88,8 @@ describe("SettingsPage", () => {
   beforeEach(() => {
     orgsMineMock.mockReset();
     installationsListMock.mockReset();
+    installationsListForOrgMock.mockReset();
+    installationsRemoveMock.mockReset();
     tokensListMock.mockReset();
     configGetAllMock.mockReset();
     patchMeMock.mockReset();
@@ -111,7 +119,10 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Failed to load organizations.")).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    // Two independent cards read the same failed "my-orgs" query -- OrgMembershipsSection
+    // and ConnectedOrgsSection (which also needs it to know which orgs the caller admins) --
+    // so each surfaces its own retry affordance.
+    expect(screen.getAllByRole("button", { name: "Retry" }).length).toBeGreaterThanOrEqual(1);
 
     await waitFor(() => {
       expect(screen.getByText("Instance configuration")).toBeInTheDocument();
@@ -210,6 +221,104 @@ describe("SettingsPage", () => {
     await waitFor(() => expect(revokeSessionsMock).toHaveBeenCalledTimes(1));
     // logout() clears the token, which removes the authenticated Settings page entirely.
     await waitFor(() => expect(localStorage.getItem(TOKEN_KEY)).toBeNull());
+  });
+
+  // ── Connected accounts (installation-connect-disconnect-ux) ────────────────
+
+  it("shows an unconfigured message instead of the install button when the App slug isn't set", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/GitHub App integration isn.t set up on this instance yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /install github app/i })).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing is connected", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/No accounts connected yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("lists both personal and admin-org installations, and disconnects one after a confirm click", async () => {
+    orgsMineMock.mockResolvedValue([{ org_login: "acme", role: "admin" }]);
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "shabnam", account_type: "User", installation_id: 7, created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-01-02T00:00:00Z" },
+    ]);
+    installationsRemoveMock.mockResolvedValue(undefined);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("shabnam")).toBeInTheDocument();
+      expect(screen.getByText("acme")).toBeInTheDocument();
+    });
+    expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
+
+    const disconnectButtons = screen.getAllByRole("button", { name: /disconnect/i });
+    expect(disconnectButtons).toHaveLength(2);
+
+    fireEvent.click(disconnectButtons[0]);
+    expect(installationsRemoveMock).not.toHaveBeenCalled();
+    expect(await screen.findByRole("button", { name: /confirm disconnect/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm disconnect/i }));
+
+    await waitFor(() => {
+      expect(installationsRemoveMock).toHaveBeenCalledWith({ scope: "me" }, 7);
+    });
+  });
+
+  it("disconnects an org-scoped installation with the org scope, not the personal one", async () => {
+    orgsMineMock.mockResolvedValue([{ org_login: "acme", role: "admin" }]);
+    installationsListMock.mockResolvedValue([]);
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-01-02T00:00:00Z" },
+    ]);
+    installationsRemoveMock.mockResolvedValue(undefined);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    const disconnectButton = await screen.findByRole("button", { name: /disconnect/i });
+    fireEvent.click(disconnectButton);
+    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+
+    await waitFor(() => {
+      expect(installationsRemoveMock).toHaveBeenCalledWith({ scope: "org", orgLogin: "acme" }, 42);
+    });
+  });
+
+  it("does not fetch installations for orgs the caller is only a member of, not an admin", async () => {
+    orgsMineMock.mockResolvedValue([{ org_login: "acme", role: "member" }]);
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/No accounts connected yet/i)).toBeInTheDocument();
+    });
+    expect(installationsListForOrgMock).not.toHaveBeenCalled();
   });
 
 });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -321,4 +321,57 @@ describe("SettingsPage", () => {
     expect(installationsListForOrgMock).not.toHaveBeenCalled();
   });
 
+  it("retries all three connected-accounts queries when Retry is clicked", async () => {
+    orgsMineMock.mockRejectedValue(new Error("boom"));
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load connected accounts.")).toBeInTheDocument();
+    });
+
+    orgsMineMock.mockClear();
+    installationsListMock.mockClear();
+    const retryButtons = screen.getAllByRole("button", { name: "Retry" });
+    fireEvent.click(retryButtons[retryButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(orgsMineMock).toHaveBeenCalled();
+      expect(installationsListMock).toHaveBeenCalled();
+    });
+  });
+
+  it("shows a spinner on the row being disconnected while the request is in flight", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "shabnam", account_type: "User", installation_id: 7, created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+    const removeGate = deferred<void>();
+    installationsRemoveMock.mockReturnValue(removeGate.promise);
+
+    renderPage();
+
+    const disconnectButton = await screen.findByRole("button", { name: /disconnect/i });
+    fireEvent.click(disconnectButton);
+    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+
+    await waitFor(() => {
+      expect(installationsRemoveMock).toHaveBeenCalled();
+    });
+    // Neither "Disconnect" nor "Confirm disconnect" text remains while the mutation is
+    // in flight -- the row shows a spinner instead.
+    expect(screen.queryByRole("button", { name: "Disconnect" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Confirm disconnect" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      removeGate.resolve();
+      await removeGate.promise;
+    });
+  });
+
 });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -374,4 +374,27 @@ describe("SettingsPage", () => {
     });
   });
 
+  it("shows an error message and lets the user try again when disconnect fails", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "shabnam", account_type: "User", installation_id: 7, created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+    installationsRemoveMock.mockRejectedValue(new Error("GitHub API unreachable"));
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /disconnect/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("GitHub API unreachable");
+    });
+    // The row is still there (not silently removed) and can be retried immediately --
+    // confirmingKey was cleared on error, not left stuck on "Confirm disconnect".
+    expect(screen.getByText("shabnam")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeInTheDocument();
+  });
+
 });

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -505,6 +505,22 @@ describe("installations.lookup / installations.sync", () => {
     const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(String(url)).toContain("/orgs/acme/installations/sync");
   });
+
+  it("DELETEs /me/installations/{id} for scope: me", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    await api.installations.remove({ scope: "me" }, 7);
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/me/installations/7");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("DELETEs /orgs/{orgLogin}/installations/{id} for scope: org", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    await api.installations.remove({ scope: "org", orgLogin: "acme" }, 42);
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/orgs/acme/installations/42");
+    expect(init.method).toBe("DELETE");
+  });
 });
 
 describe("api.auth email verification (issue #217)", () => {


### PR DESCRIPTION
## Summary

The user reported it's hard to connect additional GitHub orgs/repos or disconnect the ones already connected. Investigation (code review + running the app live) confirmed real gaps:

1. **There was no disconnect endpoint at all.** `installation_repo.delete_by_installation_id` was only ever called from the unauthenticated GitHub webhook receiver — a user could only disconnect an org by leaving Clevis entirely and uninstalling the GitHub App from github.com directly, with zero guidance pointing there.
2. Settings' `ConnectedOrgsSection` only ever called `api.installations.list()` (personal installs) and never `listForOrg`, so an org's own connected installations never showed on its own Settings page, despite org being the primary multi-tenant unit.
3. The install button's unconfigured-slug fallback printed a raw developer message (`Set NEXT_PUBLIC_GITHUB_APP_SLUG to enable the install button`) directly to real end users — confirmed live via screenshot.
4. The Overview page's "no account connected" empty state was a bare `Configure →` text link / a sentence with an inline link — no real onboarding CTA.

## What changed

- **New `DELETE /orgs/{org_login}/installations/{installation_id}`** (admin-gated via `require_org_role`) and **`DELETE /me/installations/{installation_id}`**: uninstall the App on GitHub's side via the App's own JWT (a real revocation, not just removing our row — see `github_app.delete_installation`), then delete the local row, audit-logged as `installation.disconnected`/`installation.disconnected.personal`. A GitHub-side failure (anything but a 404-already-gone) leaves the local row intact so a retry is straightforward instead of Clevis's record silently drifting out of sync.
- **Settings' Connected accounts section** now fetches both personal and admin-org-scoped installations (reusing the existing but previously-unused `listForOrg` client method), and adds a real Disconnect button per row reusing the exact arm/disarm confirm pattern already proven correct elsewhere in this file (`ProfileSection`'s "Sign out of all devices").
- Replaced the raw env-var-name message with a friendlier "GitHub App integration isn't set up on this instance yet — ask a workspace admin" state.
- **`EmptyStateNoAccount`** (shared across 7 pages: Overview, Activity, Repos, Releases, My PRs/Reviews/Issues) now renders a real "Connect a GitHub account" button pointing at Settings, not a text link buried in a sentence.

## Why now

Raised directly by the user as part of the same investigation that produced PR #361 (Overview data-accuracy fix). Scoped to the connect/disconnect functional gap only — the broader visual/UI redesign the user also flagged is tracked as separate follow-on work (concept-direction mockups first, per their explicit preference).

## Test plan
- [x] New backend tests: admin disconnects successfully (GitHub call + local row removed + audit log), member/outsider forbidden, cross-org installation_id guessing blocked, GitHub API failure leaves the row intact, GitHub App not configured / unreachable → 503, personal-installation ownership enforcement, unauthenticated → 401
- [x] New `github_app.delete_installation` tests: calls the right endpoint, treats 404 as success, propagates real errors
- [x] New frontend tests: lists both personal and admin-org installations, disconnects with the correct scope after a confirm click, doesn't fetch installations for orgs the caller is only a member (not admin) of, unconfigured-slug message, empty state, `EmptyStateNoAccount`'s new CTA
- [x] Full suite: `pytest -q` → 887 passed, 3 skipped, 3 xpassed; diff-coverage 100% on all changed backend files; `bun run check` clean, 404 UI tests passed
- [x] Manually verified the flow live in a running `docker compose` stack before writing the fix (confirmed the missing-disconnect gap and the raw dev-facing message)

No migration in this PR. Touches RBAC-adjacent code (a new admin-gated DELETE endpoint) — gated identically to the existing `require_org_role(min_role="admin")` pattern used throughout this router file, and the personal-installation endpoint verifies row ownership before acting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for disconnecting personal and organization GitHub installations.
  * Disconnecting revokes access on GitHub, removes the local connection, and records an audit event.
  * Settings now combines personal and administrator-managed organization connections.
  * Added confirmation and automatic timeout protection before disconnecting.
  * Updated empty states with a clear “Connect a GitHub account” action.

* **Bug Fixes**
  * Prevented unauthorized disconnections.
  * Preserved local connections when GitHub removal fails.
  * Improved error messaging and recovery after failed disconnect attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->