### PR TITLE
fix(ui): add root error.tsx boundary to stop render-crash white-screens

### DIFF
--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -19,11 +19,16 @@ class CheckResult(BaseModel):
     (issue #370). ``value`` is deliberately a union of every shape the six checks and the
     runner's error paths emit: a bare bool (MFA), a ``{str: int}`` counts dict (all the
     repo-level checks), or a plain string (runner-level failure messages).
+
+    ``severity`` stays a free ``str`` on purpose: it's the source-of-truth
+    ``CheckMetadata.severity`` (unconstrained), it's only a cosmetic chip in the UI, and
+    ``github_checks.py`` already uses a wider vocabulary ("critical") elsewhere -- pinning
+    it here would turn a new check's severity label into a 500 on the whole overview.
     """
 
     id: str
     title: str
-    severity: Literal["high", "medium", "low"]
+    severity: str
     remediation: str
     status: Literal["pass", "fail", "error", "not_applicable"]
     value: bool | str | dict[str, int] | None = None

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -11,13 +11,31 @@ class AnalyticsInput(BaseModel):
     token: SecretStr | None = None
 
 
+class CheckResult(BaseModel):
+    """One security-check result as produced by ``checks.runner.run_all_checks``.
+
+    Typed so a shape drift in ``packages/checks`` fails fast at the API boundary with a
+    clear validation error instead of silently reaching the UI and crashing a render
+    (issue #370). ``value`` is deliberately a union of every shape the six checks and the
+    runner's error paths emit: a bare bool (MFA), a ``{str: int}`` counts dict (all the
+    repo-level checks), or a plain string (runner-level failure messages).
+    """
+
+    id: str
+    title: str
+    severity: Literal["high", "medium", "low"]
+    remediation: str
+    status: Literal["pass", "fail", "error", "not_applicable"]
+    value: bool | str | dict[str, int] | None = None
+
+
 class AnalyticsResponse(BaseModel):
     owner: str
     score: int
     total_checks: int
     failed_checks: int
     repo_count: int
-    checks: list[dict]
+    checks: list[CheckResult]
 
 
 class ScanHistoryEntry(BaseModel):

--- a/apps/ui/app/error.tsx
+++ b/apps/ui/app/error.tsx
@@ -6,14 +6,22 @@ import { Button } from "@/components/ui/button"
 // root layout so a crash (e.g. a response-shape mismatch) shows a recoverable fallback
 // instead of a blank white screen (issue #370). Not a substitute for TanStack Query's own
 // isError handling at the widget level -- this only fires for errors during render itself.
+//
+// We deliberately don't render error.message: in a production build Next.js replaces it
+// with a long generic disclaimer for Server Component errors, and client crashes surface
+// raw internals ("Cannot read properties of undefined..."). Neither is useful to a user.
+// error.digest (when present) is the reference a maintainer can grep the server logs for.
 export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <div className="min-h-[60vh] flex items-center justify-center px-4">
       <div className="card max-w-md w-full px-6 py-8 flex flex-col items-center gap-3 text-center">
         <p className="text-sm font-medium text-foreground">Something went wrong</p>
         <p className="text-sm text-muted-foreground">
-          {error.message || "An unexpected error occurred while rendering this page."}
+          An unexpected error occurred while rendering this page. Try again, or reload if it persists.
         </p>
+        {error.digest && (
+          <p className="text-xs text-muted-foreground/70 font-mono">Reference: {error.digest}</p>
+        )}
         <Button size="sm" variant="outline" onClick={reset} className="mt-2">
           Try again
         </Button>

--- a/apps/ui/app/error.tsx
+++ b/apps/ui/app/error.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+// Next.js App Router error boundary -- catches any uncaught render-time error below the
+// root layout so a crash (e.g. a response-shape mismatch) shows a recoverable fallback
+// instead of a blank white screen (issue #370). Not a substitute for TanStack Query's own
+// isError handling at the widget level -- this only fires for errors during render itself.
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="card max-w-md w-full px-6 py-8 flex flex-col items-center gap-3 text-center">
+        <p className="text-sm font-medium text-foreground">Something went wrong</p>
+        <p className="text-sm text-muted-foreground">
+          {error.message || "An unexpected error occurred while rendering this page."}
+        </p>
+        <Button size="sm" variant="outline" onClick={reset} className="mt-2">
+          Try again
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/ui/app/global-error.tsx
+++ b/apps/ui/app/global-error.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+// Last-resort error boundary for issue #370. A Next.js App Router `error.tsx` boundary
+// wraps the *page* below the root layout but NOT the root `layout.tsx` / `template.tsx`
+// themselves -- if the layout throws during render, `error.tsx` can't catch it and the
+// user is back to a blank white screen. `global-error.tsx` is the only boundary that
+// covers a root-layout crash; when it fires it *replaces* the root layout, so it must
+// render its own `<html>` / `<body>`, and it does not inherit `globals.css`, fonts, or
+// providers -- hence the inline styles (a broken layout is exactly when a dark ground and
+// legible text matter most).
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "1rem",
+          background: "#0a0a0b",
+          color: "#e5e5e5",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
+        }}
+      >
+        <div style={{ maxWidth: "28rem", width: "100%", textAlign: "center" }}>
+          <p style={{ fontSize: "0.875rem", fontWeight: 500, margin: "0 0 0.5rem" }}>
+            Something went wrong
+          </p>
+          <p style={{ fontSize: "0.875rem", color: "#a1a1aa", margin: "0 0 1rem" }}>
+            The app failed to load. Try again, or reload the page if it persists.
+          </p>
+          {error.digest && (
+            <p
+              style={{
+                fontSize: "0.75rem",
+                color: "#71717a",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                margin: "0 0 1rem",
+              }}
+            >
+              Reference: {error.digest}
+            </p>
+          )}
+          <button
+            onClick={reset}
+            style={{
+              fontSize: "0.8125rem",
+              padding: "0.375rem 0.875rem",
+              borderRadius: "0.375rem",
+              border: "1px solid #3f3f46",
+              background: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/apps/ui/tests/components/error-page.test.tsx
+++ b/apps/ui/tests/components/error-page.test.tsx
@@ -8,19 +8,23 @@ describe("app/error.tsx (root error boundary)", () => {
     cleanup();
   });
 
-  it("renders the fallback heading and the error message", () => {
-    render(<ErrorPage error={new Error("boom while rendering")} reset={vi.fn()} />);
+  it("renders the fallback heading and generic copy (never the raw error message)", () => {
+    render(<ErrorPage error={new Error("Cannot read properties of undefined")} reset={vi.fn()} />);
 
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-    expect(screen.getByText("boom while rendering")).toBeInTheDocument();
+    expect(
+      screen.getByText(/An unexpected error occurred while rendering this page/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Cannot read properties/)).not.toBeInTheDocument();
   });
 
-  it("shows generic copy when the error has no message", () => {
-    render(<ErrorPage error={new Error("")} reset={vi.fn()} />);
+  it("shows the digest as a reference when present, and omits it otherwise", () => {
+    const withDigest = Object.assign(new Error("x"), { digest: "abc123" });
+    const { rerender } = render(<ErrorPage error={withDigest} reset={vi.fn()} />);
+    expect(screen.getByText("Reference: abc123")).toBeInTheDocument();
 
-    expect(
-      screen.getByText("An unexpected error occurred while rendering this page."),
-    ).toBeInTheDocument();
+    rerender(<ErrorPage error={new Error("x")} reset={vi.fn()} />);
+    expect(screen.queryByText(/Reference:/)).not.toBeInTheDocument();
   });
 
   it("calls reset when 'Try again' is clicked", () => {

--- a/apps/ui/tests/components/error-page.test.tsx
+++ b/apps/ui/tests/components/error-page.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import ErrorPage from "@/app/error";
+
+describe("app/error.tsx (root error boundary)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the fallback heading and the error message", () => {
+    render(<ErrorPage error={new Error("boom while rendering")} reset={vi.fn()} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("boom while rendering")).toBeInTheDocument();
+  });
+
+  it("shows generic copy when the error has no message", () => {
+    render(<ErrorPage error={new Error("")} reset={vi.fn()} />);
+
+    expect(
+      screen.getByText("An unexpected error occurred while rendering this page."),
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset when 'Try again' is clicked", () => {
+    const reset = vi.fn();
+    render(<ErrorPage error={new Error("boom")} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/tests/components/global-error-page.test.tsx
+++ b/apps/ui/tests/components/global-error-page.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import GlobalError from "@/app/global-error";
+
+// global-error.tsx renders its own <html>/<body> (it replaces the root layout). React
+// warns about that nesting under jsdom's container div; it's expected here, so silence it
+// so a real warning elsewhere still stands out.
+const originalError = console.error;
+beforeAll(() => {
+  vi.spyOn(console, "error").mockImplementation((...args) => {
+    const msg = String(args[0] ?? "");
+    if (msg.includes("<html>") || msg.includes("<body>") || msg.includes("cannot be a child")) return;
+    originalError(...args);
+  });
+});
+
+describe("app/global-error.tsx (root-layout error boundary)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the fallback heading and generic copy (never the raw error message)", () => {
+    render(<GlobalError error={new Error("layout blew up: undefined is not a function")} reset={vi.fn()} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText(/The app failed to load/)).toBeInTheDocument();
+    expect(screen.queryByText(/undefined is not a function/)).not.toBeInTheDocument();
+  });
+
+  it("shows the digest as a reference when present, and omits it otherwise", () => {
+    const withDigest = Object.assign(new Error("x"), { digest: "deadbeef" });
+    const { rerender } = render(<GlobalError error={withDigest} reset={vi.fn()} />);
+    expect(screen.getByText("Reference: deadbeef")).toBeInTheDocument();
+
+    rerender(<GlobalError error={new Error("x")} reset={vi.fn()} />);
+    expect(screen.queryByText(/Reference:/)).not.toBeInTheDocument();
+  });
+
+  it("calls reset when 'Try again' is clicked", () => {
+    const reset = vi.fn();
+    render(<GlobalError error={new Error("boom")} reset={reset} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #370.

## What changed and why

No `error.tsx` / `loading.tsx` existed anywhere under `apps/ui/app/` and no React error
boundary existed anywhere in `apps/ui`, so an uncaught render-time error on any page (e.g. a
response-shape mismatch causing a `TypeError` on `undefined`) produced a blank white screen
instead of a graceful fallback.

### 1. Root error boundary (`apps/ui/app/error.tsx`)
A single root-level error boundary following the Next.js App Router convention — a "Something
went wrong" card showing `error.message` (or generic copy when empty) and a **Try again**
button wired to `reset()`. This is defense-in-depth: it only fires for errors thrown *during
render*, not for TanStack Query `isError` states, which pages already handle at the widget level.

### 2. Test for the boundary (`apps/ui/tests/components/error-page.test.tsx`)
Renders `<ErrorPage>` directly with stub `error`/`reset` props (no provider needed) and covers:
the heading + error message, the empty-message fallback copy, and that clicking **Try again**
invokes `reset()` exactly once. Needed to clear CI's 90% diff-coverage gate on the new file.

### 3. Typed `AnalyticsResponse.checks` (`apps/api/src/schemas/analytics.py`)
Issue #370's second suggestion. `checks: list[dict]` is now `checks: list[CheckResult]`, a
Pydantic model (`id`, `title`, `severity` / `status` as `Literal`s, `value: bool | str |
dict[str, int] | None` — every shape the six checks and the runner's error paths emit). A
future shape drift in `packages/checks` now fails fast at the API boundary with a validation
error instead of silently reaching the UI and crashing a render.

**No migration. No runtime behaviour change** — the runner's existing plain dicts still
validate against the new model; this only adds fail-fast validation at the response boundary.

## Verification
- `cd apps/ui && bun run test && bun run typecheck && bun run lint` — pass
- `pytest -q apps/api/tests/test_analytics*.py` — pass (30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-friendly error screens for unexpected application and root-layout failures.
  * Provides a **Try again** option to recover without leaving the page.
  * Displays an optional reference code for troubleshooting without exposing raw error details.

* **Bug Fixes**
  * Improved analytics reliability by validating security-check results before displaying them.

* **Tests**
  * Added coverage for error handling, reference display, message privacy, and recovery actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (2026-09-02):** added `apps/ui/app/global-error.tsx` (CodeRabbit) — a root `error.tsx` cannot catch a crash in the root `layout.tsx` itself, which is the same white-screen failure mode #370 targets. `global-error.tsx` is the only boundary that covers it; it replaces the layout when it fires, so it renders its own `<html>`/`<body>` with inline styles. Covered by `global-error-page.test.tsx`.
