### PR TITLE
fix(ui): give collaborators empty-state a real Settings link

### DIFF
--- a/apps/ui/app/collaborators/page.tsx
+++ b/apps/ui/app/collaborators/page.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
-import { EmptyState } from "@/components/empty-state"
+import { EmptyStatePage } from "@/components/empty-state"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
 import type { MyOrgMembership } from "@/lib/api/types"
@@ -33,7 +33,7 @@ export default function CollaboratorsPage() {
           description="Manage your organization's team and invitations."
         />
         <div className="card">
-          <EmptyState title="Redirecting…" description="Taking you to member management." />
+          <EmptyStatePage message="Redirecting… — Taking you to member management." />
         </div>
       </>
     )
@@ -47,10 +47,7 @@ export default function CollaboratorsPage() {
       />
       <div className="card">
         {isError ? (
-          <EmptyState
-            title="Couldn't load your organizations"
-            description="Something went wrong checking your organization memberships. Try refreshing the page."
-          />
+          <EmptyStatePage message="Couldn't load your organizations — Something went wrong checking your organization memberships. Try refreshing the page." />
         ) : memberships.length > 0 ? (
           <div className="border border-dashed border-border rounded-md px-6 py-12">
             <p className="text-sm text-muted-foreground">
@@ -67,9 +64,9 @@ export default function CollaboratorsPage() {
             </p>
           </div>
         ) : (
-          <EmptyState
-            title="No organization to manage"
-            description="Member management is available for organizations where you're an admin. Visit Settings to see your organizations."
+          <EmptyStatePage
+            message="No organization to manage — Member management is available for organizations where you're an admin."
+            action={{ href: "/settings", label: "Visit Settings" }}
           />
         )}
       </div>

--- a/apps/ui/components/empty-state.tsx
+++ b/apps/ui/components/empty-state.tsx
@@ -73,19 +73,3 @@ export function EmptyStateNoAccount({ bare = false, message: messageOverride }: 
   )
   return bare ? content : <div className="card mb-6">{content}</div>
 }
-
-/**
- * Legacy compat shim — existing pages that pass icon/title/description
- * are redirected to EmptyStatePage so the old pattern doesn't crash.
- * Remove once all callers are migrated.
- */
-interface LegacyEmptyStateProps {
-  icon?: unknown
-  title: string
-  description: string
-  cta?: React.ReactNode
-}
-
-export function EmptyState({ title, description }: LegacyEmptyStateProps) {
-  return <EmptyStatePage message={`${title} — ${description}`} />
-}


### PR DESCRIPTION
## Summary

Second live QA/polish pass following the same methodology as PR #365, now that the Ember Terminal redesign is fully merged: screenshot every page/state and fix only real, verified issues.

- Screenshotted the full page inventory (Overview, Activity, Pull Requests, Releases, Repositories, Health & Security, Automation, Audit Log, Collaborators, Settings, plus the mobile sidebar drawer) in the current dark Ember Terminal theme.
- **Found one real, verified defect**: `EmptyState` (the deprecated legacy compat shim in `apps/ui/components/empty-state.tsx`) declared a `cta` prop but never rendered it, so `/collaborators`'s "No organization to manage" state told users to "Visit Settings" with plain text and no actual link — every other empty state in the app (`EmptyStateNoAccount`, `EmptyStatePage` with an `action`) has a real clickable CTA.
- Fixed by migrating the shim's three call sites in `app/collaborators/page.tsx` to `EmptyStatePage` directly, giving the "no organization to manage" case a real `action` link to `/settings`. Removed the now-dead legacy shim per its own "remove once all callers are migrated" comment — it had no other callers left.
- Everything else checked (loading skeletons, the mobile Sheet overlay scrim, disabled-button legibility from PR #365, semantic status colors used for pass/fail/severity across Security/Audit/sidebar) held up fine against the theme — left untouched rather than inventing busywork.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 413/413 (two unrelated flakes reproduced individually in isolation and confirmed as local machine memory-pressure noise, not caused by this change — this repo's Python/UI code was otherwise untouched by those files)
- [x] `bun run build` clean
- [x] `pytest -q` — 918 passed / 3 skipped / 3 xpassed
- [x] Manually verified the fix live: created a fresh admin account, navigated to `/collaborators` with no org membership, confirmed the previous plain-text "Visit Settings" now renders as a working link to `/settings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated collaborator page empty, loading, and error states with a consistent presentation.
  * Added a “Visit Settings” action when no organization is available to manage.
  * Improved empty-state messaging by consolidating related information into clearer messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->