### PR TITLE
fix(api,ui): connect an org from a pasted PAT (issue #368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Once the instance is running, here's how to go from a fresh deploy to a connecte
 
 That's it — Overview, Activity, Repositories, Collaborators, Health & Security, and Cache all work off the connected org from step 2. A legacy personal access token (**Settings → Personal access tokens (legacy)**) is only ever needed as a manual fallback for an org that has no GitHub App installation — it is not a required step.
 
+**A pasted PAT alone does not connect a new org to Clevis.** It only supplies GitHub-side credentials for an org that's already connected via step 2 above; Repositories, Activity, Releases, Automation, and Collaborators all require that connection first (only Overview's `/me/analytics/overview` endpoint has no such requirement). If you paste a token for an org Clevis has never seen, you'll get a clear "isn't connected to Clevis yet" error rather than being able to browse that org's data.
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Once the instance is running, here's how to go from a fresh deploy to a connecte
 
 That's it — Overview, Activity, Repositories, Collaborators, Health & Security, and Cache all work off the connected org from step 2. A legacy personal access token (**Settings → Personal access tokens (legacy)**) is only ever needed as a manual fallback for an org that has no GitHub App installation — it is not a required step.
 
-**A pasted PAT alone does not connect a new org to Clevis.** It only supplies GitHub-side credentials for an org that's already connected via step 2 above; Repositories, Activity, Releases, Automation, and Collaborators all require that connection first (only Overview's `/me/analytics/overview` endpoint has no such requirement). If you paste a token for an org Clevis has never seen, you'll get a clear "isn't connected to Clevis yet" error rather than being able to browse that org's data.
+**Pasting a PAT connects the org only if you're a GitHub admin of it.** When a workspace admin saves a token whose `read:org` scope lets Clevis confirm they own/administer that org, Clevis connects it then and there (same Org + membership records the App-install and OAuth paths create). If the token lacks `read:org`, or GitHub reports you as a plain member rather than an admin, the token is still saved but only powers Overview's `/me/analytics/overview` endpoint — Repositories, Activity, Releases, Automation, and Collaborators need the step-2 App connection (or, for a non-admin, an accepted org invite) first, and those pages return a clear "isn't connected to Clevis yet" error until then.
 
 ---
 

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -85,7 +85,14 @@ def require_org_role(min_role: Literal["member", "admin"]):
         if ctx is not None:
             return ctx
         if org_repo.get_by_login(db, org_login) is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"'{org_login}' isn't connected to Clevis yet — sign in with GitHub or "
