### PR TITLE
fix(ui): document decorative avatar alt="" and lock it with tests (#280)

### DIFF
--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -194,6 +194,8 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
                     <tr key={m.login}>
                       <td className="px-4 py-2.5">
                         <div className="flex items-center gap-2">
+                          {/* Decorative: the member login is the adjacent link text, so an
+                              empty alt avoids a duplicate screen-reader announcement. */}
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img src={m.avatar_url} alt="" className="size-5 rounded-full" />
                           <a
@@ -245,6 +247,8 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
                     <tr key={c.login}>
                       <td className="px-4 py-2.5">
                         <div className="flex items-center gap-2">
+                          {/* Decorative: the collaborator login is the adjacent text, so an
+                              empty alt avoids a duplicate screen-reader announcement. */}
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img src={c.avatar_url} alt="" className="size-5 rounded-full" />
                           <span className="text-foreground/80">{c.login}</span>

--- a/apps/ui/components/event-feed.tsx
+++ b/apps/ui/components/event-feed.tsx
@@ -71,6 +71,8 @@ export function EventFeed({ events, isLoading }: EventFeedProps) {
               className="stagger-item px-4 py-3 flex items-start gap-3 hover:bg-elevated transition-colors duration-150 ease-(--ease-out)"
               style={{ animationDelay: `${Math.min(i, 6) * 45}ms` }}
             >
+              {/* Decorative: the actor login is rendered as adjacent visible text below,
+                  so an empty alt keeps screen readers from announcing the avatar twice. */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={event.actor_avatar} alt="" className="h-6 w-6 shrink-0 mt-0.5" />
               <div className="min-w-0 flex-1">

--- a/apps/ui/tests/components/event-feed.test.tsx
+++ b/apps/ui/tests/components/event-feed.test.tsx
@@ -37,6 +37,17 @@ describe("EventFeed", () => {
     expect(screen.getByText(/opened PR #42: Fix cache timeout/)).toBeInTheDocument();
   });
 
+  it("marks avatars as decorative while keeping the actor name as visible text", () => {
+    const { container } = render(<EventFeed events={events} isLoading={false} />);
+
+    const avatars = container.querySelectorAll("img");
+    expect(avatars).toHaveLength(2);
+    avatars.forEach((img) => expect(img).toHaveAttribute("alt", ""));
+    // The accessible identifier for each row is the adjacent login text, not the image.
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
   it("shows an empty state when there are no events", () => {
     render(<EventFeed events={[]} isLoading={false} />);
 

--- a/apps/ui/tests/components/org-members-avatars.test.tsx
+++ b/apps/ui/tests/components/org-members-avatars.test.tsx
@@ -2,10 +2,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+let searchParams = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
   useParams: () => ({ login: "acme" }),
   useRouter: () => ({ replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParams,
 }));
 
 const membersMock = vi.fn();
@@ -41,6 +43,7 @@ function renderPage() {
 
 describe("OrgMembersPage avatars", () => {
   beforeEach(() => {
+    searchParams = new URLSearchParams();
     membersMock.mockReset();
     outsideMock.mockReset();
     membersMock.mockResolvedValue({
@@ -64,6 +67,27 @@ describe("OrgMembersPage avatars", () => {
     const avatar = container.querySelector('img[src="https://avatars/octocat.png"]');
     expect(avatar).not.toBeNull();
     // Decorative image: the login link is the accessible label, so alt must stay empty.
+    expect(avatar).toHaveAttribute("alt", "");
+  });
+
+  it("renders outside-collaborator avatars as decorative with the login as visible text", async () => {
+    searchParams = new URLSearchParams("roster=outside");
+    outsideMock.mockResolvedValue({
+      org: "acme",
+      collaborators: [
+        { login: "ext-dev", avatar_url: "https://avatars/ext-dev.png", repos: ["acme/api"] },
+      ],
+      repos_scanned: 1,
+      repos_total: 1,
+    });
+
+    const { container } = renderPage();
+
+    await waitFor(() => expect(screen.getByText("ext-dev")).toBeInTheDocument());
+
+    const avatar = container.querySelector('img[src="https://avatars/ext-dev.png"]');
+    expect(avatar).not.toBeNull();
+    // Decorative image: the collaborator login is the adjacent text, so alt must stay empty.
     expect(avatar).toHaveAttribute("alt", "");
   });
 });

--- a/apps/ui/tests/components/org-members-avatars.test.tsx
+++ b/apps/ui/tests/components/org-members-avatars.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ login: "acme" }),
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const membersMock = vi.fn();
+const outsideMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    invitations: { list: vi.fn().mockResolvedValue([]), revoke: vi.fn(), create: vi.fn() },
+    collab: {
+      members: (...args: unknown[]) => membersMock(...args),
+      outsideCollaborators: (...args: unknown[]) => outsideMock(...args),
+      invitations: vi.fn().mockResolvedValue({ org: "acme", invitations: [] }),
+      permissionAudit: vi.fn(),
+      inactiveMembers: vi.fn(),
+      membership: vi.fn(),
+    },
+    tokens: { resolve: vi.fn().mockRejectedValue(new Error("no saved token")) },
+  },
+}));
+
+import OrgMembersPage from "@/app/settings/org/[login]/members/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OrgMembersPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("OrgMembersPage avatars", () => {
+  beforeEach(() => {
+    membersMock.mockReset();
+    outsideMock.mockReset();
+    membersMock.mockResolvedValue({
+      org: "acme",
+      two_factor_overlay_available: true,
+      members: [
+        { login: "octocat", avatar_url: "https://avatars/octocat.png", role: "admin", site_admin: false, two_factor_enabled: true },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders member avatars as decorative with the login as visible text", async () => {
+    const { container } = renderPage();
+
+    await waitFor(() => expect(screen.getByText("octocat")).toBeInTheDocument());
+
+    const avatar = container.querySelector('img[src="https://avatars/octocat.png"]');
+    expect(avatar).not.toBeNull();
+    // Decorative image: the login link is the accessible label, so alt must stay empty.
+    expect(avatar).toHaveAttribute("alt", "");
+  });
+});


### PR DESCRIPTION
Fixes #280.

## Why this change

Issue #280 asked for an audit — not a predetermined fix — of the empty `alt=""`
on avatar `<img>` elements in three places:

- `apps/ui/components/event-feed.tsx` (activity feed rows)
- `apps/ui/app/settings/org/[login]/members/page.tsx` (org members table)
- same file, outside-collaborators table

The concern was that a screen-reader user would lose the only identifier for a
row if the adjacent name text were ever sparse or missing.

## Audit conclusion: `alt=""` is correct in all three spots

In every case the avatar sits immediately next to the actor / member / collaborator
**login rendered as visible text** (a `<span>` or a link). Per WCAG / ARIA
guidance, an image whose information is already conveyed by adjacent text is
decorative and should have an empty `alt` — giving it descriptive alt text
(`"octocat avatar"`) would make the screen reader announce the same identity
twice. None of the three call sites can render an avatar without the adjacent
login (it's the React `key` in the table cases, and `event.actor` in the feed).

So the right outcome is to **pin the decision**, not change behaviour:

1. A one-line comment above each `<img alt="">` explaining why the empty alt is
   intentional, so a future well-meaning "accessibility fix" doesn't regress it.
2. Regression tests (`event-feed.test.tsx`, new `org-members-avatars.test.tsx`)
   asserting both the empty `alt` **and** the presence of the adjacent login
   text — the two facts that together make the decorative treatment valid.

## Notes

- `EventFeed` is still live (mounted in `app/activity/page.tsx`); the Overview
  page uses a different `EventActivityList` component that has no avatar image at
  all, so it's unaffected.
- No behaviour change, no API change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Clarified that avatar images are decorative when the associated login is already displayed as text, helping prevent duplicate screen-reader announcements while keeping member and actor names visible.
  - Applies to event feeds, member rosters, and outside-collaborator lists.

- **Tests**
  - Added coverage verifying decorative avatar labeling and confirming that associated member and actor names remain visible across these views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->