### PR TITLE
chore(api): remove redundant org-scoped actions-cache routes

### DIFF
--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -4,7 +4,6 @@ from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
-from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.repositories import tenant_repo
 from src.schemas.cache import CacheClearInput, CacheClearResponse, CacheListInput, CacheListResponse
 from src.services.cache_service import clear
@@ -12,7 +11,6 @@ from src.services.github_client import GitHubClient
 from src.services.token_resolution import (
     InsufficientOrgRole,
     NoGitHubTokenAvailable,
-    resolve_org_token,
     resolve_owner_token,
 )
 
@@ -38,43 +36,6 @@ def _list_caches(owner: str, repo: str, token: str) -> CacheListResponse:
 
 def _client_token(payload: CacheListInput | CacheClearInput) -> str | None:
     return payload.token.get_secret_value() if payload.token else None
-
-
-@router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
-def org_list_caches(
-    org_login: str,
-    owner: str,
-    repo: str,
-    payload: CacheListInput,
-    ctx: OrgContext = Depends(require_org_role(min_role="member")),
-    db: Session = Depends(get_db),
-):
-    assert_owner_matches_org(owner, ctx)
-    try:
-        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
-    except NoGitHubTokenAvailable as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    return _list_caches(owner, repo, token)
-
-
-@router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
-def org_clear_caches(
-    org_login: str,
-    owner: str,
-    repo: str,
-    payload: CacheClearInput,
-    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
-    user: UserOut = Depends(require_auth),
-    db: Session = Depends(get_db),
-):
-    assert_owner_matches_org(owner, ctx)
-    token = ""
-    if not payload.dry_run:
-        try:
-            token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
-        except NoGitHubTokenAvailable as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
-    return clear(db, owner, repo, payload, actor=user.email, token=token, tenant_id=ctx.org.tenant_id)
 
 
 @router.post("/me/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)

--- a/apps/api/tests/test_actions_cache.py
+++ b/apps/api/tests/test_actions_cache.py
@@ -1,6 +1,6 @@
 """Tests for actions-cache GitHub error mapping."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -128,82 +128,5 @@ def test_personal_clear_caches_rejects_org_member_supplying_own_token(cache_clie
     resp = cache_client.post(
         "/me/repos/acme/demo/actions-caches/clear",
         json={"dry_run": False, "token": "ghp_testtoken123456789012345678901234"},
-    )
-    assert resp.status_code == 403
-
-
-# ── org-scoped ────────────────────────────────────────────────────────────────
-
-@pytest.fixture()
-def acme_org(db):
-    admin = User(email="admin@e.com", name=None, password_hash=None, is_workspace_admin=False)
-    member = User(email="member@e.com", name=None, password_hash=None, is_workspace_admin=False)
-    db.add_all([admin, member])
-    db.commit()
-    db.refresh(admin)
-    db.refresh(member)
-    org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
-    return {"org": org, "admin": admin, "member": member}
-
-
-def _org_client(db, user_id):
-    app = FastAPI()
-    app.include_router(cache_router)
-    app.dependency_overrides[require_auth] = lambda: UserOut(
-        id=user_id, email="u@example.com", name=None, is_workspace_admin=False
-    )
-    app.dependency_overrides[get_db] = lambda: db
-    return TestClient(app)
-
-
-def test_org_list_caches_member_ok(db, acme_org):
-    client = _org_client(db, acme_org["member"].id)
-    with patch("src.routers.actions_cache.GitHubClient") as mock_client:
-        mock_client.return_value.request.return_value = {"total_count": 0, "actions_caches": []}
-        resp = client.post(
-            "/orgs/acme/repos/acme/demo/actions-caches",
-            json={"token": "ghp_testtoken123456789012345678901234"},
-        )
-    assert resp.status_code == 200
-
-
-def test_org_list_caches_no_installation_and_no_token_returns_400(db, acme_org):
-    client = _org_client(db, acme_org["member"].id)
-    resp = client.post("/orgs/acme/repos/acme/demo/actions-caches", json={})
-    assert resp.status_code == 400
-
-
-def test_org_clear_caches_non_dry_run_no_installation_and_no_token_returns_400(db, acme_org):
-    client = _org_client(db, acme_org["admin"].id)
-    resp = client.post("/orgs/acme/repos/acme/demo/actions-caches/clear", json={"dry_run": False})
-    assert resp.status_code == 400
-
-
-def test_org_list_caches_outsider_forbidden(db, acme_org):
-    client = _org_client(db, 999999)
-    resp = client.post(
-        "/orgs/acme/repos/acme/demo/actions-caches",
-        json={"token": "ghp_testtoken123456789012345678901234"},
-    )
-    assert resp.status_code == 403
-
-
-def test_org_clear_caches_non_dry_run_uses_client_token(db, acme_org):
-    client = _org_client(db, acme_org["admin"].id)
-    resp = client.post(
-        "/orgs/acme/repos/acme/demo/actions-caches/clear",
-        json={"dry_run": False, "token": "ghp_testtoken123456789012345678901234"},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["queued"] is True
-
-
-def test_org_clear_caches_requires_admin(db, acme_org):
-    client = _org_client(db, acme_org["member"].id)
-    resp = client.post(
-        "/orgs/acme/repos/acme/demo/actions-caches/clear",
-        json={"dry_run": True},
     )
     assert resp.status_code == 403

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -1,15 +1,13 @@
 """Workspace-admin-only enforcement for jobs/audit/tokens (instance-wide data with no
-per-org column to scope by), plus org-role enforcement for the actions-cache routes.
+per-org column to scope by), plus auth enforcement for the actions-cache routes.
 """
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
 from src.routers.actions_cache import router as cache_router
 from src.routers.audit import router as audit_router
 from src.routers.jobs import router as jobs_router
@@ -17,14 +15,6 @@ from src.routers.tokens import router as tokens_router
 
 _OWNER = UserOut(id=1, email="owner@example.com", name=None, is_workspace_admin=True)
 _NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_workspace_admin=False)
-
-
-def _make_user(db, email: str) -> UserOut:
-    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
 
 def _client(router, db, user, prefix=""):
@@ -110,57 +100,12 @@ def test_tokens_resolve_writes_audit_log(db):
 
 
 # ── actions cache ─────────────────────────────────────────────────────────────
-# Org-role dependencies are resolved before the handler body runs, so a non-member/
-# non-admin never reaches the real GitHub API call — no need to mock GitHubClient here.
 
-@pytest.fixture()
-def cache_app(db):
+def test_personal_actions_cache_requires_auth(db):
     app = FastAPI()
     app.include_router(cache_router)
     app.dependency_overrides[get_db] = lambda: db
-    return app
-
-
-@pytest.fixture()
-def acme_membership(db):
-    admin = _make_user(db, "cache-admin@example.com")
-    member = _make_user(db, "cache-member@example.com")
-    org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
-    return {"org": org, "admin": admin, "member": member}
-
-
-def test_org_actions_cache_list_outsider_forbidden(cache_app, acme_membership):
-    outsider = UserOut(id=99999, email="outsider@example.com", name=None, is_workspace_admin=False)
-    cache_app.dependency_overrides[require_auth] = lambda: outsider
-    resp = TestClient(cache_app).post(
-        "/orgs/acme/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
-    )
-    assert resp.status_code == 403
-
-
-def test_org_actions_cache_clear_member_forbidden(cache_app, acme_membership):
-    """Members can list caches but clearing requires org-admin."""
-    cache_app.dependency_overrides[require_auth] = lambda: acme_membership["member"]
-    resp = TestClient(cache_app).post(
-        "/orgs/acme/repos/acme/widget/actions-caches/clear",
-        json={"token": "ghp_test"},
-    )
-    assert resp.status_code == 403
-
-
-def test_org_actions_cache_owner_mismatch_forbidden(cache_app, acme_membership):
-    """An org admin can't act on a different GitHub owner than the org they're scoped to."""
-    cache_app.dependency_overrides[require_auth] = lambda: acme_membership["admin"]
-    resp = TestClient(cache_app).post(
-        "/orgs/acme/repos/someone-else/widget/actions-caches", json={"token": "ghp_test"}
-    )
-    assert resp.status_code == 403
-
-
-def test_personal_actions_cache_requires_auth(cache_app):
-    resp = TestClient(cache_app).post(
+    resp = TestClient(app).post(
         "/me/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
     )
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Fixes #369. `apps/api/src/routers/actions_cache.py` defined two org-scoped endpoints (`POST /orgs/{org_login}/repos/{owner}/{repo}/actions-caches` and `.../clear`) with no caller anywhere in the UI — `apps/ui/lib/api/client.ts`'s `cache.list`/`cache.clear` only ever call the `/me/repos/{owner}/{repo}/actions-caches[/clear]` variants, confirmed live end-to-end (list caches, dry-run clear, real clear, job → `done`, audit log written) in the issue's own QA sweep.

## Why removed instead of wired into a UI

The issue asked to confirm intent: wire the routes into a UI, or remove them as dead code. I traced `token_resolution.resolve_owner_token` (what the `/me/...` handlers already use) and confirmed it's **already fully org-aware**:

- Same RBAC: it looks up the caller's `Membership` for the target org and rejects below `min_role` via `InsufficientOrgRole` (mapped to 403) — identical to `require_org_role`'s `OrgContext` gate the deleted routes used.
- Same installation-token resolution: `resolve_org_token` under the hood, same as the deleted routes called directly.
- Same result, for an org login passed as the `/me/...` routes' `owner` param.

So there was no capability gap for a new UI to fill — building one would just be a second code path to the same `clear()`/list logic for zero new behavior. Removed the two org-scoped handlers, their now-dead imports (`OrgContext`, `assert_owner_matches_org`, `require_org_role`, `resolve_org_token`), and their tests instead.

## What changed

- **`apps/api/src/routers/actions_cache.py`**: deleted `org_list_caches`/`org_clear_caches` and unused imports. The two `/me/...` handlers are untouched — **no API contract change for anything the UI uses**.
- **`apps/api/tests/test_actions_cache.py`**: removed the "org-scoped" test block (`acme_org` fixture + 6 tests) and an import (`MagicMock`) that was only used there.
- **`apps/api/tests/test_owner_only_routes.py`**: removed the 3 org-scoped actions-cache tests and their fixtures (`cache_app`, `acme_membership`), and the now-unused `_make_user` helper; kept `test_personal_actions_cache_requires_auth` (inlined its tiny setup since the shared fixture it used is gone).

## Testing

- `pytest -q apps/api/tests/test_actions_cache.py apps/api/tests/test_owner_only_routes.py` — 17 passed.
- `pytest -q apps/api/tests` (full suite) — 711 passed, 3 skipped, 3 xpassed.
- `ruff check` on all three touched files — clean.
- Grepped the whole repo for `org_list_caches`/`org_clear_caches`/the deleted route paths — no remaining references anywhere in `apps/api` or `apps/ui`.

No migrations, no sensitive-file changes (this narrows RBAC-adjacent surface area rather than touching auth/RBAC logic itself — `require_org_role` and `token_resolution.py` are unmodified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed organization-scoped actions cache listing and clearing endpoints.
  * Actions cache management is now available only through personal endpoints.
  * Unauthenticated access to personal actions cache routes is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->