+                    "install the GitHub App for this org first. A pasted personal access "
+                    "token alone doesn't connect a new org."
+                ),
+            )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
 
     return dependency

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -53,8 +53,12 @@ def resolve_org_role(db: Session, org_login: str, user_id: int, min_role: Litera
     min_role. Shared by require_org_role itself and by installations.py's
     sync_org_installation, which needs a non-raising check to decide whether to take its
     known-admin fast path or fall through to first-time GitHub-verified bootstrap --
-    keeping the two checks from silently drifting apart (issue #190 CodeRabbit follow-up)."""
-    org = org_repo.get_by_login(db, org_login)
+    keeping the two checks from silently drifting apart (issue #190 CodeRabbit follow-up).
+
+    Lookup is case-insensitive (issue #368): GitHub org logins are unique regardless of
+    case, and an Org row is stored under GitHub's canonical casing -- so a user who typed
+    "myorg" for an org GitHub canonicalises as "MyOrg" must still resolve to it, not 404."""
+    org = org_repo.get_by_login_ci(db, org_login)
     if org is None:
         return None
     # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
@@ -84,13 +88,14 @@ def require_org_role(min_role: Literal["member", "admin"]):
         ctx = resolve_org_role(db, org_login, user.id, min_role)
         if ctx is not None:
             return ctx
-        if org_repo.get_by_login(db, org_login) is None:
+        if org_repo.get_by_login_ci(db, org_login) is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=(
                     f"'{org_login}' isn't connected to Clevis yet — sign in with GitHub or "
-                    "install the GitHub App for this org first. A pasted personal access "
-                    "token alone doesn't connect a new org."
+                    "install the GitHub App for this org first. A pasted personal access token "
+                    "connects the org only if it has read:org scope and GitHub confirms you "
+                    "administer it."
                 ),
             )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -6,10 +6,8 @@ The GET /tokens endpoint intentionally never returns raw tokens — only metadat
 (org name, label, created_at). The UI uses PUT to upsert and DELETE to remove.
 """
 
-import logging
 from datetime import datetime
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, SecretStr
 from sqlalchemy.orm import Session
@@ -17,48 +15,11 @@ from sqlalchemy.orm import Session
 from src.core._crypto import decrypt_job_token, encrypt_job_token
 from src.core.auth import UserOut, require_workspace_admin
 from src.core.config import settings
-from src.core.db import Org, SavedToken, get_db
-from src.repositories import audit_repo, org_membership_repo, org_repo, tenant_repo
-from src.services import github_oauth
-
-logger = logging.getLogger(__name__)
+from src.core.db import SavedToken, get_db
+from src.repositories import audit_repo, org_repo, tenant_repo
+from src.services import org_provisioning
 
 router = APIRouter()
-
-
-def _try_connect_org_from_pat(
-    db: Session, org_login: str, pat: str, user: UserOut
-) -> Org | None:
-    """Best-effort: connect ``org_login`` to Clevis using the pasted PAT itself, mirroring
-    what "Sign in with GitHub" OAuth does at login (issue #368).
-
-    Without this, a workspace admin who signed up with email/password and pasted a valid,
-    fully-scoped PAT still gets a 404 from every ``/orgs/{org_login}/...`` endpoint, because
-    ``org_memberships`` is only ever written by the OAuth path — a saved PAT alone never
-    established the membership row ``require_org_role`` checks.
-
-    Returns the connected ``Org`` row, or ``None`` if the PAT lacks ``read:org`` scope, the
-    GitHub call fails, or GitHub doesn't list this user as an active member of that org. Never
-    raises — the token save must succeed regardless.
-    """
-    try:
-        memberships = github_oauth.list_user_org_memberships(pat)
-    except httpx.HTTPError as exc:  # PAT missing read:org, network error, etc.
-        logger.info("token org auto-link skipped for %s: %s", org_login, exc)
-        return None
-
-    match = next((m for m in memberships if m.login.lower() == org_login.lower()), None)
-    if match is None:
-        return None
-
-    org_row = org_repo.get_or_create(db, github_login=match.login, github_org_id=match.github_org_id)
-    role = "admin" if match.role == "admin" else "member"
-    org_membership_repo.get_or_create(db, org_id=org_row.id, user_id=user.id, role=role)
-    audit_repo.write(
-        db, user.email, "token.org_autolinked", match.login, {"role": role},
-        tenant_id=org_row.tenant_id,
-    )
-    return org_row
 
 
 # ── schemas ────────────────────────────────────────────────────────────────
@@ -118,12 +79,28 @@ def upsert_token(
     # no OR-NULL escape -- see migration 0030's docstring) can accept the write; if not,
     # tenant_id stays NULL (migration 0033 loosens WITH CHECK for exactly this case).
     existing_org = org_repo.get_by_login_ci(db, org)
-    # Issue #368: if the org isn't connected yet (or this admin has no membership row for
-    # it), try to establish that from the PAT itself -- otherwise every /orgs/{org}/...
-    # page 404s with "not connected" despite a fully valid token.
-    connected_org = _try_connect_org_from_pat(db, org, body.token.get_secret_value(), user)
-    existing_org = connected_org or existing_org
-    tenant_id = org_repo.ensure_tenant_linked(db, existing_org).tenant_id if existing_org else None
+
+    # Skip the auto-connect path (a paginated GitHub crawl) only when there's nothing it
+    # could do: the caller already has an *admin* membership for this org. A missing row
+    # -- or a "member" row GitHub might now report as "admin" -- still goes through the
+    # helper so a first connection / promotion isn't missed on token save.
+    nothing_to_do = False
+    if existing_org is not None:
+        existing_org = org_repo.ensure_tenant_linked(db, existing_org)
+        membership = tenant_repo.get_membership(db, existing_org.tenant_id, user.id)
+        nothing_to_do = membership is not None and membership.role == "admin"
+
+    # Issue #368: if this admin can't already reach the org, try to establish the Org +
+    # admin membership from the pasted PAT -- otherwise every /orgs/{org}/... page 404s
+    # with "not connected" despite a fully valid token.
+    if not nothing_to_do:
+        connected_org = org_provisioning.connect_admin_org_from_token(
+            db, user, org, body.token.get_secret_value()
+        )
+        if connected_org is not None:
+            existing_org = connected_org
+
+    tenant_id = existing_org.tenant_id if existing_org else None
 
     row = db.query(SavedToken).filter_by(org=org).first()
     if row:

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -6,8 +6,10 @@ The GET /tokens endpoint intentionally never returns raw tokens — only metadat
 (org name, label, created_at). The UI uses PUT to upsert and DELETE to remove.
 """
 
+import logging
 from datetime import datetime
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, SecretStr
 from sqlalchemy.orm import Session
@@ -15,10 +17,48 @@ from sqlalchemy.orm import Session
 from src.core._crypto import decrypt_job_token, encrypt_job_token
 from src.core.auth import UserOut, require_workspace_admin
 from src.core.config import settings
-from src.core.db import SavedToken, get_db
-from src.repositories import audit_repo, org_repo, tenant_repo
+from src.core.db import Org, SavedToken, get_db
+from src.repositories import audit_repo, org_membership_repo, org_repo, tenant_repo
+from src.services import github_oauth
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _try_connect_org_from_pat(
+    db: Session, org_login: str, pat: str, user: UserOut
+) -> Org | None:
+    """Best-effort: connect ``org_login`` to Clevis using the pasted PAT itself, mirroring
+    what "Sign in with GitHub" OAuth does at login (issue #368).
+
+    Without this, a workspace admin who signed up with email/password and pasted a valid,
+    fully-scoped PAT still gets a 404 from every ``/orgs/{org_login}/...`` endpoint, because
+    ``org_memberships`` is only ever written by the OAuth path — a saved PAT alone never
+    established the membership row ``require_org_role`` checks.
+
+    Returns the connected ``Org`` row, or ``None`` if the PAT lacks ``read:org`` scope, the
+    GitHub call fails, or GitHub doesn't list this user as an active member of that org. Never
+    raises — the token save must succeed regardless.
+    """
+    try:
+        memberships = github_oauth.list_user_org_memberships(pat)
+    except httpx.HTTPError as exc:  # PAT missing read:org, network error, etc.
+        logger.info("token org auto-link skipped for %s: %s", org_login, exc)
+        return None
+
+    match = next((m for m in memberships if m.login.lower() == org_login.lower()), None)
+    if match is None:
+        return None
+
+    org_row = org_repo.get_or_create(db, github_login=match.login, github_org_id=match.github_org_id)
+    role = "admin" if match.role == "admin" else "member"
+    org_membership_repo.get_or_create(db, org_id=org_row.id, user_id=user.id, role=role)
+    audit_repo.write(
+        db, user.email, "token.org_autolinked", match.login, {"role": role},
+        tenant_id=org_row.tenant_id,
+    )
+    return org_row
 
 
 # ── schemas ────────────────────────────────────────────────────────────────
@@ -61,9 +101,13 @@ def upsert_token(
     org: str,
     body: UpsertTokenRequest,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_workspace_admin),
+    user: UserOut = Depends(require_workspace_admin),
 ) -> TokenMeta:
-    """Save or update the token for an org (encrypted at rest). Workspace admin only."""
+    """Save or update the token for an org (encrypted at rest). Workspace admin only.
+
+    Also best-effort connects the org to Clevis using the pasted PAT (issue #368) so the
+    org-scoped dashboard pages work afterwards, not just Overview.
+    """
     encrypted = encrypt_job_token(
         body.token.get_secret_value(),
         settings.job_secret_key.get_secret_value(),
@@ -74,6 +118,11 @@ def upsert_token(
     # no OR-NULL escape -- see migration 0030's docstring) can accept the write; if not,
     # tenant_id stays NULL (migration 0033 loosens WITH CHECK for exactly this case).
     existing_org = org_repo.get_by_login_ci(db, org)
+    # Issue #368: if the org isn't connected yet (or this admin has no membership row for
+    # it), try to establish that from the PAT itself -- otherwise every /orgs/{org}/...
+    # page 404s with "not connected" despite a fully valid token.
+    connected_org = _try_connect_org_from_pat(db, org, body.token.get_secret_value(), user)
+    existing_org = connected_org or existing_org
     tenant_id = org_repo.ensure_tenant_linked(db, existing_org).tenant_id if existing_org else None
 
     row = db.query(SavedToken).filter_by(org=org).first()

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -29,11 +29,52 @@ import httpx
 
 from sqlalchemy.orm import Session
 
-from src.core.db import User, set_session_user
-from src.repositories import org_membership_repo, org_repo, tenant_repo
+from src.core.db import Org, User, set_session_user
+from src.repositories import audit_repo, org_membership_repo, org_repo, tenant_repo
 from src.services import github_oauth
 
 logger = logging.getLogger(__name__)
+
+
+def connect_admin_org_from_token(
+    db: Session, user: User, org_login: str, user_token: str
+) -> Org | None:
+    """Single-org version of :func:`sync_org_admin_memberships` for the legacy-PAT path
+    (issue #368): when a workspace admin saves a PAT for an org Clevis has never connected,
+    use that PAT to establish the ``Org`` + admin membership so the ``/orgs/{org}/...``
+    dashboard pages work, instead of every one of them 404ing.
+
+    Same authorization policy as the OAuth path: only connects when GitHub reports the caller
+    as an **admin/owner** of ``org_login``. A plain GitHub member still goes through the
+    explicit invite-accept flow — pasting a PAT must not be a back door around it.
+
+    Returns the connected ``Org`` (canonical GitHub casing), or ``None`` if the PAT can't
+    resolve it (missing ``read:org``, GitHub error, malformed response, or the caller isn't
+    an admin). **Never raises** — the token save must succeed regardless.
+    """
+    try:
+        memberships = github_oauth.list_user_org_memberships(user_token)
+    except Exception as exc:  # noqa: BLE001 -- best-effort; a bad response must not 500 the save
+        logger.info("PAT org auto-connect skipped for %s: %s", org_login, exc)
+        return None
+
+    match = next(
+        (m for m in memberships if m.login.lower() == org_login.lower() and m.role == "admin"),
+        None,
+    )
+    if match is None:
+        return None
+
+    set_session_user(db, user.id)
+    org = org_repo.get_or_create(db, github_login=match.login, github_org_id=match.github_org_id)
+    membership = org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+    if membership.role != "admin":
+        org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
+    audit_repo.write(
+        db, user.email, "token.org_autolinked", match.login, {"role": "admin"},
+        tenant_id=org.tenant_id,
+    )
+    return org
 
 
 def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None:

--- a/apps/api/tests/test_tokens_autolink.py
+++ b/apps/api/tests/test_tokens_autolink.py
@@ -1,0 +1,91 @@
+"""Issue #368: saving a legacy PAT best-effort connects the org to Clevis, so the
+org-scoped dashboard pages (Repositories/Activity/...) work afterwards, not just Overview.
+"""
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from src.core.auth import UserOut, require_auth, require_workspace_admin
+from src.core.db import AuditLog, User, get_db
+from src.core.rbac import require_org_role
+from src.repositories import org_repo, tenant_repo
+from src.routers.tokens import router as tokens_router
+from src.services.github_oauth import GitHubOrgMembership
+
+
+def _admin_client(db, user: UserOut) -> TestClient:
+    app = FastAPI()
+    app.include_router(tokens_router, prefix="/tokens")
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[require_workspace_admin] = lambda: user
+    app.dependency_overrides[require_auth] = lambda: user
+    db.execute(text(f"SET app.user_id = {user.id}"))
+    return TestClient(app)
+
+
+@pytest.fixture()
+def admin(db) -> UserOut:
+    u = User(email="wsadmin@example.com", name=None, password_hash=None, is_workspace_admin=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return UserOut(id=u.id, email=u.email, name=u.name, is_workspace_admin=True)
+
+
+def test_pat_for_admin_org_creates_org_and_membership(db, admin):
+    client = _admin_client(db, admin)
+    memberships = [GitHubOrgMembership(github_org_id=42, login="Acme", role="admin")]
+
+    with patch(
+        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
+    ):
+        resp = client.put("/tokens/acme", json={"token": "ghp_valid", "label": "acme"})
+    assert resp.status_code == 200
+
+    org = org_repo.get_by_login_ci(db, "acme")
+    assert org is not None and org.github_org_id == 42
+    # RBAC reads the tenant-keyed mirror -- it must have been dual-written.
+    membership = tenant_repo.get_membership(db, org.tenant_id, admin.id)
+    assert membership is not None and membership.role == "admin"
+
+    logs = db.query(AuditLog).filter(AuditLog.action == "token.org_autolinked").all()
+    assert len(logs) == 1 and logs[0].target == "Acme"
+
+
+def test_require_org_role_passes_after_autolink(db, admin):
+    client = _admin_client(db, admin)
+    memberships = [GitHubOrgMembership(github_org_id=7, login="acme", role="member")]
+    with patch(
+        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
+    ):
+        client.put("/tokens/acme", json={"token": "ghp_valid"})
+
+    ctx = require_org_role("member")(org_login="acme", db=db, user=admin)
+    assert ctx.org.github_login == "acme"
+
+
+def test_github_error_still_saves_token(db, admin):
+    import httpx
+
+    client = _admin_client(db, admin)
+    with patch(
+        "src.routers.tokens.github_oauth.list_user_org_memberships",
+        side_effect=httpx.HTTPStatusError("403", request=None, response=None),
+    ):
+        resp = client.put("/tokens/acme", json={"token": "ghp_noscope"})
+    assert resp.status_code == 200
+    assert org_repo.get_by_login_ci(db, "acme") is None
+
+
+def test_pat_without_matching_membership_saves_token_only(db, admin):
+    client = _admin_client(db, admin)
+    memberships = [GitHubOrgMembership(github_org_id=1, login="other-org", role="admin")]
+    with patch(
+        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
+    ):
+        resp = client.put("/tokens/acme", json={"token": "ghp_valid"})
+    assert resp.status_code == 200
+    assert org_repo.get_by_login_ci(db, "acme") is None

--- a/apps/api/tests/test_tokens_autolink.py
+++ b/apps/api/tests/test_tokens_autolink.py
@@ -1,5 +1,9 @@
 """Issue #368: saving a legacy PAT best-effort connects the org to Clevis, so the
 org-scoped dashboard pages (Repositories/Activity/...) work afterwards, not just Overview.
+
+Authorization policy mirrors the OAuth provisioning path (``sync_org_admin_memberships``):
+only a GitHub **admin/owner** of the org is auto-connected from a pasted PAT. A plain GitHub
+member still goes through the explicit invite-accept flow.
 """
 from unittest.mock import patch
 
@@ -14,6 +18,10 @@ from src.core.rbac import require_org_role
 from src.repositories import org_repo, tenant_repo
 from src.routers.tokens import router as tokens_router
 from src.services.github_oauth import GitHubOrgMembership
+
+# The PAT -> org-membership resolution moved out of the router into
+# org_provisioning.connect_admin_org_from_token, so that's where github_oauth is imported.
+_PATCH_TARGET = "src.services.org_provisioning.github_oauth.list_user_org_memberships"
 
 
 def _admin_client(db, user: UserOut) -> TestClient:
@@ -39,9 +47,7 @@ def test_pat_for_admin_org_creates_org_and_membership(db, admin):
     client = _admin_client(db, admin)
     memberships = [GitHubOrgMembership(github_org_id=42, login="Acme", role="admin")]
 
-    with patch(
-        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
-    ):
+    with patch(_PATCH_TARGET, return_value=memberships):
         resp = client.put("/tokens/acme", json={"token": "ghp_valid", "label": "acme"})
     assert resp.status_code == 200
 
@@ -57,10 +63,8 @@ def test_pat_for_admin_org_creates_org_and_membership(db, admin):
 
 def test_require_org_role_passes_after_autolink(db, admin):
     client = _admin_client(db, admin)
-    memberships = [GitHubOrgMembership(github_org_id=7, login="acme", role="member")]
-    with patch(
-        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
-    ):
+    memberships = [GitHubOrgMembership(github_org_id=7, login="acme", role="admin")]
+    with patch(_PATCH_TARGET, return_value=memberships):
         client.put("/tokens/acme", json={"token": "ghp_valid"})
 
     ctx = require_org_role("member")(org_login="acme", db=db, user=admin)
@@ -72,7 +76,7 @@ def test_github_error_still_saves_token(db, admin):
 
     client = _admin_client(db, admin)
     with patch(
-        "src.routers.tokens.github_oauth.list_user_org_memberships",
+        _PATCH_TARGET,
         side_effect=httpx.HTTPStatusError("403", request=None, response=None),
     ):
         resp = client.put("/tokens/acme", json={"token": "ghp_noscope"})
@@ -83,9 +87,38 @@ def test_github_error_still_saves_token(db, admin):
 def test_pat_without_matching_membership_saves_token_only(db, admin):
     client = _admin_client(db, admin)
     memberships = [GitHubOrgMembership(github_org_id=1, login="other-org", role="admin")]
-    with patch(
-        "src.routers.tokens.github_oauth.list_user_org_memberships", return_value=memberships
-    ):
+    with patch(_PATCH_TARGET, return_value=memberships):
         resp = client.put("/tokens/acme", json={"token": "ghp_valid"})
     assert resp.status_code == 200
     assert org_repo.get_by_login_ci(db, "acme") is None
+
+
+def test_pat_for_plain_member_saves_token_but_does_not_connect_org(db, admin):
+    """A GitHub *member* (not admin) pasting a PAT must not back-door around the
+    invite-accept flow -- token is saved, but no Org / membership is created."""
+    client = _admin_client(db, admin)
+    memberships = [GitHubOrgMembership(github_org_id=99, login="Acme", role="member")]
+    with patch(_PATCH_TARGET, return_value=memberships):
+        resp = client.put("/tokens/acme", json={"token": "ghp_valid"})
+    assert resp.status_code == 200
+    assert org_repo.get_by_login_ci(db, "acme") is None
+    assert db.query(AuditLog).filter(AuditLog.action == "token.org_autolinked").count() == 0
+
+
+def test_existing_member_row_is_promoted_when_github_says_admin(db, admin):
+    """If the caller already has a 'member' row for the org and GitHub now reports them
+    an admin, saving a PAT promotes the row (CodeRabbit: sync existing role)."""
+    org = org_repo.get_or_create(db, github_login="Acme", github_org_id=55)
+    from src.repositories import org_membership_repo
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="member")
+    db.commit()
+
+    client = _admin_client(db, admin)
+    memberships = [GitHubOrgMembership(github_org_id=55, login="Acme", role="admin")]
+    with patch(_PATCH_TARGET, return_value=memberships):
+        resp = client.put("/tokens/acme", json={"token": "ghp_valid"})
+    assert resp.status_code == 200
+
+    membership = tenant_repo.get_membership(db, org.tenant_id, admin.id)
+    assert membership is not None and membership.role == "admin"

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -312,7 +312,7 @@ export default function ReposPage() {
               <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
                 <span className="text-[0.6875rem] text-muted-foreground font-normal">
-                  optional if the GitHub App is connected for this org — a token alone can&rsquo;t connect a new org
+                  optional if the GitHub App is connected — a token with read:org connects the org only if you administer it on GitHub
                 </span>
                 {tokenSaved && (
                   <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -312,7 +312,7 @@ export default function ReposPage() {
               <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
                 <span className="text-[0.6875rem] text-muted-foreground font-normal">
-                  optional if the GitHub App is connected for this org
+                  optional if the GitHub App is connected for this org — a token alone can&rsquo;t connect a new org
                 </span>
                 {tokenSaved && (
                   <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
@@ -321,7 +321,7 @@ export default function ReposPage() {
                 )}
               </label>
               <Input
-                placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                placeholder="ghp_... (org must already be connected via GitHub sign-in or the App)"
                 type="password"
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -321,7 +321,7 @@ export default function ReposPage() {
                 )}
               </label>
               <Input
-                placeholder="ghp_... (org must already be connected via GitHub sign-in or the App)"
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
                 type="password"
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}


### PR DESCRIPTION
Fixes #368.

## The problem

The Repositories page invites you to type any GitHub org name and paste a personal access
token, framed as sufficient. It isn't: a valid, fully-scoped PAT is **not** enough for
Repositories / Activity / Releases / Automation / Collaborators — every `/orgs/{org_login}/...`
endpoint 404s with a misleading `"Org not found"` unless the org was previously connected via
"Sign in with GitHub" OAuth or a GitHub App install. `org_memberships` (which `require_org_role`
checks) is only ever written by the OAuth login path; `PUT /tokens/{org}` never touched it.

A workspace admin who signs up with email/password and pastes a PAT ends up with a
mostly-empty app (only Overview, via `/me/analytics/overview`, works) and no explanation.

## What changed and why

### 1. `PUT /tokens/{org}` connects the org from the PAT itself
`org_provisioning.connect_admin_org_from_token` (a single-org sibling of the OAuth path's
`sync_org_admin_memberships`, living in the same module): resolves the org via
`GET /user/memberships/orgs` using the pasted token and, **only when GitHub confirms the caller
is an admin/owner of that org**, creates the `Org` row + membership mirror exactly as the OAuth
and App-install paths do. Writes a `token.org_autolinked` audit entry.

Strictly best-effort — it **never fails the token save**. A PAT without `read:org` scope, any
GitHub API error, or an org where GitHub reports the caller as a plain member (not admin) all
fall through to the honest 404 below. A non-admin still gets access only through the explicit
invite-accept flow — a pasted PAT is not a back door around it.

### 2. Honest 404 fallback (`apps/api/src/core/rbac.py`)
When auto-connect can't happen, `/orgs/{org_login}/...` returns
`"'{org}' isn't connected to Clevis yet — sign in with GitHub or install the GitHub App for
this org first. A pasted personal access token connects the org only if it has read:org scope
and GitHub confirms you administer it."` instead of the typo-looking `"Org not found"`.
The Org lookup here is now **case-insensitive** (`get_by_login_ci`) so an org GitHub
canonicalises to a different casing than the user typed resolves instead of 404ing.

### 3. Honest copy (`README.md`, `apps/ui/app/repos/page.tsx`)
README "Get started" and the token-field hint describe the real behaviour: a PAT connects the
org for a GitHub admin with `read:org`; otherwise it only powers Overview.

## Review fixes (commit `fb18b5b`, addressing agent review + CodeRabbit)
- **Admin-only** auto-connect (was: any active GitHub member — bypassed the invite-accept flow).
- Extracted the shared `connect_admin_org_from_token` helper instead of a hand-rolled parallel
  copy of `sync_org_admin_memberships` in the router.
- **Role sync**: an existing `member` row is promoted to `admin` when GitHub now reports admin.
- Case-insensitive RBAC org lookup (`get_by_login` → `get_by_login_ci`, 2 call sites).
- The GitHub membership crawl is skipped on save only when the caller already has an `admin`
  row for the org (nothing to do) — not on every re-save.
- `except Exception` (not just `httpx.HTTPError`) so a malformed response can't 500 the save.

## Sensitive areas
- Touches **auth/RBAC provisioning** — writes the `org_memberships` / tenant membership mirror
  from a new code path. Authorization signal is GitHub's own admin-membership list for that PAT,
  the same signal the OAuth path trusts.
- **No migration.**

## Verification
- `pytest -q apps/api/tests/test_tokens_autolink.py apps/api/tests/test_owner_only_routes.py apps/api/tests/test_rbac.py apps/api/tests/test_org_provisioning.py` — 40 pass
- Tests cover: admin org → Org + membership created & `require_org_role` passes; GitHub error →
  token still saved, no org; non-matching org → token only; **plain member → token saved, org
  NOT connected**; **existing member row promoted to admin** when GitHub says admin.
