### PR TITLE
fix(ui): visual consistency sweep for Ember Terminal redesign

### DIFF
--- a/apps/ui/app/pulls/page.tsx
+++ b/apps/ui/app/pulls/page.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import { useQuery } from "@tanstack/react-query"
-import Link from "next/link"
 import { PageHeader } from "@/components/page-header"
 import { Skeleton } from "@/components/ui/skeleton"
 import { SectionError } from "@/components/section-error"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { GitPullRequest } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
@@ -81,14 +81,7 @@ export default function PullRequestsPage() {
           {pulls.length > 0 && <span className="stat-chip">{pulls.length} total</span>}
         </div>
         {!hasOrg ? (
-          <div className="px-4 py-8">
-            <p className="text-sm text-muted-foreground">
-              No account selected yet. Pick one from the profile menu, or{" "}
-              <Link href="/security" className="text-primary hover:underline">
-                configure →
-              </Link>
-            </p>
-          </div>
+          <EmptyStateNoAccount bare />
         ) : reposQuery.isError ? (
           <SectionError
             message={reposQuery.error instanceof Error ? reposQuery.error.message : "Failed to load repositories."}

--- a/apps/ui/components/ui/button.tsx
+++ b/apps/ui/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground border-primary/20 hover:bg-primary/90",
+          "bg-primary text-primary-foreground border-primary/20 hover:bg-primary/90 disabled:text-foreground",
         outline:
           "border-border bg-transparent hover:bg-elevated hover:text-foreground",
         secondary:


### PR DESCRIPTION
## Summary
- Fix disabled primary-button legibility: the Ember Terminal palette's `--primary-foreground` is now near-black, so combined with the existing `disabled:opacity-40`, disabled primary buttons (Repos "Load repositories", Health & Security "Run scan", Automation "Load workflows", Settings "Save token") became nearly unreadable against the near-black page background. Adds `disabled:text-foreground` to the `default` button variant.
- Unify the Pull Requests page's "no account selected" state with the shared `EmptyStateNoAccount` component (used elsewhere by Overview, Activity, Releases, My PRs) instead of a bespoke plain-text link, for a consistent connect-account CTA.

## Why
Following up on #364 (Ember Terminal design tokens), I ran a live Playwright-screenshot QA pass across every main page/state to verify the reskin actually landed cleanly everywhere rather than assuming the token swap alone was sufficient. Most pages already matched the target design once tokens changed (shared primitives read every color/radius from CSS variables), but these two real issues surfaced: a genuine accessibility/usability regression from the new palette, and a UX inconsistency directly relevant to the standing goal of making account-connection flows less confusing.

## Test plan
- [x] `bun run test` — 413/413 passed
- [x] `bun run build` — succeeds, all routes compile
- [x] `pytest -q` — 918 passed, 3 skipped, 3 xpassed
- [x] Manual verification via Playwright screenshots: disabled buttons now legible in Ember Terminal dark theme; Pull Requests empty state matches Overview/Activity/Releases/My PRs pattern
- [x] Existing test `tests/components/pulls-page.test.tsx` ("shows a configure prompt when no org is set") still passes unmodified — assertion matches `EmptyStateNoAccount`'s default message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pull requests page’s empty state when no organization is selected.
  * Disabled default buttons now retain readable foreground text for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->