### PR TITLE
refactor(ui): move the PR-by-author view from Activity into /pulls

### DIFF
--- a/apps/ui/app/activity/page.tsx
+++ b/apps/ui/app/activity/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { ActivityList } from "@/components/activity-list"
@@ -8,15 +9,14 @@ import { EventFeed } from "@/components/event-feed"
 import { HeatmapCalendar } from "@/components/charts/heatmap-calendar"
 import { SectionError } from "@/components/section-error"
 import { EmptyStateNoAccount } from "@/components/empty-state"
+import { ArrowRight } from "@phosphor-icons/react"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
 import { api } from "@/lib/api/client"
 import { useActiveScope } from "@/lib/active-scope"
-import type { PullSummary } from "@/lib/api/types"
 
 const EVENTS_REFRESH_SECONDS = 30
 const HEATMAP_COLOR_SCALE = [CHART_COLORS.grid, "#1d4ed8", "#3b82f6", "#60a5fa", "#93c5fd"]
-const MAX_REPOS_FOR_PR_BOARD = 10
 
 // Isolated into its own component so the 1s tick only re-renders this small chip,
 // not the whole page (and the feed/job lists below it).
@@ -37,8 +37,6 @@ function RefreshCountdown({ resetKey, seconds }: { resetKey: number; seconds: nu
   return <span className="stat-chip">refreshes in {remaining}s</span>
 }
 
-type PrBoardTab = "feed" | "board"
-
 export default function ActivityPage() {
   // Marks all cockpit-sourced events as read so the sidebar's unread badge
   // clears once the user has actually looked at this page.
@@ -54,8 +52,6 @@ export default function ActivityPage() {
 
   const { scope } = useActiveScope()
   const org = scope?.login ?? ""
-
-  const [feedTab, setFeedTab] = useState<PrBoardTab>("feed")
 
   const resolveQuery = useQuery({
     queryKey: ["tokens.resolve", org],
@@ -111,108 +107,38 @@ export default function ActivityPage() {
     retry: false,
   })
 
-  const reposQuery = useQuery({
-    queryKey: ["repos.list", org],
-    queryFn: () => api.repos.list(org, token),
-    enabled: queriesEnabled && feedTab === "board",
-    retry: false,
-  })
-
-  const prBoardQuery = useQuery({
-    queryKey: ["repos.pulls.board", org, reposQuery.data?.repos.map((r) => r.name).join(",")],
-    queryFn: async () => {
-      const repoNames = (reposQuery.data?.repos ?? []).slice(0, MAX_REPOS_FOR_PR_BOARD).map((r) => r.name)
-      const results = await Promise.all(
-        repoNames.map((repo) =>
-          api.repos.pulls(org, org, repo, token).catch(() => ({ repository: repo, total: 0, pulls: [] })),
-        ),
-      )
-      return results.flatMap((r) => r.pulls)
-    },
-    enabled: queriesEnabled && feedTab === "board" && !!reposQuery.data,
-    retry: false,
-  })
-
-  const prsByAuthor = new Map<string, PullSummary[]>()
-  for (const pr of prBoardQuery.data ?? []) {
-    const author = pr.user ?? "unknown"
-    const existing = prsByAuthor.get(author)
-    if (existing) existing.push(pr)
-    else prsByAuthor.set(author, [pr])
-  }
-
   return (
     <>
       <PageHeader
         title="Activity"
         description="Recent GitHub activity and background jobs."
+        actions={
+          <Link
+            href="/pulls"
+            className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Open pull requests
+            <ArrowRight className="size-3.5" />
+          </Link>
+        }
       />
 
       <div className="grid gap-4 lg:grid-cols-3">
         <div className="lg:col-span-2 card">
           <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
-            <div className="flex items-center gap-1.5">
-              <button
-                onClick={() => setFeedTab("feed")}
-                aria-pressed={feedTab === "feed"}
-                className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
-                  feedTab === "feed"
-                    ? "border-border bg-elevated text-foreground"
-                    : "border-transparent text-muted-foreground hover:bg-elevated"
-                }`}
-              >
-                Activity Feed
-              </button>
-              <button
-                onClick={() => setFeedTab("board")}
-                aria-pressed={feedTab === "board"}
-                className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
-                  feedTab === "board"
-                    ? "border-border bg-elevated text-foreground"
-                    : "border-transparent text-muted-foreground hover:bg-elevated"
-                }`}
-              >
-                PR Board
-              </button>
-            </div>
-            {feedTab === "feed" && hasOrg && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
+            <span className="section-label">Activity Feed</span>
+            {hasOrg && <RefreshCountdown resetKey={lastAttemptAt} seconds={EVENTS_REFRESH_SECONDS} />}
           </div>
           {!hasOrg ? (
             <EmptyStateNoAccount bare />
-          ) : feedTab === "feed" && eventsQuery.isError ? (
+          ) : eventsQuery.isError ? (
             <SectionError
               message={eventsQuery.error instanceof Error ? eventsQuery.error.message : "Failed to load events."}
               onRetry={() => eventsQuery.refetch()}
               retrying={eventsQuery.isFetching}
             />
-          ) : feedTab === "feed" ? (
-            <EventFeed events={eventsQuery.data?.events ?? []} isLoading={eventsQuery.isLoading} />
-          ) : prBoardQuery.isLoading || reposQuery.isLoading ? (
-            <p className="px-4 py-8 text-sm text-muted-foreground">Loading…</p>
-          ) : prsByAuthor.size === 0 ? (
-            <p className="px-4 py-8 text-sm text-muted-foreground">No open pull requests</p>
           ) : (
-            <div className="p-4 grid gap-3 sm:grid-cols-2">
-              {[...prsByAuthor.entries()].map(([author, prs]) => (
-                <div key={author} className="border border-border/60 rounded-md p-3">
-                  <p className="text-xs font-medium text-foreground mb-2">{author}</p>
-                  <ul className="flex flex-col gap-1.5">
-                    {prs.map((pr) => (
-                      <li key={pr.html_url}>
-                        <a
-                          href={pr.html_url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-xs text-muted-foreground hover:text-foreground transition-colors truncate block"
-                        >
-                          #{pr.number} {pr.title}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
+            <EventFeed events={eventsQuery.data?.events ?? []} isLoading={eventsQuery.isLoading} />
           )}
         </div>
 

--- a/apps/ui/app/pulls/page.tsx
+++ b/apps/ui/app/pulls/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -21,10 +22,16 @@ interface PullRow extends PullSummary {
   repo: string
 }
 
+type GroupBy = "repo" | "author"
+
 export default function PullRequestsPage() {
   const { scope } = useActiveScope()
   const org = scope?.login ?? ""
   const hasOrg = org.trim().length > 0
+
+  // Activity's old "PR Board" tab was the same open-PRs data grouped by author (issue
+  // #284); it's a view toggle here now, and that tab is gone from Activity.
+  const [groupBy, setGroupBy] = useState<GroupBy>("repo")
 
   const resolveQuery = useQuery({
     queryKey: ["tokens.resolve", org],
@@ -72,13 +79,40 @@ export default function PullRequestsPage() {
   const pulls = pullsQuery.data ?? []
   const isLoading = reposQuery.isLoading || (reposQuery.isSuccess && pullsQuery.isLoading)
 
+  const byAuthor = new Map<string, PullRow[]>()
+  for (const p of pulls) {
+    const author = p.user ?? "unknown"
+    const existing = byAuthor.get(author)
+    if (existing) existing.push(p)
+    else byAuthor.set(author, [p])
+  }
+
   return (
     <>
       <PageHeader title="Pull Requests" description="Open PRs across your organization." />
       <div className="card">
-        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-3 flex-wrap">
           <span className="section-title">Open Pull Requests</span>
-          {pulls.length > 0 && <span className="stat-chip">{pulls.length} total</span>}
+          <div className="flex items-center gap-3">
+            {pulls.length > 0 && <span className="stat-chip">{pulls.length} total</span>}
+            <div className="flex items-center gap-1.5" role="group" aria-label="Group pull requests by">
+              {(["repo", "author"] as const).map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => setGroupBy(g)}
+                  aria-pressed={groupBy === g}
+                  className={`text-xs font-medium px-2.5 py-1 rounded-md border transition-colors ${
+                    groupBy === g
+                      ? "border-border bg-elevated text-foreground"
+                      : "border-transparent text-muted-foreground hover:bg-elevated"
+                  }`}
+                >
+                  by {g}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
         {!hasOrg ? (
           <EmptyStateNoAccount bare />
@@ -96,6 +130,30 @@ export default function PullRequestsPage() {
           </div>
         ) : pulls.length === 0 ? (
           <p className="px-4 py-8 text-sm text-muted-foreground">No open pull requests</p>
+        ) : groupBy === "author" ? (
+          <div className="p-4 grid gap-3 sm:grid-cols-2">
+            {[...byAuthor.entries()].map(([author, authorPulls]) => (
+              <div key={author} className="border border-border/60 rounded-md p-3">
+                <p className="text-xs font-medium text-foreground mb-2">
+                  {author} <span className="text-muted-foreground font-normal">· {authorPulls.length}</span>
+                </p>
+                <ul className="flex flex-col gap-1.5">
+                  {authorPulls.map((p) => (
+                    <li key={`${p.repo}-${p.number}`}>
+                      <a
+                        href={p.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-muted-foreground hover:text-foreground transition-colors truncate block"
+                      >
+                        <span className="text-foreground/60">{p.repo}</span> #{p.number} {p.title}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-xs">

--- a/apps/ui/tests/components/activity-page.test.tsx
+++ b/apps/ui/tests/components/activity-page.test.tsx
@@ -220,39 +220,19 @@ describe("ActivityPage", () => {
     expect(await screen.findByText("(estimated)")).toBeInTheDocument();
   });
 
-  it("groups open PRs by author under the PR Board tab", async () => {
+  // Issue #284: the "PR Board" tab is gone from Activity -- that view (open PRs grouped
+  // by author) is now a toggle on /pulls. Activity just links there.
+  it("has no PR Board tab and links to the Pull Requests page instead", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
     githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
-    reposListMock.mockResolvedValue({ org: "acme", total: 1, repos: [{ name: "api" }] });
-    reposPullsMock.mockResolvedValue({
-      repository: "acme/api",
-      total: 1,
-      pulls: [{ number: 5, title: "Fix bug", user: "alice", created_at: new Date().toISOString(), html_url: "https://github.com/acme/api/pull/5" }],
-    });
 
     renderPage();
 
-    fireEvent.click(await screen.findByRole("button", { name: "PR Board" }));
-
-    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "api", "ghp_test"));
-    expect(await screen.findByText("alice")).toBeInTheDocument();
-    expect(screen.getByText("#5 Fix bug")).toBeInTheDocument();
-  });
-
-  it("shows an empty state under the PR Board tab when there are no open pull requests", async () => {
-    localStorage.setItem("default_org", "acme");
-    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
-    githubEventsMock.mockResolvedValue({ org: "acme", events: [] });
-    reposListMock.mockResolvedValue({ org: "acme", total: 1, repos: [{ name: "api" }] });
-    reposPullsMock.mockResolvedValue({ repository: "acme/api", total: 0, pulls: [] });
-
-    renderPage();
-
-    fireEvent.click(await screen.findByRole("button", { name: "PR Board" }));
-
-    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "api", "ghp_test"));
-    expect(await screen.findByText("No open pull requests")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "PR Board" })).not.toBeInTheDocument();
+    const link = await screen.findByRole("link", { name: /open pull requests/i });
+    expect(link).toHaveAttribute("href", "/pulls");
+    expect(reposPullsMock).not.toHaveBeenCalled();
   });
 
   it("marks a pre-release in the release timeline", async () => {

--- a/apps/ui/tests/components/pulls-page.test.tsx
+++ b/apps/ui/tests/components/pulls-page.test.tsx
@@ -157,6 +157,39 @@ describe("PullRequestsPage", () => {
     expect(await screen.findByText("Failed to load repositories.")).toBeInTheDocument();
   });
 
+  it("regroups the open PRs by author when the 'by author' toggle is selected (issue #284)", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [{ name: "api", full_name: "acme/api", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/api" }],
+    });
+    reposPullsMock.mockResolvedValue({
+      repository: "acme/api",
+      total: 2,
+      pulls: [
+        pull({ number: 1, title: "alice one", user: "alice", html_url: "https://github.com/acme/api/pull/1" }),
+        pull({ number: 2, title: "bob one", user: "bob", html_url: "https://github.com/acme/api/pull/2" }),
+      ],
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/2 total/)).toBeInTheDocument());
+    // repo view: a real table
+    expect(screen.getAllByRole("row").length).toBeGreaterThan(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "by author" }));
+
+    await waitFor(() => expect(screen.queryByRole("table")).not.toBeInTheDocument());
+    // Author-grouped card headings: the author login is its own text node ("alice",
+    // "bob"), with the per-author count in a sibling span.
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText(/#1 alice one/)).toBeInTheDocument();
+    expect(screen.getByText(/#2 bob one/)).toBeInTheDocument();
+  });
+
   it("falls back to 'unknown' when a pull request has no author", async () => {
     localStorage.setItem("default_org", "acme");
     reposListMock.mockResolvedValue({


### PR DESCRIPTION
Fixes #284.

## The problem

Two places rendered "open pull requests across the org", and they had drifted apart:

| | Activity → "PR Board" tab | `/pulls` page |
|---|---|---|
| repo coverage | first **10** repos only (`MAX_REPOS_FOR_PR_BOARD`) | all repos, fanned out in batches of 10 |
| grouping | by author, as cards | flat table, newest first |
| discoverability | a secondary tab on a page about event feeds | the page literally named "Pull Requests" |

Same data, two half-answers, and the Activity tab silently dropped PRs for any org
with more than 10 repos.

## What changed and why

**`/pulls` gets a `by repo | by author` toggle.** `by repo` is the default and is the
existing table, unchanged. `by author` groups the *same already-fetched* pull list
(the full batched fan-out over every repo) into per-author cards — the view the old PR
Board tab offered, minus its 10-repo cap. It's a `useState` toggle, no new query.

**Activity drops the PR Board tab.** Removed `feedTab` state and the tab buttons, the
board-only `reposQuery` / `prBoardQuery`, `prsByAuthor`, and `MAX_REPOS_FOR_PR_BOARD`.
Activity is the event feed again; its header gets an "Open pull requests →" link to
`/pulls` so the path there is obvious.

## Tests
- `pulls-page.test.tsx`: new case — clicking "by author" replaces the table with
  per-author groupings of the same PRs.
- `activity-page.test.tsx`: the two "PR Board tab" tests are replaced by one asserting
  the tab no longer exists and the header links to `/pulls`.

No API changes, no migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open pull requests” link to the Activity page.
  * Added repository and author grouping options on the Pull Requests page.
  * Added author-grouped pull request cards with links to individual pull requests.

* **Changes**
  * Removed the PR Board tab from the Activity page; the Activity Feed is now shown directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->