### PR TITLE
fix(ui): auto-select the sole scope (issue #371)

### DIFF
--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -204,12 +204,16 @@ export function AppSidebar() {
   // the request when both are mounted. Only route the "Invite members" link at an
   // org where the user is actually an admin — mirrors the /collaborators fallback
   // logic (prefer the active org scope, else the first admin org, else /settings).
-  const { data: memberships = [], isLoading: membershipsLoading } = useQuery<MyOrgMembership[]>({
+  const {
+    data: memberships = [],
+    isLoading: membershipsLoading,
+    isSuccess: membershipsReady,
+  } = useQuery<MyOrgMembership[]>({
     queryKey: ["my-orgs"],
     queryFn: () => api.orgs.mine(),
   })
 
-  const { data: installs = [], isLoading: installsLoading } = useQuery<InstallationMeta[]>({
+  const { data: installs = [], isSuccess: installsReady } = useQuery<InstallationMeta[]>({
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
@@ -238,15 +242,20 @@ export function AppSidebar() {
   // set. Only fires when nothing is persisted (`scope === null`); an explicit pick from the
   // profile menu always persists, so it's never overridden, and a multi-scope user can
   // still switch freely. `useRef` keeps it to a single attempt.
+  //
+  // Gate on isSuccess (not just !isLoading): a failed query also clears isLoading but
+  // leaves the `= []` fallback in place, which could make a partial/empty result look like
+  // "exactly one scope" and persist it. If a query genuinely errors we simply don't
+  // auto-select and the user picks manually -- same as the pre-#371 baseline, no regression.
   const autoSelectedScope = useRef(false)
   useEffect(() => {
     if (autoSelectedScope.current || scope !== null) return
-    if (membershipsLoading || installsLoading) return
+    if (!membershipsReady || !installsReady) return
     if (scopeOptions.length >= 1) {
       autoSelectedScope.current = true
       setScope(scopeOptions[0].scope)
     }
-  }, [scope, membershipsLoading, installsLoading, scopeOptions, setScope])
+  }, [scope, membershipsReady, installsReady, scopeOptions, setScope])
 
   // Profile identity row reflects the active scope, falling back to real
   // membership/installation data if nothing has been picked yet.

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -231,17 +231,18 @@ export function AppSidebar() {
     [personalInstall, memberships],
   )
 
-  // Issue #371: when a user has exactly one place to look (one org membership, or just
-  // their personal install), auto-select it as the real active scope once the data loads
-  // -- otherwise the sidebar cosmetically shows that org under the avatar while every page
-  // still says "no account selected yet" because `scope` was never set. Only fires when
-  // nothing is persisted (`scope === null`); an explicit pick always persists, so a
-  // multi-org user's choice is never overridden. `useRef` keeps it to a single attempt.
+  // Issue #371: when nothing is persisted yet, auto-select the first available scope (the
+  // personal install if there is one, else the first org membership) as the real active
+  // scope once the data loads -- otherwise the sidebar cosmetically shows an org under the
+  // avatar while every page still says "no account selected yet" because `scope` was never
+  // set. Only fires when nothing is persisted (`scope === null`); an explicit pick from the
+  // profile menu always persists, so it's never overridden, and a multi-scope user can
+  // still switch freely. `useRef` keeps it to a single attempt.
   const autoSelectedScope = useRef(false)
   useEffect(() => {
     if (autoSelectedScope.current || scope !== null) return
     if (membershipsLoading || installsLoading) return
-    if (scopeOptions.length === 1) {
+    if (scopeOptions.length >= 1) {
       autoSelectedScope.current = true
       setScope(scopeOptions[0].scope)
     }

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { usePathname, useRouter } from "next/navigation"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { GearSix, Check, SignOut, UserPlus, ArrowSquareOut, User } from "@phosphor-icons/react"
@@ -209,7 +209,7 @@ export function AppSidebar() {
     queryFn: () => api.orgs.mine(),
   })
 
-  const { data: installs = [] } = useQuery<InstallationMeta[]>({
+  const { data: installs = [], isLoading: installsLoading } = useQuery<InstallationMeta[]>({
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
@@ -217,16 +217,35 @@ export function AppSidebar() {
   const slug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG
   const personalInstallUrl = !personalInstall && slug ? `https://github.com/apps/${slug}/installations/new` : null
 
-  const scopeOptions: ScopeOption[] = [
-    ...(personalInstall
-      ? [{ scope: { kind: "personal", login: personalInstall.account_login } as ActiveScope, label: personalInstall.account_login, sublabel: "Personal account" }]
-      : []),
-    ...memberships.map((m) => ({
-      scope: { kind: "org", login: m.org_login } as ActiveScope,
-      label: m.org_login,
-      sublabel: `Organization · ${m.role}`,
-    })),
-  ]
+  const scopeOptions: ScopeOption[] = useMemo(
+    () => [
+      ...(personalInstall
+        ? [{ scope: { kind: "personal", login: personalInstall.account_login } as ActiveScope, label: personalInstall.account_login, sublabel: "Personal account" }]
+        : []),
+      ...memberships.map((m) => ({
+        scope: { kind: "org", login: m.org_login } as ActiveScope,
+        label: m.org_login,
+        sublabel: `Organization · ${m.role}`,
+      })),
+    ],
+    [personalInstall, memberships],
+  )
+
+  // Issue #371: when a user has exactly one place to look (one org membership, or just
+  // their personal install), auto-select it as the real active scope once the data loads
+  // -- otherwise the sidebar cosmetically shows that org under the avatar while every page
+  // still says "no account selected yet" because `scope` was never set. Only fires when
+  // nothing is persisted (`scope === null`); an explicit pick always persists, so a
+  // multi-org user's choice is never overridden. `useRef` keeps it to a single attempt.
+  const autoSelectedScope = useRef(false)
+  useEffect(() => {
+    if (autoSelectedScope.current || scope !== null) return
+    if (membershipsLoading || installsLoading) return
+    if (scopeOptions.length === 1) {
+      autoSelectedScope.current = true
+      setScope(scopeOptions[0].scope)
+    }
+  }, [scope, membershipsLoading, installsLoading, scopeOptions, setScope])
 
   // Profile identity row reflects the active scope, falling back to real
   // membership/installation data if nothing has been picked yet.

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -527,7 +527,7 @@ describe("AppSidebar scope switcher", () => {
     );
   });
 
-  it("does not auto-select when the user has more than one candidate scope", async () => {
+  it("auto-selects the first scope for a multi-org user, so no page shows the empty state", async () => {
     orgMemberships = [
       { org_login: "acme", role: "admin" },
       { org_login: "globex", role: "member" },
@@ -535,9 +535,26 @@ describe("AppSidebar scope switcher", () => {
     installations = [];
     renderSidebar();
 
-    // give the effect a chance to (not) fire
+    await waitFor(() =>
+      expect(localStorage.getItem("active_scope")).toBe(
+        JSON.stringify({ kind: "org", login: "acme" }),
+      ),
+    );
+  });
+
+  it("does not override an already-persisted explicit scope choice", async () => {
+    localStorage.setItem("active_scope", JSON.stringify({ kind: "org", login: "globex" }));
+    orgMemberships = [
+      { org_login: "acme", role: "admin" },
+      { org_login: "globex", role: "member" },
+    ];
+    installations = [];
+    renderSidebar();
+
     await screen.findByRole("button", { name: /user/i });
     await new Promise((r) => setTimeout(r, 50));
-    expect(localStorage.getItem("active_scope")).toBeNull();
+    expect(localStorage.getItem("active_scope")).toBe(
+      JSON.stringify({ kind: "org", login: "globex" }),
+    );
   });
 });

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -512,4 +512,32 @@ describe("AppSidebar scope switcher", () => {
     const connectLink = await screen.findByRole("link", { name: /connect your personal github account/i });
     expect(connectLink).toHaveAttribute("href", "https://github.com/apps/clevis/installations/new");
   });
+
+  // Issue #371
+  it("auto-selects the sole org membership as the active scope when nothing is persisted", async () => {
+    orgMemberships = [{ org_login: "acme", role: "admin" }];
+    installations = [];
+    expect(localStorage.getItem("active_scope")).toBeNull();
+    renderSidebar();
+
+    await waitFor(() =>
+      expect(localStorage.getItem("active_scope")).toBe(
+        JSON.stringify({ kind: "org", login: "acme" }),
+      ),
+    );
+  });
+
+  it("does not auto-select when the user has more than one candidate scope", async () => {
+    orgMemberships = [
+      { org_login: "acme", role: "admin" },
+      { org_login: "globex", role: "member" },
+    ];
+    installations = [];
+    renderSidebar();
+
+    // give the effect a chance to (not) fire
+    await screen.findByRole("button", { name: /user/i });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(localStorage.getItem("active_scope")).toBeNull();
+  });
 });

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -551,10 +551,36 @@ describe("AppSidebar scope switcher", () => {
     installations = [];
     renderSidebar();
 
-    await screen.findByRole("button", { name: /user/i });
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait until the queries have resolved and rendered their scope options (both come from
+    // the same /me/orgs response), so the auto-select effect has definitely had its chance.
+    fireEvent.click(screen.getByRole("button", { name: /user/i }));
+    await waitFor(() => expect(screen.getAllByText(/globex/i).length).toBeGreaterThan(0));
     expect(localStorage.getItem("active_scope")).toBe(
       JSON.stringify({ kind: "org", login: "globex" }),
     );
+  });
+
+  it("does not auto-select when the org query fails", async () => {
+    orgMemberships = [{ org_login: "acme", role: "admin" }];
+    installations = [];
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/auth/me")) {
+        return Promise.resolve(
+          jsonResponse({ id: 1, email: "user@example.com", name: "User", is_workspace_admin: false }),
+        );
+      }
+      if (url.endsWith("/me/orgs")) return Promise.resolve(jsonResponse({ detail: "boom" }, 500));
+      if (url.endsWith("/me/installations")) return Promise.resolve(jsonResponse([]));
+      if (url.endsWith("/tokens/resolve")) return Promise.resolve(jsonResponse({}, 404));
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    renderSidebar();
+
+    await screen.findByRole("button", { name: /user/i });
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining("/me/orgs"), expect.anything()),
+    );
+    expect(localStorage.getItem("active_scope")).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #371.

## The problem

On the Activity page (and Pull Requests / Releases / Repositories / Health & Security), a user
whose active scope had never been set saw a stuck **"No account selected yet — this page has
nothing to query"** even though the sidebar showed an org name right under their avatar.

Root cause: `app-sidebar.tsx`'s `displayLogin` cosmetically falls back to `memberships[0].org_login`
for the label under the avatar, but the shared `useActiveScope()` `scope` — which every page
gates its queries on — was only ever set by an explicit pick from the profile menu. So the
sidebar said "you're in acme" while every page said "nothing selected".

## What changed and why

`AppSidebar` now sets the active scope **once**, after `/me/orgs` and `/me/installations`
resolve, when nothing is already persisted (`scope === null`) and at least one candidate scope
exists — picking `scopeOptions[0]` (the personal install if there is one, else the first org
membership).

An explicit pick from the profile menu always persists to `localStorage`, so `scope` is never
`null` for that user and their choice is never overridden; a multi-scope user can still switch
freely at any time. A `useRef` keeps the auto-select to a single attempt per mount.

`scopeOptions` is wrapped in `useMemo` since it feeds the new effect's dependency array.

### Review note
The first cut (commit `4da554b`) only auto-selected when there was **exactly one** candidate,
which left the same stuck empty state for anyone with 2+ memberships. Broadened in `873a242`
to select the first scope in that case too — landing on a working dashboard the user can then
switch from beats a dead-end empty state.

## Verification
- `bunx vitest run tests/components/app-sidebar.test.tsx` — 28 pass, incl. "auto-selects the
  sole membership", "auto-selects the first scope for a multi-org user", and "does not override
  an already-persisted explicit scope choice".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope selection when switching between personal and organization contexts.
  * Preserved previously selected scopes instead of overriding them.
  * Prevented automatic selection when organization data fails to load.

* **Tests**
  * Added coverage for automatic selection, persisted choices, and failed data requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->