### PR TITLE
fix(triage): drop area: prefix from path/scope labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,18 @@
-"area:api":
+"api":
   - changed-files:
       - any-glob-to-any-file: "apps/api/**"
-"area:ui":
+"ui":
   - changed-files:
       - any-glob-to-any-file: "apps/ui/**"
-"area:worker":
+"worker":
   - changed-files:
       - any-glob-to-any-file: "apps/worker/**"
-"area:checks":
+"checks":
   - changed-files:
       - any-glob-to-any-file: "packages/checks/**"
-"area:db":
+"db":
   - changed-files:
       - any-glob-to-any-file: "apps/api/alembic/versions/**"
-"area:ci":
+"ci":
   - changed-files:
       - any-glob-to-any-file: [".github/**"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
-"api":
+"API":
   - changed-files:
       - any-glob-to-any-file: "apps/api/**"
-"ui":
+"UX/UI":
   - changed-files:
       - any-glob-to-any-file: "apps/ui/**"
 "worker":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,6 @@
 "db":
   - changed-files:
       - any-glob-to-any-file: "apps/api/alembic/versions/**"
-"ci":
+"CI/CD":
   - changed-files:
       - any-glob-to-any-file: [".github/**"]

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -40,9 +40,13 @@ jobs:
             const author = item.user.login;
             const repo = context.repo;
 
-            // Scopes we recognise; anything else is ignored rather than
-            // auto-creating a junk label. Keep in sync with .github/labeler.yml.
-            const AREAS = new Set(["api", "ui", "worker", "checks", "db", "ci"]);
+            // Scopes we recognise, mapped to the label name to apply; anything else is
+            // ignored rather than auto-creating a junk label. Keep in sync with
+            // .github/labeler.yml -- "ci" maps to the repo's existing "CI/CD" label
+            // rather than a plain "ci" one.
+            const AREA_LABELS = {
+              api: "api", ui: "ui", worker: "worker", checks: "checks", db: "db", ci: "CI/CD",
+            };
 
             // 1. Labels from the "type(scope):" title prefix
             const m = (item.title || "").match(/^([a-z]+)(?:\(([^)]+)\))?!?:/i);
@@ -51,9 +55,8 @@ jobs:
               const type = TYPE_LABELS[m[1].toLowerCase()];
               if (type) labels.push(type);
               const scope = (m[2] || "").toLowerCase().trim();
-              if (AREAS.has(scope)) {
-                labels.push(scope);
-              }
+              const areaLabel = AREA_LABELS[scope];
+              if (areaLabel) labels.push(areaLabel);
             }
             if (labels.length) {
               // Don't let a labelling failure abort assignee/milestone below.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,8 +51,8 @@ jobs:
               const type = TYPE_LABELS[m[1].toLowerCase()];
               if (type) labels.push(type);
               const scope = (m[2] || "").toLowerCase().trim();
-              if (AREAS.has(scope) && `area:${scope}`.length <= 50) {
-                labels.push(`area:${scope}`);
+              if (AREAS.has(scope)) {
+                labels.push(scope);
               }
             }
             if (labels.length) {

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -40,23 +40,52 @@ jobs:
             const author = item.user.login;
             const repo = context.repo;
 
-            // Scopes we recognise, mapped to the label name to apply; anything else is
-            // ignored rather than auto-creating a junk label. Keep in sync with
-            // .github/labeler.yml -- "ci" maps to the repo's existing "CI/CD" label
-            // rather than a plain "ci" one.
-            const AREA_LABELS = {
-              api: "api", ui: "ui", worker: "worker", checks: "checks", db: "db", ci: "CI/CD",
+            // Scopes we recognise; anything else is ignored rather than auto-creating a
+            // junk label. Each maps to the *existing* repo label(s) to look for first
+            // (checked case-insensitively, in order) -- e.g. "ui" reuses the repo's
+            // "UX/UI" label rather than creating a near-duplicate "ui" one. The last
+            // entry is what gets created if none of the candidates exist yet. Keep in
+            // sync with .github/labeler.yml.
+            const AREA_LABEL_CANDIDATES = {
+              api: ["API", "api"],
+              ui: ["UX/UI", "ui"],
+              worker: ["worker"],
+              checks: ["checks"],
+              db: ["db"],
+              ci: ["CI/CD", "ci"],
             };
+
+            // Look up the repo's labels once so area labels above (and TYPE_LABELS
+            // below) can reuse whatever already exists instead of assuming a name.
+            const existingLabels = await github.paginate(github.rest.issues.listLabelsForRepo, { ...repo, per_page: 100 });
+            const labelsByLower = new Map(existingLabels.map((l) => [l.name.toLowerCase(), l.name]));
+
+            async function resolveLabel(candidates) {
+              for (const name of candidates) {
+                const found = labelsByLower.get(name.toLowerCase());
+                if (found) return found;
+              }
+              const toCreate = candidates[candidates.length - 1];
+              try {
+                await github.rest.issues.createLabel({ ...repo, name: toCreate, color: "ededed" });
+                labelsByLower.set(toCreate.toLowerCase(), toCreate);
+              } catch (e) {
+                // Race with another run creating the same label concurrently, or
+                // missing perms -- addLabels below will warn if it's still missing.
+                core.warning(`could not create label "${toCreate}": ${e.message}`);
+              }
+              return toCreate;
+            }
 
             // 1. Labels from the "type(scope):" title prefix
             const m = (item.title || "").match(/^([a-z]+)(?:\(([^)]+)\))?!?:/i);
             const labels = [];
             if (m) {
               const type = TYPE_LABELS[m[1].toLowerCase()];
-              if (type) labels.push(type);
+              if (type) labels.push(await resolveLabel([type]));
               const scope = (m[2] || "").toLowerCase().trim();
-              const areaLabel = AREA_LABELS[scope];
-              if (areaLabel) labels.push(areaLabel);
+              const areaCandidates = AREA_LABEL_CANDIDATES[scope];
+              if (areaCandidates) labels.push(await resolveLabel(areaCandidates));
             }
             if (labels.length) {
               // Don't let a labelling failure abort assignee/milestone below.


### PR DESCRIPTION
Labels were being created as area:api / area:ui / area:db / etc. Use the plain scope name instead (api, ui, db, worker, checks, ci) on both the path-based actions/labeler config and the title-scope labels the triage job applies to new issues/PRs.

Additive-only (labeler's sync-labels: false), so this doesn't touch labels already applied under the old area:* names -- only new labelling uses the plain names going forward.

## Summary

<!-- What does this PR change, and why? -->

Closes #<!-- issue number, if any -->

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
- [ ] Relevant `pytest` tests pass (if API/worker changed)
- [ ] Docker images still build, if `Dockerfile`/deps changed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
