### PR TITLE
feat(ui): make the Overview activity card's role legible (#285)

### DIFF
--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -255,9 +255,9 @@ export default function OverviewPage() {
           </div>
         </div>
 
-        <div className="card">
+        <div className="card flex flex-col">
           <div className="px-4 py-3 border-b border-border flex items-center gap-2">
-            <span className="section-label">Recent Activity</span>
+            <span className="section-label">Recent Highlights</span>
             {cockpit?.recent_events_stale && (
               <span
                 className="text-[0.6875rem] text-warning"
@@ -272,6 +272,13 @@ export default function OverviewPage() {
             isLoading={cockpitQuery.isLoading}
             limit={5}
           />
+          <Link
+            href="/activity"
+            className="group mt-auto flex items-center justify-center gap-1 border-t border-border px-4 py-2.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View full activity feed
+            <ArrowRight className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5" />
+          </Link>
         </div>
       </div>
 

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -255,6 +255,19 @@ describe("OverviewPage cockpit", () => {
     expect(screen.getByText("pushed 3 commits to main")).toBeInTheDocument();
   });
 
+  it("titles the card 'Recent Highlights' and links to the full activity feed (issue #285)", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue({ ...EMPTY_COCKPIT });
+
+    renderPage();
+
+    expect(await screen.findByText("Recent Highlights")).toBeInTheDocument();
+    expect(screen.queryByText("Recent Activity")).not.toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /view full activity feed/i });
+    expect(link).toHaveAttribute("href", "/activity");
+  });
+
   it("hides the Needs Attention card when there are no at-risk repos", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });


### PR DESCRIPTION
Fixes #285.

## The problem

The Overview page's "Recent Activity" card and the `/activity` page look like the same
thing shown twice. They aren't:

| | Overview "Recent Activity" card | `/activity` page |
|---|---|---|
| source | cockpit endpoint's `recent_events` (curated, stored) | live `github.events` stream |
| scope | top 5, glance only | full feed + jobs + CI failures + releases + commit heatmap |
| refresh | with the rest of the cockpit query | polls every 30s |

But nothing on the card says so, so it reads as redundant.

## What changed

Minimal, per the issue discussion — this doesn't merge or re-source anything, it just
makes the card's role clear:

- Header: **"Recent Activity" → "Recent Highlights"** (a summary, not "the feed").
- New **"View full activity feed →"** link at the bottom of the card, to `/activity`,
  so the glance → full-feed relationship is explicit and one click away.

`overview-page.test.tsx` covers the new header text and the link target.

No API changes, no migration. See the issue thread for why the two feeds stay separate
sources.