### PR TITLE
fix(worker): stop false-alarm TimeoutError spam in event consumer

### DIFF
--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -95,7 +95,10 @@ def _redis_client() -> redis.Redis:
             settings.redis_url.get_secret_value(),
             decode_responses=True,
             socket_connect_timeout=2,
-            socket_timeout=2,
+            # Must exceed _BLOCK_MS: the client-side read timeout has to outlast the
+            # server-side XREADGROUP BLOCK duration it's waiting on, or redis-py raises
+            # a false-alarm TimeoutError on every idle poll (issue #367).
+            socket_timeout=(_BLOCK_MS / 1000) + 2,
         )
     return _client
 


### PR DESCRIPTION
## Summary

Fixes #367. The worker's event consumer (`apps/worker/src/event_consumer.py`) logged a false-alarm `ERROR` roughly every 5-7 seconds on any idle deployment (no incoming webhook traffic), because two constants were inconsistent:

- `_BLOCK_MS = 5_000` — how long `XREADGROUP ... BLOCK` asks Redis to hold the connection open server-side while waiting for new stream entries.
- `_redis_client()`'s `socket_timeout=2` — the client-side socket read timeout, shorter than the server-side block it was waiting on.

Because the client-side read timeout (2s) was shorter than the block duration it was blocking on (5s), `redis-py` raised `TimeoutError` on the client side before the server's block window could naturally return "no new entries" — on essentially every idle poll. That exception is a subclass of `redis.RedisError`, so `run()`'s broad handler swallowed it, logged it as `ERROR`, and slept 5s before retrying, repeating indefinitely. Every occurrence also forced a client disconnect/reconnect, wasted churn against the `redis` service, and made it harder to spot a genuine connectivity problem in the noise.

## Why this is safe

Single-constant change: `socket_timeout` is now derived from `_BLOCK_MS` with a 2s buffer (`(_BLOCK_MS / 1000) + 2`), so the client always waits at least as long as the blocking Redis call it issued. `socket_connect_timeout` (the separate initial-connection timeout) is untouched. No behavior change for a real connectivity failure — a genuinely unreachable Redis still times out, just no longer confused with a normal idle poll.

## Testing

- `pytest -q apps/worker/tests/test_event_consumer.py` — 54 passed (ran against local Postgres + a real local Redis, since some tests connect for real rather than mocking `_redis_client`).
- Manually ran the worker against local Redis with no webhook traffic; confirmed no more `ERROR event consumer connection error: TimeoutError` lines over a sustained idle period (previously reproduced every ~5-7s).

## Notes for reviewers

No migrations, no sensitive-file changes (auth/RBAC/token encryption untouched). Not flagging anything per the AI Attribution Policy checklist beyond the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event polling reliability by preventing premature timeouts during idle periods.
  * Reduced false timeout errors when waiting for new events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->