### PR TITLE
ci(triage): auto-label, assign, and set milestone on issue/PR open

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+"area:api":
+  - changed-files:
+      - any-glob-to-any-file: "apps/api/**"
+"area:ui":
+  - changed-files:
+      - any-glob-to-any-file: "apps/ui/**"
+"area:worker":
+  - changed-files:
+      - any-glob-to-any-file: "apps/worker/**"
+"area:checks":
+  - changed-files:
+      - any-glob-to-any-file: "packages/checks/**"
+"area:db":
+  - changed-files:
+      - any-glob-to-any-file: "apps/api/alembic/versions/**"
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file: [".github/**"]

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,15 +6,15 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   pr-path-labels:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # actions/labeler reads the repo's .github/labeler.yml
+      pull-requests: write # ...and writes labels onto the PR
     steps:
       - uses: actions/labeler@v5
         with:
@@ -22,6 +22,9 @@ jobs:
 
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # labels/assignee/milestone on issues
+      pull-requests: write # ...and the same on PRs (pull_request_target)
     steps:
       - uses: actions/github-script@v7
         with:
@@ -37,22 +40,40 @@ jobs:
             const author = item.user.login;
             const repo = context.repo;
 
+            // Scopes we recognise; anything else is ignored rather than
+            // auto-creating a junk label. Keep in sync with .github/labeler.yml.
+            const AREAS = new Set(["api", "ui", "worker", "checks", "db", "ci"]);
+
             // 1. Labels from the "type(scope):" title prefix
             const m = (item.title || "").match(/^([a-z]+)(?:\(([^)]+)\))?!?:/i);
             const labels = [];
             if (m) {
               const type = TYPE_LABELS[m[1].toLowerCase()];
               if (type) labels.push(type);
-              if (m[2]) labels.push(`area:${m[2].toLowerCase().trim()}`);
+              const scope = (m[2] || "").toLowerCase().trim();
+              if (AREAS.has(scope) && `area:${scope}`.length <= 50) {
+                labels.push(`area:${scope}`);
+              }
             }
             if (labels.length) {
-              await github.rest.issues.addLabels({ ...repo, issue_number, labels });
+              // Don't let a labelling failure abort assignee/milestone below.
+              try {
+                await github.rest.issues.addLabels({ ...repo, issue_number, labels });
+              } catch (e) {
+                core.warning(`labels skipped: ${e.message}`);
+              }
             }
 
             // 2. Assign the author (only if nobody is assigned yet)
             if (!(item.assignees && item.assignees.length)) {
               try {
-                await github.rest.issues.addAssignees({ ...repo, issue_number, assignees: [author] });
+                const res = await github.rest.issues.addAssignees({ ...repo, issue_number, assignees: [author] });
+                // GitHub silently drops non-assignable users (non-collaborators)
+                // and still returns 201, so confirm the author actually landed.
+                const assigned = (res.data.assignees || []).some((a) => a.login === author);
+                if (!assigned) {
+                  core.warning(`assignee skipped: ${author} is not assignable on this repo`);
+                }
               } catch (e) {
                 core.warning(`assignee skipped: ${e.message}`);
               }

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,71 @@
+name: Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-path-labels:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false # additive only; never strip manually-set labels
+
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // fix -> bug, feat -> enhancement, everything else -> chore/documentation
+            const TYPE_LABELS = {
+              feat: "enhancement", fix: "bug", docs: "documentation",
+              perf: "chore", refactor: "chore", test: "chore", chore: "chore", ci: "chore",
+            };
+
+            const item = context.payload.issue || context.payload.pull_request;
+            const issue_number = item.number;
+            const author = item.user.login;
+            const repo = context.repo;
+
+            // 1. Labels from the "type(scope):" title prefix
+            const m = (item.title || "").match(/^([a-z]+)(?:\(([^)]+)\))?!?:/i);
+            const labels = [];
+            if (m) {
+              const type = TYPE_LABELS[m[1].toLowerCase()];
+              if (type) labels.push(type);
+              if (m[2]) labels.push(`area:${m[2].toLowerCase().trim()}`);
+            }
+            if (labels.length) {
+              await github.rest.issues.addLabels({ ...repo, issue_number, labels });
+            }
+
+            // 2. Assign the author (only if nobody is assigned yet)
+            if (!(item.assignees && item.assignees.length)) {
+              try {
+                await github.rest.issues.addAssignees({ ...repo, issue_number, assignees: [author] });
+              } catch (e) {
+                core.warning(`assignee skipped: ${e.message}`);
+              }
+            }
+
+            // 3. Milestone = open milestone with the nearest due date (only if none set)
+            if (!item.milestone) {
+              const ms = await github.rest.issues.listMilestones({ ...repo, state: "open", per_page: 100 });
+              const withDue = ms.data
+                .filter((x) => x.due_on)
+                .sort((a, b) => new Date(a.due_on) - new Date(b.due_on));
+              const pick = withDue[0] || ms.data[0]; // fallback: any open milestone; undefined -> skip
+              if (pick) {
+                await github.rest.issues.update({ ...repo, issue_number, milestone: pick.number });
+              }
+            }


### PR DESCRIPTION
## What changed

Adds a **Triage** workflow (`.github/workflows/triage.yml`) plus `.github/labeler.yml`. On every issue and PR `opened` / `reopened`:

1. **Labels from the title.** Parses the Conventional-Commit prefix that commitlint and the issue templates already enforce (`type(scope):`). `fix` → `bug`, `feat` → `enhancement`, `docs` → `documentation`, everything else → `chore`; `(api)` → `area:api`, etc. Runs for both issues and PRs via `actions/github-script`.
2. **Labels from changed paths (PR fallback).** `actions/labeler@v5` maps `apps/api/**` → `area:api`, `apps/ui/**` → `area:ui`, `apps/worker/**` → `area:worker`, `packages/checks/**` → `area:checks`, `apps/api/alembic/versions/**` → `area:db`, `.github/**` → `area:ci`. This covers PRs whose title lacks a scope.
3. **Assignee.** Assigns the author, but only when no assignee is set.
4. **Milestone (the "deadline").** Sets the milestone to the open milestone with the nearest `due_on`; if no milestone is open, it's left empty. Only written when the item has no milestone.

## Why

The Projects board is already automated by GitHub's built-in Project workflows (auto-add, "Done" on merge/close), but labels, assignee, and deadlines were still fully manual. The only existing auto-labeling was the hard-coded `bug` / `enhancement` in the two issue templates, and only when an issue is filed through a template. This closes that gap without touching the board automation.

Manual choices are preserved: labels are additive (`sync-labels: false`), and assignee/milestone are only set when currently empty.

## Notes for review

- Uses the `pull_request_target` trigger so `actions/labeler` and `github-script` get a write-scoped token. This is safe here because neither job checks out or executes PR head code — it only reads event metadata and calls the issues API.
- `issues.addLabels` auto-creates any missing label (default gray). A follow-up could add a `.github/labels.yml` + label-sync for `area:*` colors; deliberately out of scope here.
- The milestone step needs at least one **open milestone with a due date** to do anything (Issues → Milestones).
- No app code, **no migrations**, no auth / RBAC / token-encryption / `.env` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automatic labeling for pull requests and issues based on changed areas and title prefixes.
  - Added workflow automation to assign unassigned issues and pull requests to their authors.
  - Added milestone assignment based on the nearest upcoming open milestone when no milestone is set.
  - Added support for applying labels when issues or pull requests are opened or reopened, without removing existing labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->