### PR TITLE
ci(triage): auto-label, assign, and set milestone on issue/PR open

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+"area:api":
+  - changed-files:
+      - any-glob-to-any-file: "apps/api/**"
+"area:ui":
+  - changed-files:
+      - any-glob-to-any-file: "apps/ui/**"
+"area:worker":
+  - changed-files:
+      - any-glob-to-any-file: "apps/worker/**"
+"area:checks":
+  - changed-files:
+      - any-glob-to-any-file: "packages/checks/**"
+"area:db":
+  - changed-files:
+      - any-glob-to-any-file: "apps/api/alembic/versions/**"
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file: [".github/**"]

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,71 @@
+name: Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-path-labels:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false # additive only; never strip manually-set labels
+
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // fix -> bug, feat -> enhancement, everything else -> chore/documentation
+            const TYPE_LABELS = {
+              feat: "enhancement", fix: "bug", docs: "documentation",
+              perf: "chore", refactor: "chore", test: "chore", chore: "chore", ci: "chore",
+            };
+
+            const item = context.payload.issue || context.payload.pull_request;
+            const issue_number = item.number;
+            const author = item.user.login;
+            const repo = context.repo;
+
+            // 1. Labels from the "type(scope):" title prefix
+            const m = (item.title || "").match(/^([a-z]+)(?:\(([^)]+)\))?!?:/i);
+            const labels = [];
+            if (m) {
+              const type = TYPE_LABELS[m[1].toLowerCase()];
+              if (type) labels.push(type);
+              if (m[2]) labels.push(`area:${m[2].toLowerCase().trim()}`);
+            }
+            if (labels.length) {
+              await github.rest.issues.addLabels({ ...repo, issue_number, labels });
+            }
+
+            // 2. Assign the author (only if nobody is assigned yet)
+            if (!(item.assignees && item.assignees.length)) {
+              try {
+                await github.rest.issues.addAssignees({ ...repo, issue_number, assignees: [author] });
+              } catch (e) {
+                core.warning(`assignee skipped: ${e.message}`);
+              }
+            }
+
+            // 3. Milestone = open milestone with the nearest due date (only if none set)
+            if (!item.milestone) {
+              const ms = await github.rest.issues.listMilestones({ ...repo, state: "open", per_page: 100 });
+              const withDue = ms.data
+                .filter((x) => x.due_on)
+                .sort((a, b) => new Date(a.due_on) - new Date(b.due_on));
+              const pick = withDue[0] || ms.data[0]; // fallback: any open milestone; undefined -> skip
+              if (pick) {
+                await github.rest.issues.update({ ...repo, issue_number, milestone: pick.number });
+              }
+            }


### PR DESCRIPTION
Adds a Triage workflow that fills the gap left by the built-in Project board workflows, which only handle add-to-project and Done-on-close.

On issues and PRs opened/reopened:
- labels from the enforced Conventional-Commit title prefix (type -> bug/ enhancement/chore/documentation, scope -> area:<scope>), for both issues and PRs
- actions/labeler as a path-based fallback for PRs whose title lacks a scope (.github/labeler.yml maps apps/api/** -> area:api, etc.)
- assigns the author, only when no assignee is set
- sets the milestone to the nearest-due open milestone, only when none is set; left empty when no milestone is open

Manual choices are preserved: labels are additive (sync-labels: false), assignee and milestone are only written when currently empty.

Uses pull_request_target so labeler and github-script get a write-scoped token; safe here because neither job checks out or executes PR head code. No app code, migrations, or auth/RBAC/secret files touched.



## Summary

<!-- What does this PR change, and why? -->

Closes #<!-- issue number, if any -->

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
- [ ] Relevant `pytest` tests pass (if API/worker changed)
- [ ] Docker images still build, if `Dockerfile`/deps changed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic labeling for pull requests based on changed files.
  * Added issue and pull request triage automation based on title conventions.
  * Automatically assigns unassigned issues and pull requests to their authors.
  * Automatically applies an open milestone when none is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->