### PR TITLE
fix(ui): cap vitest worker pool on local runs to stop OOM flake

### DIFF
--- a/apps/ui/vitest.config.ts
+++ b/apps/ui/vitest.config.ts
@@ -23,6 +23,15 @@ export default defineConfig({
     // file each run, not a real bug in any one of them). 20s gives headroom without masking a
     // genuine hang; layout.test.tsx keeps its own higher override for its unusually slow import.
     testTimeout: 20000,
+    // Vitest's default is one worker fork per CPU core. On a memory-constrained dev machine
+    // (the pre-push hook is the common victim) ~45 concurrent jsdom + React environments
+    // exhaust RAM -> the OS swaps -> module-import times blow up into the minutes -> tinypool
+    // worker RPCs time out, which Vitest reports as "N errors" with zero test failures, a
+    // different set every run. Capping the pool bounds peak memory and makes local runs
+    // deterministic. CI runners are dedicated and adequately provisioned, so they keep full
+    // parallelism for speed. Raise the local cap with VITEST_MAX_WORKERS=<n> (Vitest honors
+    // that env var natively) if your machine has the headroom.
+    ...(process.env.CI ? {} : { maxWorkers: 3, minWorkers: 1 }),
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
## Problem

The `pre-push` hook (`bun run test` in `apps/ui`) intermittently fails with output like:

```
Test Files  34 passed (34)
     Tests  216 passed (216)
    Errors  11 errors
  Duration  329.96s (... import 2488.53s ...)
```

Zero test failures, but N "errors" and an absurd cumulative import time — a different
set of files each run. It is not a real test regression; it's resource exhaustion.

## Root cause

Vitest's default pool spawns **one worker fork per CPU core**. On a memory-constrained
machine (e.g. 12 cores / 8 GB RAM), ~45 concurrent files each booting a full jsdom +
React environment exhaust available memory. The OS starts swapping, module imports that
normally take ~2s stretch into minutes, and tinypool's worker RPC calls time out —
which Vitest reports as `Errors` (not failed tests). The flake has been pushing
contributors toward `git push --no-verify`.

A previous change (`56b3278`, raise `testTimeout` to 20s) treated the symptom — the
individual tests aren't slow, the machine is thrashing.

## Change

`apps/ui/vitest.config.ts`: cap the worker pool at **3** for non-CI runs
(`...(process.env.CI ? {} : { maxWorkers: 3, minWorkers: 1 })`). This bounds peak
memory so local runs are deterministic. CI runners are dedicated and adequately
provisioned, so they keep full parallelism for speed — the guard is `process.env.CI`,
which GitHub Actions sets. Local override: `VITEST_MAX_WORKERS=<n>` (Vitest honours
that env var natively).

No test or source changes. No migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved local test execution stability by limiting test parallelism outside CI environments.
  * CI test runs retain full parallel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->