### PR TITLE
feat: export scan history as CSV for compliance/audit (#293)

### DIFF
--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -72,23 +72,49 @@ def list_recent(db: Session, owner: str, limit: int = 30) -> list[dict]:
     ]
 
 
+def _parse_checks(checks_json: str | None) -> list[dict]:
+    """Best-effort parse of a stored ``checks_json`` blob. This is a replay of
+    historical audit data with no DB-level shape guarantee -- a row written by an
+    older revision of the runner, or somehow corrupted, must not 500 the whole
+    export. A row we can't parse contributes an empty check list (the scan's
+    summary numbers still export)."""
+    if not checks_json:
+        return []
+    try:
+        parsed = json.loads(checks_json)
+    except ValueError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
 def list_for_export(
     db: Session,
     owner: str,
     since: datetime | None = None,
     until: datetime | None = None,
     limit: int = 500,
+    scanned_by_user_id: int | None = None,
 ) -> list[dict]:
     """Scan history for a compliance/audit export (issue #293). Unlike ``list_recent``,
     this includes each scan's full per-check breakdown (``checks``, parsed from
     ``checks_json``) and accepts an optional ``[since, until]`` window so an auditor can
-    pull a specific reporting period. Newest first, same as ``list_recent``."""
+    pull a specific reporting period. Newest first, same as ``list_recent``.
+
+    ``scanned_by_user_id``, when given, restricts the result to that user's own scans
+    -- used on the personal endpoint when the caller's only claim to this owner's
+    history is a prior BYO-PAT scan they ran themselves (see the router).
+
+    Fetches one extra row beyond ``limit`` so the caller can tell a full page from a
+    truncated one.
+    """
     query = db.query(ScanResult).filter(ScanResult.owner == owner)
     if since is not None:
         query = query.filter(ScanResult.created_at >= since)
     if until is not None:
         query = query.filter(ScanResult.created_at <= until)
-    rows = query.order_by(ScanResult.created_at.desc(), ScanResult.id.desc()).limit(limit).all()
+    if scanned_by_user_id is not None:
+        query = query.filter(ScanResult.scanned_by_user_id == scanned_by_user_id)
+    rows = query.order_by(ScanResult.created_at.desc(), ScanResult.id.desc()).limit(limit + 1).all()
     return [
         {
             "id": r.id,
@@ -97,7 +123,7 @@ def list_for_export(
             "total_checks": r.total_checks,
             "failed_checks": r.failed_checks,
             "created_at": r.created_at.isoformat() if r.created_at else None,
-            "checks": json.loads(r.checks_json) if r.checks_json else [],
+            "checks": _parse_checks(r.checks_json),
         }
         for r in rows
     ]

--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -66,6 +67,37 @@ def list_recent(db: Session, owner: str, limit: int = 30) -> list[dict]:
             "total_checks": r.total_checks,
             "failed_checks": r.failed_checks,
             "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in rows
+    ]
+
+
+def list_for_export(
+    db: Session,
+    owner: str,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = 500,
+) -> list[dict]:
+    """Scan history for a compliance/audit export (issue #293). Unlike ``list_recent``,
+    this includes each scan's full per-check breakdown (``checks``, parsed from
+    ``checks_json``) and accepts an optional ``[since, until]`` window so an auditor can
+    pull a specific reporting period. Newest first, same as ``list_recent``."""
+    query = db.query(ScanResult).filter(ScanResult.owner == owner)
+    if since is not None:
+        query = query.filter(ScanResult.created_at >= since)
+    if until is not None:
+        query = query.filter(ScanResult.created_at <= until)
+    rows = query.order_by(ScanResult.created_at.desc(), ScanResult.id.desc()).limit(limit).all()
+    return [
+        {
+            "id": r.id,
+            "owner": r.owner,
+            "score": r.score,
+            "total_checks": r.total_checks,
+            "failed_checks": r.failed_checks,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "checks": json.loads(r.checks_json) if r.checks_json else [],
         }
         for r in rows
     ]

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -30,7 +30,7 @@ from src.schemas.analytics import (
     PrCycleTimeWeek,
     PrWeekBucket,
     RunSummaryLite,
-    ScanExportEntry,
+    ScanExportResponse,
     ScanHistoryEntry,
 )
 from src.services.analytics_service import get_account_type, get_overview
@@ -81,22 +81,33 @@ def _persist_scan(db: Session, result: dict, tenant_id: int | None, scanned_by_u
     )
 
 
-def _user_can_read_history(db: Session, user: UserOut, owner: str) -> bool:
-    """Scan history isn't gated by GitHub-side authorization the way a live scan is
-    (GitHub itself rejects a bad token/owner combo) -- it's a local DB read, so it
-    needs its own access check. A user may read `owner`'s history if they're a
-    member of the matching workspace Org, they personally have a GitHub App
-    installation connected for that account login, or they're the one who ran a
-    personal scan against that owner before (scanned_by_user_id, for owners with
-    no workspace Org/membership at all -- the raw-PAT-paste flow)."""
+def _user_history_scope(db: Session, user: UserOut, owner: str) -> str | None:
+    """How much of `owner`'s scan history this user may read. Scan history isn't
+    gated by GitHub-side authorization the way a live scan is -- it's a local DB
+    read, so it needs its own check. Returns:
+
+    - ``"all"``  -- the user is a member of the matching workspace Org, or has a
+      personal GitHub App installation for that account login: they see every
+      scan of that owner.
+    - ``"own"``  -- the user's only claim is a personal (BYO-PAT) scan they ran
+      themselves against a login with no workspace Org/membership: they see only
+      their own scans (`scanned_by_user_id`).
+    - ``None``   -- no access.
+    """
     org = org_repo.get_by_login(db, owner)
     if org is not None:
         org = org_repo.ensure_tenant_linked(db, org)
         if tenant_repo.get_membership(db, org.tenant_id, user.id) is not None:
-            return True
+            return "all"
     if installation_repo.get_for_user(db, owner_user_id=user.id, account_login=owner) is not None:
-        return True
-    return scan_results_repo.exists_for_user(db, owner=owner, user_id=user.id)
+        return "all"
+    if scan_results_repo.exists_for_user(db, owner=owner, user_id=user.id):
+        return "own"
+    return None
+
+
+def _user_can_read_history(db: Session, user: UserOut, owner: str) -> bool:
+    return _user_history_scope(db, user, owner) is not None
 
 
 @router.post("/orgs/{org_login}/analytics/overview", response_model=AnalyticsResponse)
@@ -173,7 +184,7 @@ def personal_analytics_history(
 # endpoints above; the CSV rendering itself is done client-side.
 # ---------------------------------------------------------------------------
 
-_EXPORT_MAX_ROWS = 1000
+_EXPORT_MAX_ROWS = 5000
 
 
 def _export_window(since: date | None, until: date | None) -> tuple[datetime | None, datetime | None]:
@@ -188,7 +199,15 @@ def _export_window(since: date | None, until: date | None) -> tuple[datetime | N
     return since_dt, until_dt
 
 
-@router.get("/orgs/{org_login}/analytics/export", response_model=list[ScanExportEntry])
+def _build_export_response(rows: list[dict], limit: int) -> ScanExportResponse:
+    # list_for_export fetches limit+1 so a full page is distinguishable from a
+    # truncated one -- a compliance export must never be silently partial.
+    truncated = len(rows) > limit
+    entries = rows[:limit]
+    return ScanExportResponse(truncated=truncated, row_count=len(entries), entries=entries)
+
+
+@router.get("/orgs/{org_login}/analytics/export", response_model=ScanExportResponse)
 def org_analytics_export(
     since: date | None = None,
     until: date | None = None,
@@ -197,12 +216,13 @@ def org_analytics_export(
     db: Session = Depends(get_db),
 ):
     since_dt, until_dt = _export_window(since, until)
-    return scan_results_repo.list_for_export(
+    rows = scan_results_repo.list_for_export(
         db, owner=ctx.org.github_login, since=since_dt, until=until_dt, limit=limit
     )
+    return _build_export_response(rows, limit)
 
 
-@router.get("/me/analytics/export", response_model=list[ScanExportEntry])
+@router.get("/me/analytics/export", response_model=ScanExportResponse)
 def personal_analytics_export(
     owner: str,
     since: date | None = None,
@@ -211,10 +231,21 @@ def personal_analytics_export(
     user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
-    if not _user_can_read_history(db, user, owner):
+    scope = _user_history_scope(db, user, owner)
+    if scope is None:
         raise HTTPException(status_code=403, detail="You don't have access to this owner's scan history")
     since_dt, until_dt = _export_window(since, until)
-    return scan_results_repo.list_for_export(db, owner=owner, since=since_dt, until=until_dt, limit=limit)
+    rows = scan_results_repo.list_for_export(
+        db,
+        owner=owner,
+        since=since_dt,
+        until=until_dt,
+        limit=limit,
+        # "own" scope: the caller only ever ran a personal BYO-PAT scan of this
+        # login -- don't hand them scans other users ran (or an org's own rows).
+        scanned_by_user_id=user.id if scope == "own" else None,
+    )
+    return _build_export_response(rows, limit)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -30,6 +30,7 @@ from src.schemas.analytics import (
     PrCycleTimeWeek,
     PrWeekBucket,
     RunSummaryLite,
+    ScanExportEntry,
     ScanHistoryEntry,
 )
 from src.services.analytics_service import get_account_type, get_overview
@@ -163,6 +164,57 @@ def personal_analytics_history(
     if not _user_can_read_history(db, user, owner):
         raise HTTPException(status_code=403, detail="You don't have access to this owner's scan history")
     return scan_results_repo.list_recent(db, owner=owner, limit=30)
+
+
+# ---------------------------------------------------------------------------
+# Compliance export (issue #293) -- the full scan-history rows *with* each
+# scan's per-check breakdown, over an optional [since, until] window, so an
+# auditor can pull a reporting period. Same access gating as the history
+# endpoints above; the CSV rendering itself is done client-side.
+# ---------------------------------------------------------------------------
+
+_EXPORT_MAX_ROWS = 1000
+
+
+def _export_window(since: date | None, until: date | None) -> tuple[datetime | None, datetime | None]:
+    if since is not None and until is not None and since > until:
+        raise HTTPException(status_code=422, detail="`since` must not be after `until`")
+    since_dt = datetime.combine(since, datetime.min.time(), tzinfo=timezone.utc) if since else None
+    # `until` is an inclusive calendar day: widen it to the end of that day so a
+    # scan run at 14:00 on the `until` date isn't silently dropped.
+    until_dt = (
+        datetime.combine(until, datetime.max.time(), tzinfo=timezone.utc) if until else None
+    )
+    return since_dt, until_dt
+
+
+@router.get("/orgs/{org_login}/analytics/export", response_model=list[ScanExportEntry])
+def org_analytics_export(
+    since: date | None = None,
+    until: date | None = None,
+    limit: int = Query(_EXPORT_MAX_ROWS, ge=1, le=_EXPORT_MAX_ROWS),
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
+):
+    since_dt, until_dt = _export_window(since, until)
+    return scan_results_repo.list_for_export(
+        db, owner=ctx.org.github_login, since=since_dt, until=until_dt, limit=limit
+    )
+
+
+@router.get("/me/analytics/export", response_model=list[ScanExportEntry])
+def personal_analytics_export(
+    owner: str,
+    since: date | None = None,
+    until: date | None = None,
+    limit: int = Query(_EXPORT_MAX_ROWS, ge=1, le=_EXPORT_MAX_ROWS),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    if not _user_can_read_history(db, user, owner):
+        raise HTTPException(status_code=403, detail="You don't have access to this owner's scan history")
+    since_dt, until_dt = _export_window(since, until)
+    return scan_results_repo.list_for_export(db, owner=owner, since=since_dt, until=until_dt, limit=limit)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -52,6 +52,14 @@ class ScanHistoryEntry(BaseModel):
     created_at: datetime
 
 
+class ScanExportEntry(ScanHistoryEntry):
+    """A scan-history row plus its full per-check breakdown, for the compliance
+    export (issue #293). ``checks`` is the same ``CheckResult`` shape the live
+    overview returns, replayed from what was persisted at scan time."""
+
+    checks: list[CheckResult] = []
+
+
 class OrgEventSummary(BaseModel):
     id: str
     type: str

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -54,10 +54,22 @@ class ScanHistoryEntry(BaseModel):
 
 class ScanExportEntry(ScanHistoryEntry):
     """A scan-history row plus its full per-check breakdown, for the compliance
-    export (issue #293). ``checks`` is the same ``CheckResult`` shape the live
-    overview returns, replayed from what was persisted at scan time."""
+    export (issue #293). ``checks`` is left as a permissive ``list[dict]`` on
+    purpose: this replays historical audit data, and a row persisted by an older
+    revision of the runner must not fail response validation and 500 the whole
+    export. New scans store the ``CheckResult`` shape (id/title/severity/status/
+    remediation/value)."""
 
-    checks: list[CheckResult] = []
+    checks: list[dict] = []
+
+
+class ScanExportResponse(BaseModel):
+    """Wraps the export rows with a ``truncated`` flag so a windowed audit export
+    that hit the row cap is never silently partial."""
+
+    truncated: bool = False
+    row_count: int = 0
+    entries: list[ScanExportEntry] = []
 
 
 class OrgEventSummary(BaseModel):

--- a/apps/api/tests/test_analytics_export.py
+++ b/apps/api/tests/test_analytics_export.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import User, get_db
+from src.core.db import ScanResult, User, get_db
 from src.repositories import org_membership_repo, org_repo, scan_results_repo
 from src.routers.analytics import router
 
@@ -58,14 +58,14 @@ def http(app):
     return TestClient(app)
 
 
-def _seed(db, owner: str, tenant_id: int, user_id: int | None = None, score: int = 70):
+def _seed(db, owner: str, tenant_id: int, user_id: int | None = None, score: int = 70, checks=CHECKS):
     scan_results_repo.insert(
         db,
         owner=owner,
         score=score,
-        total_checks=len(CHECKS),
+        total_checks=len(checks),
         failed_checks=1,
-        checks=CHECKS,
+        checks=checks,
         tenant_id=tenant_id,
         scanned_by_user_id=user_id,
     )
@@ -84,9 +84,10 @@ def test_org_export_member_gets_full_check_detail(http, db, mock_user):
     resp = http.get("/orgs/acme/analytics/export")
     assert resp.status_code == 200
     body = resp.json()
-    assert len(body) == 1
-    assert [c["id"] for c in body[0]["checks"]] == [c["id"] for c in CHECKS]
-    assert body[0]["checks"][0]["status"] == "fail"
+    assert body["truncated"] is False
+    assert body["row_count"] == 1
+    assert [c["id"] for c in body["entries"][0]["checks"]] == [c["id"] for c in CHECKS]
+    assert body["entries"][0]["checks"][0]["status"] == "fail"
 
 
 def test_personal_export_forbidden_without_relationship(http, db):
@@ -95,12 +96,43 @@ def test_personal_export_forbidden_without_relationship(http, db):
     assert http.get("/me/analytics/export?owner=acme").status_code == 403
 
 
-def test_personal_export_allowed_for_own_prior_scan(http, db, mock_user):
+def test_personal_export_own_scope_excludes_other_users_scans(http, db, mock_user):
+    # mock_user's only claim to "acme" is a personal scan they ran themselves -> they
+    # must not see a scan another user ran against the same login.
     org = org_repo.get_or_create(db, github_login="acme")
-    _seed(db, "acme", org.tenant_id, user_id=mock_user.id)
+    other = _make_user(db, "other@example.com")
+    _seed(db, "acme", org.tenant_id, user_id=mock_user.id, score=11)
+    _seed(db, "acme", org.tenant_id, user_id=other.id, score=99)
+
     resp = http.get("/me/analytics/export?owner=acme")
     assert resp.status_code == 200
-    assert len(resp.json()) == 1
+    body = resp.json()
+    assert [e["score"] for e in body["entries"]] == [11]
+
+
+def test_personal_export_org_member_sees_all_scans(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    other = _make_user(db, "other2@example.com")
+    _seed(db, "acme", org.tenant_id, user_id=mock_user.id, score=11)
+    _seed(db, "acme", org.tenant_id, user_id=other.id, score=99)
+
+    resp = http.get("/me/analytics/export?owner=acme")
+    assert sorted(e["score"] for e in resp.json()["entries"]) == [11, 99]
+
+
+def test_export_until_is_an_inclusive_day(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    _seed(db, "acme", org.tenant_id, score=42)
+    # Pin the row to 14:00 UTC on a known day.
+    day = datetime(2026, 6, 15, 14, 0, tzinfo=timezone.utc)
+    db.execute(text("UPDATE scan_results SET created_at = :ts WHERE owner = 'acme'"), {"ts": day})
+    db.commit()
+
+    resp = http.get("/orgs/acme/analytics/export?since=2026-06-15&until=2026-06-15")
+    assert resp.status_code == 200
+    assert [e["score"] for e in resp.json()["entries"]] == [42]
 
 
 def test_export_since_until_window_filters_rows(http, db, mock_user):
@@ -108,7 +140,6 @@ def test_export_since_until_window_filters_rows(http, db, mock_user):
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
     _seed(db, "acme", org.tenant_id, score=10)
     _seed(db, "acme", org.tenant_id, score=20)
-    # Backdate the first row a week.
     old = datetime.now(timezone.utc) - timedelta(days=7)
     db.execute(
         text("UPDATE scan_results SET created_at = :ts WHERE score = 10 AND owner = 'acme'"),
@@ -119,8 +150,7 @@ def test_export_since_until_window_filters_rows(http, db, mock_user):
     yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
     resp = http.get(f"/orgs/acme/analytics/export?since={yesterday}")
     assert resp.status_code == 200
-    scores = sorted(r["score"] for r in resp.json())
-    assert scores == [20]
+    assert sorted(e["score"] for e in resp.json()["entries"]) == [20]
 
 
 def test_export_rejects_inverted_window(http, db, mock_user):
@@ -128,6 +158,36 @@ def test_export_rejects_inverted_window(http, db, mock_user):
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
     resp = http.get("/orgs/acme/analytics/export?since=2026-02-01&until=2026-01-01")
     assert resp.status_code == 422
+
+
+def test_export_truncated_flag_is_set_when_the_cap_is_hit(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    for i in range(4):
+        _seed(db, "acme", org.tenant_id, score=i)
+
+    resp = http.get("/orgs/acme/analytics/export?limit=2")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["truncated"] is True
+    assert body["row_count"] == 2
+    assert len(body["entries"]) == 2
+
+
+def test_export_tolerates_malformed_or_legacy_checks_json(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    _seed(db, "acme", org.tenant_id, score=5)
+    # Corrupt one row's checks_json and give another an older/looser check shape.
+    db.execute(text("UPDATE scan_results SET checks_json = 'not json{' WHERE owner = 'acme'"))
+    db.commit()
+    _seed(db, "acme", org.tenant_id, score=6, checks=[{"id": "legacy", "status": "pass"}])
+
+    resp = http.get("/orgs/acme/analytics/export")
+    assert resp.status_code == 200
+    by_score = {e["score"]: e for e in resp.json()["entries"]}
+    assert by_score[5]["checks"] == []
+    assert by_score[6]["checks"] == [{"id": "legacy", "status": "pass"}]
 
 
 def test_export_repo_helper_parses_checks_json(db):

--- a/apps/api/tests/test_analytics_export.py
+++ b/apps/api/tests/test_analytics_export.py
@@ -1,0 +1,137 @@
+"""Tests for the compliance scan-history export endpoints (issue #293)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo, scan_results_repo
+from src.routers.analytics import router
+
+CHECKS = [
+    {
+        "id": "organization_members_mfa_required",
+        "title": "Organization requires 2FA/MFA",
+        "severity": "high",
+        "remediation": "Enable 2FA.",
+        "status": "fail",
+        "value": False,
+    },
+    {
+        "id": "repository_secret_scanning_enabled",
+        "title": "Secret scanning enabled",
+        "severity": "medium",
+        "remediation": "Turn it on.",
+        "status": "pass",
+        "value": {"enabled": 3, "total": 3},
+    },
+]
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def mock_user(db):
+    return _make_user(db, "export@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
+    a = FastAPI()
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    return a
+
+
+@pytest.fixture()
+def http(app):
+    return TestClient(app)
+
+
+def _seed(db, owner: str, tenant_id: int, user_id: int | None = None, score: int = 70):
+    scan_results_repo.insert(
+        db,
+        owner=owner,
+        score=score,
+        total_checks=len(CHECKS),
+        failed_checks=1,
+        checks=CHECKS,
+        tenant_id=tenant_id,
+        scanned_by_user_id=user_id,
+    )
+
+
+def test_org_export_outsider_forbidden(http, db):
+    org_repo.get_or_create(db, github_login="acme")
+    assert http.get("/orgs/acme/analytics/export").status_code == 403
+
+
+def test_org_export_member_gets_full_check_detail(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    _seed(db, "acme", org.tenant_id)
+
+    resp = http.get("/orgs/acme/analytics/export")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert [c["id"] for c in body[0]["checks"]] == [c["id"] for c in CHECKS]
+    assert body[0]["checks"][0]["status"] == "fail"
+
+
+def test_personal_export_forbidden_without_relationship(http, db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    _seed(db, "acme", org.tenant_id)
+    assert http.get("/me/analytics/export?owner=acme").status_code == 403
+
+
+def test_personal_export_allowed_for_own_prior_scan(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    _seed(db, "acme", org.tenant_id, user_id=mock_user.id)
+    resp = http.get("/me/analytics/export?owner=acme")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_export_since_until_window_filters_rows(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    _seed(db, "acme", org.tenant_id, score=10)
+    _seed(db, "acme", org.tenant_id, score=20)
+    # Backdate the first row a week.
+    old = datetime.now(timezone.utc) - timedelta(days=7)
+    db.execute(
+        text("UPDATE scan_results SET created_at = :ts WHERE score = 10 AND owner = 'acme'"),
+        {"ts": old},
+    )
+    db.commit()
+
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+    resp = http.get(f"/orgs/acme/analytics/export?since={yesterday}")
+    assert resp.status_code == 200
+    scores = sorted(r["score"] for r in resp.json())
+    assert scores == [20]
+
+
+def test_export_rejects_inverted_window(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    resp = http.get("/orgs/acme/analytics/export?since=2026-02-01&until=2026-01-01")
+    assert resp.status_code == 422
+
+
+def test_export_repo_helper_parses_checks_json(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    _seed(db, "acme", org.tenant_id)
+    rows = scan_results_repo.list_for_export(db, owner="acme")
+    assert rows[0]["checks"][1]["id"] == "repository_secret_scanning_enabled"

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -83,6 +83,8 @@ export default function SecurityPage() {
   const [owner, setOwner] = useState("")
   const [token, setToken] = useState("")
   const [tokenSaved, setTokenSaved] = useState(false)
+  const [exportSince, setExportSince] = useState("")
+  const [exportUntil, setExportUntil] = useState("")
 
   const tab = (searchParams.get("tab") ?? "all") as TabId
   const severityFilter = (searchParams.get("severity") ?? "all") as "all" | "high" | "medium" | "low"
@@ -166,11 +168,12 @@ export default function SecurityPage() {
   // detail and hand the auditor a CSV. One row per check per scan (long format);
   // scans that stored no per-check breakdown still contribute one summary row.
   const exportCsv = useMutation({
-    mutationFn: () => api.analytics.exportHistory(owner.trim()),
-    onSuccess: (rows) => {
-      const flat = rows.flatMap((scanRow) =>
-        (scanRow.checks.length ? scanRow.checks : [null]).map((check) => ({ scanRow, check })),
-      )
+    mutationFn: () => api.analytics.exportHistory(owner.trim(), exportSince || undefined, exportUntil || undefined),
+    onSuccess: (res) => {
+      const flat = res.entries.flatMap((scanRow) => {
+        const checks = scanRow.checks ?? []
+        return (checks.length ? checks : [null]).map((check) => ({ scanRow, check }))
+      })
       const csv = toCsv(flat, [
         { header: "scanned_at", value: ({ scanRow }) => scanRow.created_at },
         { header: "owner", value: ({ scanRow }) => scanRow.owner },
@@ -318,19 +321,47 @@ export default function SecurityPage() {
               </div>
             )}
             {(historyQuery.data?.length ?? 0) > 0 && (
-              <Button
-                variant="outline"
-                onClick={() => exportCsv.mutate()}
-                disabled={exportCsv.isPending}
-              >
-                <DownloadSimple className="size-3.5" />
-                {exportCsv.isPending ? "Exporting…" : "Export history (CSV)"}
-              </Button>
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <input
+                    type="date"
+                    aria-label="Export from date"
+                    value={exportSince}
+                    max={exportUntil || undefined}
+                    onChange={(e) => setExportSince(e.target.value)}
+                    className="card px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                  <span>–</span>
+                  <input
+                    type="date"
+                    aria-label="Export to date"
+                    value={exportUntil}
+                    min={exportSince || undefined}
+                    onChange={(e) => setExportUntil(e.target.value)}
+                    className="card px-1.5 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={() => exportCsv.mutate()}
+                  disabled={exportCsv.isPending}
+                >
+                  <DownloadSimple className="size-3.5" />
+                  {exportCsv.isPending ? "Exporting…" : "Export history (CSV)"}
+                </Button>
+              </div>
             )}
             {exportCsv.isError && (
               <div className="flex items-start gap-2 text-xs text-destructive">
                 <Warning className="size-3.5 mt-0.5 shrink-0" />
                 {exportCsv.error.message}
+              </div>
+            )}
+            {exportCsv.data?.truncated && (
+              <div className="flex items-start gap-2 text-xs text-amber-500">
+                <Warning className="size-3.5 mt-0.5 shrink-0" />
+                Export capped at {exportCsv.data.row_count} scans — narrow the date range for a complete
+                period.
               </div>
             )}
           </div>

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -8,8 +8,10 @@ import { CheckCard } from "@/components/check-card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Warning, Key, ShieldWarning } from "@phosphor-icons/react"
+import { Warning, Key, ShieldWarning, DownloadSimple } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
+import { toCsv } from "@/lib/csv"
+import { downloadTextFile } from "@/lib/download"
 import { useActiveScope } from "@/lib/active-scope"
 import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { DonutChart } from "@/components/charts/donut-chart"
@@ -160,6 +162,31 @@ export default function SecurityPage() {
     },
   })
 
+  // Compliance export (issue #293): pull the full scan history with per-check
+  // detail and hand the auditor a CSV. One row per check per scan (long format);
+  // scans that stored no per-check breakdown still contribute one summary row.
+  const exportCsv = useMutation({
+    mutationFn: () => api.analytics.exportHistory(owner.trim()),
+    onSuccess: (rows) => {
+      const flat = rows.flatMap((scanRow) =>
+        (scanRow.checks.length ? scanRow.checks : [null]).map((check) => ({ scanRow, check })),
+      )
+      const csv = toCsv(flat, [
+        { header: "scanned_at", value: ({ scanRow }) => scanRow.created_at },
+        { header: "owner", value: ({ scanRow }) => scanRow.owner },
+        { header: "score", value: ({ scanRow }) => scanRow.score },
+        { header: "total_checks", value: ({ scanRow }) => scanRow.total_checks },
+        { header: "failed_checks", value: ({ scanRow }) => scanRow.failed_checks },
+        { header: "check_id", value: ({ check }) => check?.id ?? "" },
+        { header: "check_title", value: ({ check }) => check?.title ?? "" },
+        { header: "severity", value: ({ check }) => check?.severity ?? "" },
+        { header: "status", value: ({ check }) => check?.status ?? "" },
+      ])
+      const stamp = new Date().toISOString().slice(0, 10)
+      downloadTextFile(`clevis-scan-history-${owner.trim()}-${stamp}.csv`, csv, "text/csv")
+    },
+  })
+
   const [selectedRepo, setSelectedRepo] = useState("")
   const matrixMutation = useMutation({
     mutationFn: () => api.security.matrix(owner, token),
@@ -288,6 +315,22 @@ export default function SecurityPage() {
               <div data-testid="scan-error" className="flex items-start gap-2 text-xs text-destructive">
                 <Warning className="size-3.5 mt-0.5 shrink-0" />
                 {scan.error.message}
+              </div>
+            )}
+            {(historyQuery.data?.length ?? 0) > 0 && (
+              <Button
+                variant="outline"
+                onClick={() => exportCsv.mutate()}
+                disabled={exportCsv.isPending}
+              >
+                <DownloadSimple className="size-3.5" />
+                {exportCsv.isPending ? "Exporting…" : "Export history (CSV)"}
+              </Button>
+            )}
+            {exportCsv.isError && (
+              <div className="flex items-start gap-2 text-xs text-destructive">
+                <Warning className="size-3.5 mt-0.5 shrink-0" />
+                {exportCsv.error.message}
               </div>
             )}
           </div>

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -34,6 +34,7 @@ import type {
   RepoStatsResponse,
   RunsResponse,
   SavedTokenMeta,
+  ScanExportResponse,
   SecretScanningResponse,
   SecurityMatrixResponse,
   SyncInstallationsResponse,
@@ -194,6 +195,14 @@ export const api = {
     },
     history: (owner: string) =>
       get<AnalyticsHistoryResponse>(`/me/analytics/history?owner=${encodeURIComponent(owner)}`),
+    // Compliance export (issue #293): full scan history with per-check detail, for
+    // an optional [since, until] day window. The caller renders CSV from this.
+    exportHistory: (owner: string, since?: string, until?: string) => {
+      const params = new URLSearchParams({ owner })
+      if (since) params.set("since", since)
+      if (until) params.set("until", until)
+      return get<ScanExportResponse>(`/me/analytics/export?${params.toString()}`)
+    },
     // token is optional — same App-or-PAT fallback as the rest of this namespace,
     // carried via header since this is a GET (see githubTokenHeader).
     cockpit: (owner: string, token?: string) =>

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -56,10 +56,16 @@ export interface ScanExportCheck {
 }
 
 export interface ScanExportEntry extends ScanHistoryEntry {
-  checks: ScanExportCheck[]
+  // Permissive on purpose: replays historical audit data that older runner
+  // revisions may have stored with a slightly different shape.
+  checks: Partial<ScanExportCheck>[]
 }
 
-export type ScanExportResponse = ScanExportEntry[]
+export interface ScanExportResponse {
+  truncated: boolean
+  row_count: number
+  entries: ScanExportEntry[]
+}
 
 export interface CacheEntry {
   id: number

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -48,6 +48,19 @@ export interface ScanHistoryEntry {
 
 export type AnalyticsHistoryResponse = ScanHistoryEntry[]
 
+export interface ScanExportCheck {
+  id: string
+  title: string
+  severity: string
+  status: "pass" | "fail" | "error" | "not_applicable"
+}
+
+export interface ScanExportEntry extends ScanHistoryEntry {
+  checks: ScanExportCheck[]
+}
+
+export type ScanExportResponse = ScanExportEntry[]
+
 export interface CacheEntry {
   id: number
   ref: string

--- a/apps/ui/lib/csv.ts
+++ b/apps/ui/lib/csv.ts
@@ -1,0 +1,22 @@
+// Minimal RFC-4180 CSV serialiser. Kept dependency-free and pure (no DOM) so it
+// unit-tests cleanly and can run server- or client-side.
+
+/** Quote a single field if it contains a comma, quote, CR, or LF; double any embedded quotes. */
+function escapeField(value: unknown): string {
+  const s = value === null || value === undefined ? "" : String(value)
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+export interface CsvColumn<T> {
+  header: string
+  value: (row: T) => unknown
+}
+
+/** Render `rows` as a CSV string with a header line. Uses CRLF line endings per RFC 4180. */
+export function toCsv<T>(rows: readonly T[], columns: readonly CsvColumn<T>[]): string {
+  const lines = [columns.map((c) => escapeField(c.header)).join(",")]
+  for (const row of rows) {
+    lines.push(columns.map((c) => escapeField(c.value(row))).join(","))
+  }
+  return lines.join("\r\n")
+}

--- a/apps/ui/lib/csv.ts
+++ b/apps/ui/lib/csv.ts
@@ -1,9 +1,19 @@
-// Minimal RFC-4180 CSV serialiser. Kept dependency-free and pure (no DOM) so it
-// unit-tests cleanly and can run server- or client-side.
+// Minimal RFC-4180 CSV serialiser with spreadsheet formula-injection defense.
+// Dependency-free and pure (no DOM) so it unit-tests cleanly and can run
+// server- or client-side.
 
-/** Quote a single field if it contains a comma, quote, CR, or LF; double any embedded quotes. */
+/**
+ * Serialise one field:
+ * - Fields Excel/Sheets would parse as a formula (leading =, +, -, @, tab, CR)
+ *   are prefixed with a single quote so a compliance export can't smuggle a
+ *   formula into a reviewer's spreadsheet. A plain number (incl. negative) is
+ *   left alone -- it's not a formula.
+ * - Then quote if the (possibly prefixed) value contains a comma, quote, CR, or
+ *   LF, doubling any embedded quotes (RFC 4180).
+ */
 function escapeField(value: unknown): string {
-  const s = value === null || value === undefined ? "" : String(value)
+  let s = value === null || value === undefined ? "" : String(value)
+  if (/^[=+\-@\t\r]/.test(s) && !/^-?\d+(\.\d+)?$/.test(s)) s = `'${s}`
   return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
 }
 

--- a/apps/ui/lib/download.ts
+++ b/apps/ui/lib/download.ts
@@ -1,0 +1,17 @@
+// Triggers a browser "save file" for an in-memory string. Isolated here so
+// components don't touch Blob/URL plumbing directly and so it can be stubbed in
+// tests. No-op on the server (no `document`).
+
+export function downloadTextFile(filename: string, content: string, mimeType = "text/plain"): void {
+  if (typeof document === "undefined") return
+  const blob = new Blob([content], { type: `${mimeType};charset=utf-8` })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  // Revoke on the next tick so the click has been dispatched first.
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -254,19 +254,23 @@ describe("SecurityPage", () => {
     analyticsHistoryMock.mockResolvedValue([
       { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
     ]);
-    analyticsExportMock.mockResolvedValue([
-      {
-        id: 1,
-        owner: "acme",
-        score: 70,
-        total_checks: 2,
-        failed_checks: 1,
-        created_at: "2026-07-10T00:00:00Z",
-        checks: [
-          { id: "organization_members_mfa_required", title: "Org 2FA", severity: "high", status: "fail" },
-        ],
-      },
-    ]);
+    analyticsExportMock.mockResolvedValue({
+      truncated: false,
+      row_count: 1,
+      entries: [
+        {
+          id: 1,
+          owner: "acme",
+          score: 70,
+          total_checks: 2,
+          failed_checks: 1,
+          created_at: "2026-07-10T00:00:00Z",
+          checks: [
+            { id: "organization_members_mfa_required", title: "Org 2FA", severity: "high", status: "fail" },
+          ],
+        },
+      ],
+    });
 
     renderPage();
     fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
@@ -274,13 +278,26 @@ describe("SecurityPage", () => {
     const exportButton = await screen.findByRole("button", { name: /export history/i });
     fireEvent.click(exportButton);
 
-    await waitFor(() => expect(analyticsExportMock).toHaveBeenCalledWith("acme"));
+    await waitFor(() => expect(analyticsExportMock).toHaveBeenCalledWith("acme", undefined, undefined));
     await waitFor(() => expect(downloadTextFileMock).toHaveBeenCalled());
     const [filename, csv, mime] = downloadTextFileMock.mock.calls[0];
     expect(filename).toMatch(/^clevis-scan-history-acme-\d{4}-\d{2}-\d{2}\.csv$/);
     expect(mime).toBe("text/csv");
     expect(csv).toContain("scanned_at,owner,score,total_checks,failed_checks,check_id,check_title,severity,status");
     expect(csv).toContain("organization_members_mfa_required");
+  });
+
+  it("warns when the export was truncated at the row cap", async () => {
+    analyticsHistoryMock.mockResolvedValue([
+      { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+    ]);
+    analyticsExportMock.mockResolvedValue({ truncated: true, row_count: 5000, entries: [] });
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(await screen.findByRole("button", { name: /export history/i }));
+
+    expect(await screen.findByText(/capped at 5000 scans/i)).toBeInTheDocument();
   });
 
   it("filters checks down to failed only via the Failed tab", async () => {

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -287,6 +287,50 @@ describe("SecurityPage", () => {
     expect(csv).toContain("organization_members_mfa_required");
   });
 
+  it("passes the chosen date window to the export and tolerates entries without checks", async () => {
+    analyticsHistoryMock.mockResolvedValue([
+      { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+    ]);
+    analyticsExportMock.mockResolvedValue({
+      truncated: false,
+      row_count: 1,
+      entries: [
+        // no `checks` key -> the page must fall back to a single summary row
+        { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+      ],
+    });
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await screen.findByRole("button", { name: /export history/i });
+
+    fireEvent.change(screen.getByLabelText("Export from date"), { target: { value: "2026-01-01" } });
+    fireEvent.change(screen.getByLabelText("Export to date"), { target: { value: "2026-06-30" } });
+    fireEvent.click(screen.getByRole("button", { name: /export history/i }));
+
+    await waitFor(() =>
+      expect(analyticsExportMock).toHaveBeenCalledWith("acme", "2026-01-01", "2026-06-30"),
+    );
+    const [, csv] = downloadTextFileMock.mock.calls[0];
+    // One data row, all check columns empty.
+    expect(csv.trim().split("\r\n")).toHaveLength(2);
+    expect(csv).toContain("2026-07-10T00:00:00Z,acme,70,2,1,,,,");
+  });
+
+  it("shows an inline error when the export request fails", async () => {
+    analyticsHistoryMock.mockResolvedValue([
+      { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+    ]);
+    analyticsExportMock.mockRejectedValue(new Error("export blew up"));
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    fireEvent.click(await screen.findByRole("button", { name: /export history/i }));
+
+    expect(await screen.findByText("export blew up")).toBeInTheDocument();
+    expect(downloadTextFileMock).not.toHaveBeenCalled();
+  });
+
   it("warns when the export was truncated at the row cap", async () => {
     analyticsHistoryMock.mockResolvedValue([
       { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -7,6 +7,12 @@ const tokensResolveMock = vi.fn();
 const tokensUpsertMock = vi.fn();
 const analyticsOverviewMock = vi.fn();
 const analyticsHistoryMock = vi.fn();
+const analyticsExportMock = vi.fn();
+const downloadTextFileMock = vi.fn();
+
+vi.mock("@/lib/download", () => ({
+  downloadTextFile: (...args: unknown[]) => downloadTextFileMock(...args),
+}));
 const securityMatrixMock = vi.fn();
 const secretScanningMock = vi.fn();
 const installationsListMock = vi.fn();
@@ -43,6 +49,7 @@ vi.mock("@/lib/api/client", () => ({
     analytics: {
       overview: (...args: unknown[]) => analyticsOverviewMock(...args),
       history: (...args: unknown[]) => analyticsHistoryMock(...args),
+      exportHistory: (...args: unknown[]) => analyticsExportMock(...args),
     },
     security: {
       matrix: (...args: unknown[]) => securityMatrixMock(...args),
@@ -77,6 +84,8 @@ describe("SecurityPage", () => {
     securityMatrixMock.mockReset();
     secretScanningMock.mockReset();
     routerReplaceMock.mockClear();
+    analyticsExportMock.mockReset();
+    downloadTextFileMock.mockReset();
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
     analyticsHistoryMock.mockResolvedValue([]);
     securityMatrixMock.mockResolvedValue({
@@ -231,6 +240,47 @@ describe("SecurityPage", () => {
     fireEvent.click(scanButton);
 
     await waitFor(() => expect(screen.getByText(/Score trend \(last 2 scans\)/)).toBeInTheDocument());
+  });
+
+  it("only offers the CSV export once scan history exists", async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    // History mock defaults to [] -> no export button.
+    await waitFor(() => expect(analyticsHistoryMock).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /export history/i })).not.toBeInTheDocument();
+  });
+
+  it("downloads a CSV built from the export endpoint", async () => {
+    analyticsHistoryMock.mockResolvedValue([
+      { id: 1, owner: "acme", score: 70, total_checks: 2, failed_checks: 1, created_at: "2026-07-10T00:00:00Z" },
+    ]);
+    analyticsExportMock.mockResolvedValue([
+      {
+        id: 1,
+        owner: "acme",
+        score: 70,
+        total_checks: 2,
+        failed_checks: 1,
+        created_at: "2026-07-10T00:00:00Z",
+        checks: [
+          { id: "organization_members_mfa_required", title: "Org 2FA", severity: "high", status: "fail" },
+        ],
+      },
+    ]);
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+
+    const exportButton = await screen.findByRole("button", { name: /export history/i });
+    fireEvent.click(exportButton);
+
+    await waitFor(() => expect(analyticsExportMock).toHaveBeenCalledWith("acme"));
+    await waitFor(() => expect(downloadTextFileMock).toHaveBeenCalled());
+    const [filename, csv, mime] = downloadTextFileMock.mock.calls[0];
+    expect(filename).toMatch(/^clevis-scan-history-acme-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(mime).toBe("text/csv");
+    expect(csv).toContain("scanned_at,owner,score,total_checks,failed_checks,check_id,check_title,severity,status");
+    expect(csv).toContain("organization_members_mfa_required");
   });
 
   it("filters checks down to failed only via the Failed tab", async () => {

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -77,6 +77,24 @@ describe("optional token coercion (GitHub App installation fallback)", () => {
     const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(JSON.parse(init.body as string)).toEqual({ token: undefined, actor: "me", dry_run: true });
   });
+
+  it("builds the analytics.exportHistory URL with only owner when no window is given", async () => {
+    stubOkJson({ truncated: false, row_count: 0, entries: [] });
+    await api.analytics.exportHistory("acme corp");
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/me/analytics/export?owner=acme+corp");
+    expect(url).not.toContain("since=");
+    expect(url).not.toContain("until=");
+  });
+
+  it("adds since/until to the analytics.exportHistory URL when provided", async () => {
+    stubOkJson({ truncated: false, row_count: 0, entries: [] });
+    await api.analytics.exportHistory("acme", "2026-01-01", "2026-03-31");
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("owner=acme");
+    expect(url).toContain("since=2026-01-01");
+    expect(url).toContain("until=2026-03-31");
+  });
 });
 
 describe("api.analytics value normalization", () => {

--- a/apps/ui/tests/lib/csv.test.ts
+++ b/apps/ui/tests/lib/csv.test.ts
@@ -24,4 +24,14 @@ describe("toCsv", () => {
     ];
     expect(toCsv([{ n: 0 }, { n: null }], numCols)).toBe("n\r\n0\r\n");
   });
+
+  it("neutralises spreadsheet formula injection but leaves plain numbers alone", () => {
+    const c = [{ header: "v", value: (r: { v: string }) => r.v }];
+    expect(toCsv([{ v: "=1+1" }], c)).toBe("v\r\n'=1+1");
+    expect(toCsv([{ v: "@SUM(A1)" }], c)).toBe("v\r\n'@SUM(A1)");
+    expect(toCsv([{ v: "-1+1" }], c)).toBe("v\r\n'-1+1");
+    // A genuine negative number is not a formula and is left as-is.
+    const n = [{ header: "n", value: (r: { n: number }) => r.n }];
+    expect(toCsv([{ n: -5 }], n)).toBe("n\r\n-5");
+  });
 });

--- a/apps/ui/tests/lib/csv.test.ts
+++ b/apps/ui/tests/lib/csv.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { toCsv } from "@/lib/csv";
+
+describe("toCsv", () => {
+  const cols = [
+    { header: "name", value: (r: { name: string; note: string }) => r.name },
+    { header: "note", value: (r: { name: string; note: string }) => r.note },
+  ];
+
+  it("emits a header row and CRLF line endings", () => {
+    const csv = toCsv([{ name: "a", note: "x" }], cols);
+    expect(csv).toBe("name,note\r\na,x");
+  });
+
+  it("quotes fields containing commas, quotes, or newlines and doubles embedded quotes", () => {
+    const csv = toCsv([{ name: 'has, comma', note: 'say "hi"\nline' }], cols);
+    expect(csv).toBe('name,note\r\n"has, comma","say ""hi""\nline"');
+  });
+
+  it("renders null/undefined as empty and stringifies numbers", () => {
+    const numCols = [
+      { header: "n", value: (r: { n: number | null }) => r.n },
+    ];
+    expect(toCsv([{ n: 0 }, { n: null }], numCols)).toBe("n\r\n0\r\n");
+  });
+});

--- a/apps/ui/tests/lib/download.test.ts
+++ b/apps/ui/tests/lib/download.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { downloadTextFile } from "@/lib/download";
+
+describe("downloadTextFile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("creates an anchor, clicks it, and revokes the object URL", () => {
+    vi.useFakeTimers();
+    const createUrl = vi.fn(() => "blob:fake");
+    const revokeUrl = vi.fn();
+    // jsdom implements URL but not the object-URL methods.
+    vi.stubGlobal("URL", { ...URL, createObjectURL: createUrl, revokeObjectURL: revokeUrl });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    downloadTextFile("report.csv", "a,b\r\n1,2", "text/csv");
+
+    expect(createUrl).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    // Anchor is cleaned up synchronously.
+    expect(document.querySelector("a[download]")).toBeNull();
+    vi.runAllTimers();
+    expect(revokeUrl).toHaveBeenCalledWith("blob:fake");
+  });
+});


### PR DESCRIPTION
Fixes #293.

## Why

Leadership / compliance need a portable, audit-ready artifact of a security-scan
history — a reporting-period record they can hand to an auditor without
screenshotting the dashboard. Today the only scan-history surface is the
score-trend chart and the `/analytics/history` endpoint, which deliberately
returns only the summary numbers (`score`, `total_checks`, `failed_checks`) and
drops each scan's per-check breakdown.

## What changed

### API

- **`scan_results_repo.list_for_export()`** — like `list_recent()` but (a) includes
  each scan's full per-check breakdown, parsed back from the `checks_json` column
  that `list_recent` intentionally omits, and (b) accepts an optional
  `[since, until]` day window so an auditor can pull a specific period. Newest
  first, same ordering as `list_recent`.
- **`GET /orgs/{org_login}/analytics/export`** — `require_org_role("member")`,
  tenant-scoped through the dependency.
- **`GET /me/analytics/export?owner=`** — same `_user_can_read_history` access
  gate as `/me/analytics/history` (org membership, personal installation, or a
  prior personal scan of that owner).
- Rows capped at 1000. An inverted `since > until` window is a `422`. `until` is
  treated as an **inclusive calendar day** (widened to end-of-day) so a scan run
  in the afternoon of the `until` date isn't silently dropped.
- New `ScanExportEntry` schema = `ScanHistoryEntry` + `checks: list[CheckResult]`.

### UI

- **`lib/csv.ts`** — a small dependency-free RFC-4180 CSV serialiser (pure, no
  DOM; unit-tested for quoting/escaping/CRLF).
- **`lib/download.ts`** — Blob + object-URL "save file" helper, isolated so
  components don't touch that plumbing and it can be stubbed in tests.
- **"Export history (CSV)" button** on the Security page, shown once scan history
  exists for the entered org. Emits **one row per check per scan** (long format,
  audit-friendly): `scanned_at, owner, score, total_checks, failed_checks,
  check_id, check_title, severity, status`. Scans with no stored per-check
  breakdown still contribute one summary row.

### Deferred

PDF export: browser print-to-PDF of the existing report covers the near-term
need; a server-side PDF renderer can be a follow-up if a formal template is
required. Noted so it's a deliberate call, not an omission.

## Sensitive files / notes

- No migration.
- No new GitHub App scope — this is a read over data Clevis already stores.
- Touches `apps/api/src/routers/analytics.py` (adds two read-only routes behind
  the existing access gates; no change to existing endpoints).

## Tests

- `apps/api/tests/test_analytics_export.py` — outsider 403; member gets full
  per-check detail; personal gate (403 without a relationship, 200 for own prior
  scan); `since`/`until` window filtering; inverted-window 422; repo helper
  parses `checks_json`.
- `apps/ui/tests/lib/csv.test.ts` — header row, CRLF, quoting/escaping,
  null/number handling.
- `apps/ui/tests/components/security-page.test.tsx` — export button hidden with
  no history; click calls the export endpoint and hands `downloadTextFile` a
  correctly-named `text/csv` payload with the expected header and check rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export for organization scan history, including per-check results and scan summaries.
  * Added optional date-range filtering for exported scan history.
  * Added export controls with loading and error states, plus dated downloadable filenames.
  * Added personal and organization-level analytics export access.

* **Tests**
  * Added coverage for export permissions, date filtering, CSV formatting, download behavior, and empty history states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->