### PR TITLE
fix(ui): UX audit fixes - Configure link bug, empty-state consistency, My Work identity resolution

### DIFF
--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -63,6 +63,10 @@ class UserOut(BaseModel):
     email: str
     name: str | None
     is_workspace_admin: bool
+    # Set when the user linked/signed in via GitHub OAuth; None otherwise. Read fresh from
+    # the DB in require_auth below (not carried in the JWT), same as this function already
+    # re-checks token_version against the DB rather than trusting a stale claim.
+    github_login: str | None = None
 
 
 def create_access_token(
@@ -130,6 +134,7 @@ def require_auth(
         email=email,
         name=payload.get("name"),
         is_workspace_admin=bool(payload.get("is_workspace_admin", False)),
+        github_login=db_user.github_login,
     )
 
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -867,14 +867,17 @@ async def personal_analytics_cockpit(
 _MAX_REPOS_FOR_RUN_LOOKUP = 15
 
 
-def _my_login(client: GitHubClient) -> str | None:
+def _my_login(client: GitHubClient, fallback_login: str | None = None) -> str | None:
     try:
         data = client.request("GET", "/user")
         return data.get("login") if isinstance(data, dict) else None
     except (httpx.HTTPStatusError, httpx.RequestError):
         # Installation (App) tokens aren't user-to-server tokens and can't call /user --
-        # degrade to an empty MyViewResponse rather than 500 the whole page.
-        return None
+        # fall back to the signed-in Clevis user's own GitHub OAuth-linked login (if any)
+        # instead of silently returning zero PRs/issues for someone who really has some.
+        # Still None (caller degrades to an empty response) if the user never linked
+        # GitHub OAuth -- there's no other way to know who they are on GitHub.
+        return fallback_login
 
 
 def _search_items(client: GitHubClient, query: str, per_page: int = 10) -> list[dict]:
@@ -958,9 +961,9 @@ async def my_view(
         raise HTTPException(status_code=400, detail=str(exc))
 
     client = GitHubClient(token)
-    login = await anyio.to_thread.run_sync(lambda: _my_login(client))
+    login = await anyio.to_thread.run_sync(lambda: _my_login(client, user.github_login))
     if login is None:
-        return MyViewResponse()
+        return MyViewResponse(identity_unresolved=True)
 
     try:
         repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))
@@ -1027,9 +1030,9 @@ async def _my_items_list(
         raise HTTPException(status_code=400, detail=str(exc))
 
     client = GitHubClient(token)
-    login = await anyio.to_thread.run_sync(lambda: _my_login(client))
+    login = await anyio.to_thread.run_sync(lambda: _my_login(client, user.github_login))
     if login is None:
-        return response_cls(page=page, per_page=per_page)
+        return response_cls(page=page, per_page=per_page, identity_unresolved=True)
     if page * per_page > _MAX_SEARCH_RESULTS:
         # Beyond GitHub's reachable window -- report the capped total (not 0) so
         # page/lastPage math stays consistent instead of regressing to "Page N of 1".

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -871,8 +871,13 @@ def _my_login(client: GitHubClient, fallback_login: str | None = None) -> str | 
     try:
         data = client.request("GET", "/user")
         return data.get("login") if isinstance(data, dict) else None
-    except (httpx.HTTPStatusError, httpx.RequestError):
-        # Installation (App) tokens aren't user-to-server tokens and can't call /user --
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 403:
+            # Not the expected "installation token can't call /user" case -- a real
+            # auth/server failure (401/404/5xx). Let it propagate rather than silently
+            # masquerading as "this user has zero PRs/issues".
+            raise
+        # Installation (App) tokens aren't user-to-server tokens and get a 403 here --
         # fall back to the signed-in Clevis user's own GitHub OAuth-linked login (if any)
         # instead of silently returning zero PRs/issues for someone who really has some.
         # Still None (caller degrades to an empty response) if the user never linked

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -168,6 +168,12 @@ class MyViewResponse(BaseModel):
     review_requests: list[PRSummary] = []
     assigned_issues: list[IssueSummary] = []
     my_recent_runs: list[RunSummaryLite] = []
+    # True when GitHub's /user (the source of "who am I") couldn't be resolved -- an
+    # installation (App) token can't call it, and the signed-in Clevis user has no
+    # GitHub-OAuth-linked login to fall back on either. Distinguishes "we don't know who
+    # you are on GitHub" from "you genuinely have zero open PRs/reviews/issues", which
+    # would otherwise render identically as an empty list.
+    identity_unresolved: bool = False
 
 
 class MyPrListResponse(BaseModel):
@@ -175,6 +181,7 @@ class MyPrListResponse(BaseModel):
     total_count: int = 0
     page: int = 1
     per_page: int = 25
+    identity_unresolved: bool = False
 
 
 class MyIssueListResponse(BaseModel):
@@ -182,6 +189,7 @@ class MyIssueListResponse(BaseModel):
     total_count: int = 0
     page: int = 1
     per_page: int = 25
+    identity_unresolved: bool = False
 
 
 class ActionsUsageResponse(BaseModel):

--- a/apps/api/tests/test_analytics_my_items.py
+++ b/apps/api/tests/test_analytics_my_items.py
@@ -69,7 +69,38 @@ def test_degrades_to_empty_when_login_unresolvable(http, path):
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"items": [], "total_count": 0, "page": 1, "per_page": 25}
+    assert body == {"items": [], "total_count": 0, "page": 1, "per_page": 25, "identity_unresolved": True}
+
+
+def test_falls_back_to_users_github_login_when_user_endpoint_unresolvable(app, http):
+    """A GitHub App installation token can't call GET /user, but if the signed-in Clevis
+    user linked their own GitHub identity via OAuth, my-prs should use that login rather
+    than degrading to empty."""
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=1, email="myitems@example.com", name=None, is_workspace_admin=False, github_login="octocat"
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            raise httpx.HTTPStatusError(
+                "boom",
+                request=httpx.Request("GET", "https://api.github.com/user"),
+                response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+            )
+        if path == "/search/issues":
+            assert "author:octocat" in params["q"]
+            return {"items": [], "total_count": 0}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        resp = http.get("/me/github/my-prs?owner=acme")
+
+    assert resp.status_code == 200
+    assert resp.json()["identity_unresolved"] is False
 
 
 def test_my_prs_success_returns_pagination_fields(http):
@@ -177,7 +208,7 @@ def test_page_times_per_page_over_1000_returns_empty_without_calling_github(http
     body = resp.json()
     # total_count is capped at the reachable max (not 0) so page/lastPage math on the
     # client stays consistent instead of regressing once paging crosses GitHub's window.
-    assert body == {"items": [], "total_count": 1000, "page": 11, "per_page": 100}
+    assert body == {"items": [], "total_count": 1000, "page": 11, "per_page": 100, "identity_unresolved": False}
 
 
 def test_search_failure_degrades_to_empty_not_500(http):

--- a/apps/api/tests/test_analytics_my_items.py
+++ b/apps/api/tests/test_analytics_my_items.py
@@ -72,6 +72,39 @@ def test_degrades_to_empty_when_login_unresolvable(http, path):
     assert body == {"items": [], "total_count": 0, "page": 1, "per_page": 25, "identity_unresolved": True}
 
 
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+def test_propagates_unexpected_user_endpoint_error(http, path):
+    """A non-403 failure calling GET /user (a real auth/server problem, not the expected
+    "installation token can't call /user" case) must propagate rather than being silently
+    swallowed as identity_unresolved."""
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(500, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            http.get(f"{path}?owner=acme")
+
+
+@pytest.mark.parametrize("path", ["/me/github/my-prs", "/me/github/my-reviews", "/me/github/my-issues"])
+def test_propagates_network_error_from_user_endpoint(http, path):
+    """A network-level failure (timeout, DNS, connection reset) calling GET /user must
+    also propagate rather than being treated as the expected App-token case."""
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.RequestError(
+            "boom", request=httpx.Request("GET", "https://api.github.com/user")
+        )
+        with pytest.raises(httpx.RequestError):
+            http.get(f"{path}?owner=acme")
+
+
 def test_falls_back_to_users_github_login_when_user_endpoint_unresolvable(app, http):
     """A GitHub App installation token can't call GET /user, but if the signed-in Clevis
     user linked their own GitHub identity via OAuth, my-prs should use that login rather
@@ -259,7 +292,15 @@ def test_non_dict_search_response_degrades_to_empty(http):
 
 def test_falls_back_to_client_supplied_token_header(http):
     with patch("src.routers.analytics.GitHubClient") as mock_client:
-        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        # 403 (not a bare network error) -- this test is exercising the client-supplied
+        # X-GitHub-Token header path (no 400 from a missing token), not /user's error
+        # handling, so it uses the "expected" degrade-to-empty case rather than a
+        # network failure that would now (correctly) propagate.
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
         resp = http.get("/me/github/my-prs?owner=acme", headers={"X-GitHub-Token": "ghp_client"})
 
     assert resp.status_code == 200

--- a/apps/api/tests/test_analytics_my_view.py
+++ b/apps/api/tests/test_analytics_my_view.py
@@ -78,6 +78,38 @@ def test_my_view_degrades_to_empty_when_login_unresolvable(http):
     }
 
 
+def test_my_view_propagates_unexpected_user_endpoint_error(http):
+    """A non-403 failure calling GET /user (a real auth/server problem, not the expected
+    "installation token can't call /user" case) must not be silently swallowed as
+    identity_unresolved -- it should propagate so the failure stays visible to the caller
+    instead of masquerading as "this user has zero PRs/issues"."""
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(500, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            http.get("/me/github/my-view?owner=acme")
+
+
+def test_my_view_propagates_network_error_from_user_endpoint(http):
+    """A network-level failure (timeout, DNS, connection reset) calling GET /user must
+    also propagate rather than being treated as the expected App-token case."""
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = httpx.RequestError(
+            "boom", request=httpx.Request("GET", "https://api.github.com/user")
+        )
+        with pytest.raises(httpx.RequestError):
+            http.get("/me/github/my-view?owner=acme")
+
+
 def test_my_view_falls_back_to_users_github_login_when_user_endpoint_unresolvable(app, http):
     """A GitHub App installation token can't call GET /user, but if the signed-in Clevis
     user linked their own GitHub identity via OAuth, my-view should use that login rather
@@ -173,7 +205,15 @@ def test_my_view_success(http):
 
 def test_my_view_falls_back_to_client_supplied_token_header(http):
     with patch("src.routers.analytics.GitHubClient") as mock_client:
-        mock_client.return_value.request.side_effect = httpx.RequestError("boom")
+        # 403 (not a bare network error) -- this test is exercising the client-supplied
+        # X-GitHub-Token header path (no 400 from a missing token), not /user's error
+        # handling, so it uses the "expected" degrade-to-empty case rather than a
+        # network failure that would now (correctly) propagate.
+        mock_client.return_value.request.side_effect = httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("GET", "https://api.github.com/user"),
+            response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+        )
         resp = http.get("/me/github/my-view?owner=acme", headers={"X-GitHub-Token": "ghp_client"})
 
     assert resp.status_code == 200

--- a/apps/api/tests/test_analytics_my_view.py
+++ b/apps/api/tests/test_analytics_my_view.py
@@ -53,8 +53,9 @@ def test_my_view_no_token_available_returns_400(http):
 
 
 def test_my_view_degrades_to_empty_when_login_unresolvable(http):
-    """An installation (App) token can't call GET /user -- this should degrade to an
-    empty MyViewResponse, not 500 the page."""
+    """An installation (App) token can't call GET /user, and this mock_user has no
+    GitHub-OAuth-linked login to fall back on either -- this should degrade to an empty
+    MyViewResponse flagged identity_unresolved, not 500 the page."""
     with (
         patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
         patch("src.routers.analytics.GitHubClient") as mock_client,
@@ -68,7 +69,57 @@ def test_my_view_degrades_to_empty_when_login_unresolvable(http):
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"my_open_prs": [], "review_requests": [], "assigned_issues": [], "my_recent_runs": []}
+    assert body == {
+        "my_open_prs": [],
+        "review_requests": [],
+        "assigned_issues": [],
+        "my_recent_runs": [],
+        "identity_unresolved": True,
+    }
+
+
+def test_my_view_falls_back_to_users_github_login_when_user_endpoint_unresolvable(app, http):
+    """A GitHub App installation token can't call GET /user, but if the signed-in Clevis
+    user linked their own GitHub identity via OAuth, my-view should use that login rather
+    than degrading to empty -- an App-connected org shouldn't silently hide a real user's
+    PRs/issues just because the *org's* token isn't a personal one."""
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=1, email="myview@example.com", name=None, is_workspace_admin=False, github_login="octocat"
+    )
+
+    def _request_side_effect(method, path, params=None):
+        if path == "/user":
+            raise httpx.HTTPStatusError(
+                "boom",
+                request=httpx.Request("GET", "https://api.github.com/user"),
+                response=httpx.Response(403, request=httpx.Request("GET", "https://api.github.com/user")),
+            )
+        if path == "/search/issues":
+            q = params["q"]
+            if "author:octocat" in q:
+                return {"items": [{
+                    "number": 12,
+                    "title": "Fix bug",
+                    "repository_url": "https://api.github.com/repos/acme/api",
+                    "html_url": "https://github.com/acme/api/pull/12",
+                    "updated_at": "2026-07-20T00:00:00Z",
+                }]}
+            return {"items": []}
+        return {}
+
+    with (
+        patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"),
+        patch("src.routers.analytics.GitHubClient") as mock_client,
+    ):
+        mock_client.return_value.request.side_effect = _request_side_effect
+        mock_client.return_value.request_paginated.return_value = []
+        resp = http.get("/me/github/my-view?owner=acme")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["identity_unresolved"] is False
+    assert len(body["my_open_prs"]) == 1
+    assert body["my_open_prs"][0]["repository"] == "acme/api"
 
 
 def test_my_view_success(http):

--- a/apps/ui/app/audit/page.tsx
+++ b/apps/ui/app/audit/page.tsx
@@ -6,8 +6,10 @@ import { useQuery } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { EmptyStateInline } from "@/components/empty-state"
 import { SectionError } from "@/components/section-error"
+import { Button } from "@/components/ui/button"
+import { DataTable, type DataTableColumn } from "@/components/ui/data-table"
 import { api } from "@/lib/api/client"
-import type { JobOut } from "@/lib/api/types"
+import type { AuditLogOut, JobOut } from "@/lib/api/types"
 
 const ACTION_TYPES = [
   "",
@@ -25,6 +27,13 @@ const JOB_STATUS_COLOR: Record<JobOut["status"], string> = {
   failed:     "text-destructive",
 }
 
+// The backend has no true offset/cursor pagination -- /audit only ever returns the N
+// most recent rows (Query(default=100, le=500)) -- so "Load more" re-fetches with a
+// bigger limit rather than requesting a next page.
+const INITIAL_LIMIT = 100
+const LIMIT_STEP = 100
+const MAX_LIMIT = 500
+
 // audit_logs.payload embeds job_id for cache-clear rows (a deliberate cross-reference,
 // not duplicate data -- see #281) so a row's live job status can be shown inline instead
 // of sending the user to a separate Job Queue page for exactly one operation type.
@@ -40,12 +49,19 @@ function parseJobId(payload: string): number | null {
 
 export default function AuditPage() {
   const [actionFilter, setActionFilter] = useState("")
+  const [limit, setLimit] = useState(INITIAL_LIMIT)
   const searchParams = useSearchParams()
   const highlightJobId = Number(searchParams.get("job_id")) || null
 
+  // A new filter starts back at the default window -- an old "load more" bump for a
+  // different (or no) filter isn't a meaningful limit for this one.
+  useEffect(() => {
+    setLimit(INITIAL_LIMIT)
+  }, [actionFilter])
+
   const { data: logs = [], isLoading, isError, error, isFetching, refetch } = useQuery({
-    queryKey: ["audit", actionFilter],
-    queryFn: () => api.audit.list(actionFilter || undefined),
+    queryKey: ["audit", actionFilter, limit],
+    queryFn: () => api.audit.list(actionFilter || undefined, limit),
     refetchInterval: 30_000,
   })
 
@@ -64,6 +80,54 @@ export default function AuditPage() {
       highlightRef.current.scrollIntoView({ block: "center", behavior: "smooth" })
     }
   }, [highlightJobId, logs.length])
+
+  const columns: DataTableColumn<AuditLogOut>[] = [
+    {
+      key: "actor",
+      header: "Actor",
+      sortValue: (log) => log.actor,
+      cellClassName: "font-mono text-foreground/80",
+      render: (log) => log.actor,
+    },
+    {
+      key: "action",
+      header: "Action",
+      sortValue: (log) => log.action,
+      cellClassName: "text-primary font-mono",
+      render: (log) => log.action,
+    },
+    {
+      key: "target",
+      header: "Target",
+      sortValue: (log) => log.target,
+      cellClassName: "text-muted-foreground max-w-[14rem] truncate",
+      render: (log) => log.target,
+    },
+    {
+      key: "job_status",
+      header: "Job status",
+      cellClassName: "font-mono",
+      render: (log) => {
+        const jobId = parseJobId(log.payload)
+        const job = jobId !== null ? jobsById.get(jobId) : undefined
+        return job ? (
+          <span className={`font-medium ${JOB_STATUS_COLOR[job.status]}`}>{job.status}</span>
+        ) : jobId !== null && isJobsError ? (
+          <span className="text-destructive" title="Failed to load job status">failed to load</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )
+      },
+    },
+    {
+      key: "created_at",
+      header: "Time",
+      align: "right",
+      sortValue: (log) => new Date(log.created_at).getTime(),
+      cellClassName: "font-mono text-muted-foreground whitespace-nowrap",
+      render: (log) => new Date(log.created_at).toLocaleString(),
+    },
+  ]
 
   return (
     <>
@@ -100,52 +164,42 @@ export default function AuditPage() {
         ) : logs.length === 0 ? (
           <EmptyStateInline noun="audit events" qualifier={actionFilter || undefined} />
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="text-left section-label px-4 py-2">Actor</th>
-                  <th className="text-left section-label px-4 py-2">Action</th>
-                  <th className="text-left section-label px-4 py-2">Target</th>
-                  <th className="text-left section-label px-4 py-2">Job status</th>
-                  <th className="text-right section-label px-4 py-2">Time</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {logs.map((log) => {
-                  const jobId = parseJobId(log.payload)
-                  const job = jobId !== null ? jobsById.get(jobId) : undefined
-                  const isHighlighted = highlightJobId !== null && jobId === highlightJobId
-                  return (
-                    <tr
-                      key={log.id}
-                      ref={isHighlighted ? highlightRef : null}
-                      className={[
-                        "hover:bg-elevated transition-colors",
-                        isHighlighted ? "ring-1 ring-inset ring-primary/40 bg-primary/5" : "",
-                      ].join(" ")}
-                    >
-                      <td className="px-4 py-2.5 font-mono text-foreground/80">{log.actor}</td>
-                      <td className="px-4 py-2.5 text-primary font-mono">{log.action}</td>
-                      <td className="px-4 py-2.5 text-muted-foreground max-w-[14rem] truncate">{log.target}</td>
-                      <td className="px-4 py-2.5 font-mono">
-                        {job ? (
-                          <span className={`font-medium ${JOB_STATUS_COLOR[job.status]}`}>{job.status}</span>
-                        ) : jobId !== null && isJobsError ? (
-                          <span className="text-destructive" title="Failed to load job status">failed to load</span>
-                        ) : (
-                          <span className="text-muted-foreground">—</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-muted-foreground whitespace-nowrap">
-                        {new Date(log.created_at).toLocaleString()}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
+          <>
+            <DataTable
+              columns={columns}
+              data={logs}
+              getRowKey={(log) => log.id}
+              // Set high enough that this table's own pagination never triggers (the
+              // backend already caps rows at MAX_LIMIT) -- "Load more" below, not
+              // client-side paging, is what lets a highlighted row past the current
+              // window stay reachable instead of hiding behind an unrelated page click.
+              pageSize={MAX_LIMIT}
+              getRowRef={(log) => {
+                const jobId = parseJobId(log.payload)
+                return highlightJobId !== null && jobId === highlightJobId ? highlightRef : undefined
+              }}
+              rowClassName={(log) => {
+                const jobId = parseJobId(log.payload)
+                const isHighlighted = highlightJobId !== null && jobId === highlightJobId
+                return [
+                  "hover:bg-elevated transition-colors",
+                  isHighlighted ? "ring-1 ring-inset ring-primary/40 bg-primary/5" : "",
+                ].join(" ")
+              }}
+            />
+            {logs.length >= limit && limit < MAX_LIMIT && (
+              <div className="px-4 py-3 border-t border-border flex justify-center">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isFetching}
+                  onClick={() => setLimit((l) => Math.min(l + LIMIT_STEP, MAX_LIMIT))}
+                >
+                  {isFetching ? "Loading…" : "Load more"}
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </>

--- a/apps/ui/app/layout.tsx
+++ b/apps/ui/app/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css"
 import { Geist, Archivo, JetBrains_Mono } from "next/font/google"
 import { cn } from "@/lib/utils"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { Toaster } from "@/components/ui/toast"
 import { QueryProvider } from "@/components/query-provider"
 import { AuthProvider } from "@/lib/auth-context"
 import { AuthGuard } from "@/components/auth-guard"
@@ -59,6 +60,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <AuthProvider>
                 <AuthGuard>
                   <ShellRouter>{children}</ShellRouter>
+                  <Toaster />
                 </AuthGuard>
               </AuthProvider>
             </IconProvider>

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { CircleNotch, Warning } from "@phosphor-icons/react"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
@@ -113,8 +114,8 @@ export default function LoginPage() {
         )}
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+          <Field>
+            <FieldLabel>Email</FieldLabel>
             <Input
               type="email"
               placeholder="you@example.com"
@@ -123,9 +124,9 @@ export default function LoginPage() {
               required
               autoComplete="email"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Password</label>
+          </Field>
+          <Field>
+            <FieldLabel>Password</FieldLabel>
             <Input
               type="password"
               placeholder="Password"
@@ -134,7 +135,7 @@ export default function LoginPage() {
               required
               autoComplete="current-password"
             />
-          </div>
+          </Field>
 
           {error && (
             <p className="text-xs text-destructive">{error}</p>

--- a/apps/ui/app/my/page.tsx
+++ b/apps/ui/app/my/page.tsx
@@ -129,6 +129,7 @@ export default function MyWorkPage() {
           page={page}
           perPage={PER_PAGE}
           onPageChange={setPage}
+          identityUnresolved={itemsQuery.data?.identity_unresolved}
         />
       )}
     </>

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -53,8 +53,9 @@ const quickActions = [
   { label: "View Collaborators", href: "/collaborators" },
 ]
 
-function LiveStatCard({ label, loading, configured, value, trend }: {
+function LiveStatCard({ label, href, loading, configured, value, trend }: {
   label: string
+  href: string
   loading: boolean
   configured: boolean
   value: number | undefined
@@ -62,7 +63,7 @@ function LiveStatCard({ label, loading, configured, value, trend }: {
 }) {
   if (!configured) {
     return (
-      <Link href="/security" className="card px-4 py-4 block hover:bg-elevated transition-colors">
+      <Link href={href} className="card px-4 py-4 block hover:bg-elevated transition-colors">
         <p className="telemetry-label mb-2 block">
           {label}
         </p>
@@ -194,18 +195,21 @@ export default function OverviewPage() {
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-px mb-6 border border-border bg-border">
         <LiveStatCard
           label="Repositories"
+          href="/repos"
           loading={cockpitQuery.isLoading}
           configured={configured}
           value={cockpit?.repo_count}
         />
         <LiveStatCard
           label="Open PRs"
+          href="/pulls"
           loading={cockpitQuery.isLoading}
           configured={configured}
           value={cockpit?.open_pr_count}
         />
         <LiveStatCard
           label="Security Score"
+          href="/security"
           loading={cockpitQuery.isLoading}
           configured={configured}
           value={cockpit?.latest_score ?? undefined}
@@ -213,6 +217,7 @@ export default function OverviewPage() {
         />
         <LiveStatCard
           label="Team Members"
+          href="/collaborators"
           loading={cockpitQuery.isLoading}
           configured={configured}
           value={cockpit?.member_count}
@@ -438,6 +443,11 @@ export default function OverviewPage() {
           </div>
           {myViewQuery.isLoading ? (
             <p className="p-4 text-sm text-muted-foreground">Loading…</p>
+          ) : myView?.identity_unresolved ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              Clevis can’t tell who you are on GitHub for this account — sign in with GitHub
+              (or add a personal access token) to see this.
+            </p>
           ) : myViewItems.length === 0 ? (
             <p className="p-4 text-sm text-muted-foreground">Nothing here right now</p>
           ) : (

--- a/apps/ui/app/register/page.tsx
+++ b/apps/ui/app/register/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { CircleNotch } from "@phosphor-icons/react"
 
 export default function RegisterPage() {
@@ -64,17 +65,17 @@ export default function RegisterPage() {
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Name (optional)</label>
+          <Field>
+            <FieldLabel>Name (optional)</FieldLabel>
             <Input
               placeholder="Your name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               autoComplete="name"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+          </Field>
+          <Field>
+            <FieldLabel>Email</FieldLabel>
             <Input
               type="email"
               placeholder="you@example.com"
@@ -83,9 +84,9 @@ export default function RegisterPage() {
               required
               autoComplete="email"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Password</label>
+          </Field>
+          <Field>
+            <FieldLabel>Password</FieldLabel>
             <Input
               type="password"
               placeholder="At least 12 characters"
@@ -94,9 +95,9 @@ export default function RegisterPage() {
               required
               autoComplete="new-password"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Confirm password</label>
+          </Field>
+          <Field>
+            <FieldLabel>Confirm password</FieldLabel>
             <Input
               type="password"
               placeholder="Repeat password"
@@ -105,7 +106,7 @@ export default function RegisterPage() {
               required
               autoComplete="new-password"
             />
-          </div>
+          </Field>
 
           {error && (
             <p className="text-xs text-destructive">{error}</p>

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
+import { EmptyStateNoAccount } from "@/components/empty-state"
 import { CheckCard } from "@/components/check-card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Input } from "@/components/ui/input"
@@ -105,6 +106,14 @@ export default function SecurityPage() {
   useEffect(() => {
     setOwner(scopeOrgLogin)
   }, [scopeOrgLogin])
+
+  // Same pattern as the other pages that gate on useActiveScope() (see app/page.tsx,
+  // app/repos/page.tsx, etc.) -- deferred a tick so this doesn't flash before
+  // useActiveScope's first read of localStorage resolves.
+  const [scopeChecked, setScopeChecked] = useState(false)
+  useEffect(() => {
+    setScopeChecked(true)
+  }, [])
 
   const { data: installs = [] } = useQuery<InstallationMeta[]>({
     queryKey: ["installations"],
@@ -257,6 +266,10 @@ export default function SecurityPage() {
         title="Health & Security"
         description="Run security checks against a GitHub organization."
       />
+
+      {scopeChecked && !scope && (
+        <EmptyStateNoAccount message="No account selected — pick an organization from the profile menu to prefill the scan below, or just type one in directly." />
+      )}
 
       <div className="grid gap-4 lg:grid-cols-3">
         {/* Config */}

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -6,11 +6,58 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tansta
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { DataTable, type DataTableColumn } from "@/components/ui/data-table"
 import { CircleNotch, EnvelopeSimple, Warning, X } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { addRevokingId, isRevoking, removeRevokingId } from "@/lib/revoke-pending"
 import { relativeTime } from "@/lib/format"
-import type { InvitationOut } from "@/lib/api/types"
+import type { GithubOrgMember, InvitationOut } from "@/lib/api/types"
+
+const MEMBER_COLUMNS: DataTableColumn<GithubOrgMember>[] = [
+  {
+    key: "login",
+    header: "Member",
+    sortValue: (m) => m.login.toLowerCase(),
+    render: (m) => (
+      <div className="flex items-center gap-2">
+        {/* Decorative: the member login is the adjacent link text, so an empty alt
+            avoids a duplicate screen-reader announcement. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={m.avatar_url} alt="" className="size-5 rounded-full" />
+        <a
+          href={`https://github.com/${m.login}`}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground/80 hover:text-foreground"
+        >
+          {m.login}
+        </a>
+      </div>
+    ),
+  },
+  {
+    key: "role",
+    header: "Role",
+    sortValue: (m) => m.role,
+    cellClassName: "text-muted-foreground capitalize",
+    render: (m) => m.role,
+  },
+  {
+    key: "two_factor_enabled",
+    header: "2FA",
+    // Groups unknown (null) between the two known states rather than sorting it to an
+    // arbitrary end -- there's no natural "less/more 2FA" ordering for "we don't know".
+    sortValue: (m) => (m.two_factor_enabled === true ? 1 : m.two_factor_enabled === false ? -1 : 0),
+    render: (m) => (
+      <>
+        {m.two_factor_enabled === true && <span className="stat-chip">✓ 2FA</span>}
+        {m.two_factor_enabled === false && (
+          <span className="stat-chip text-red-400 border-red-500/30">No 2FA</span>
+        )}
+      </>
+    ),
+  },
+]
 
 const ROSTER_TABS = [
   { id: "members", label: "Members" },
@@ -180,46 +227,7 @@ function GithubRoster({ orgLogin }: { orgLogin: string }) {
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs">
-                <thead>
-                  <tr className="border-b border-border">
-                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Member</th>
-                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Role</th>
-                    <th className="text-left text-muted-foreground font-medium px-4 py-2">2FA</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {filteredMembers.map((m) => (
-                    <tr key={m.login}>
-                      <td className="px-4 py-2.5">
-                        <div className="flex items-center gap-2">
-                          {/* Decorative: the member login is the adjacent link text, so an
-                              empty alt avoids a duplicate screen-reader announcement. */}
-                          {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img src={m.avatar_url} alt="" className="size-5 rounded-full" />
-                          <a
-                            href={`https://github.com/${m.login}`}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-foreground/80 hover:text-foreground"
-                          >
-                            {m.login}
-                          </a>
-                        </div>
-                      </td>
-                      <td className="px-4 py-2.5 text-muted-foreground capitalize">{m.role}</td>
-                      <td className="px-4 py-2.5">
-                        {m.two_factor_enabled === true && <span className="stat-chip">✓ 2FA</span>}
-                        {m.two_factor_enabled === false && (
-                          <span className="stat-chip text-red-400 border-red-500/30">No 2FA</span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <DataTable columns={MEMBER_COLUMNS} data={filteredMembers} getRowKey={(m) => m.login} />
             {membersQuery.data?.two_factor_overlay_available && (
               <div className="px-4 py-2.5 border-t border-border">
                 <span className="text-xs text-muted-foreground">Members without 2FA: {membersWithout2fa}</span>

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { Trash, Plus, CircleNotch, Check, ArrowSquareOut, CheckCircle } from "@p
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Field, FieldLabel, FieldDescription } from "@/components/ui/field"
 import { SectionError } from "@/components/section-error"
 import { EmptyStatePage } from "@/components/empty-state"
 import { PermissionDriftNotice } from "@/components/permission-drift-notice"
@@ -74,19 +75,19 @@ function ProfileSection() {
         <span className="section-label">Profile</span>
       </div>
       <div className="p-4 flex flex-col gap-3 max-w-sm">
-        <div>
-          <label className="text-xs font-medium text-foreground block mb-1.5">Display name</label>
+        <Field>
+          <FieldLabel>Display name</FieldLabel>
           <Input
             placeholder="Your name"
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
-        </div>
-        <div>
-          <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+        </Field>
+        <Field>
+          <FieldLabel>Email</FieldLabel>
           <Input value={user?.email || ""} disabled className="opacity-60 cursor-not-allowed" />
-          <p className="text-xs text-muted-foreground mt-1">Email cannot be changed.</p>
-        </div>
+          <FieldDescription>Email cannot be changed.</FieldDescription>
+        </Field>
         <p className="text-xs text-muted-foreground -mt-1">
           Switch between your organizations and personal GitHub account from the profile menu in the sidebar.
         </p>
@@ -517,23 +518,32 @@ function SavedTokensSection() {
       <div className="border-t border-border p-4">
         <p className="text-xs font-medium text-foreground mb-3">Add token</p>
         <div className="grid gap-2 sm:grid-cols-3">
-          <Input
-            placeholder="Org or owner"
-            value={addOrg}
-            onChange={(e) => setAddOrg(e.target.value)}
-          />
-          <Input
-            placeholder="ghp_… token"
-            type="password"
-            value={addToken}
-            onChange={(e) => setAddToken(e.target.value)}
-            className="font-mono"
-          />
-          <Input
-            placeholder="Label (optional)"
-            value={addLabel}
-            onChange={(e) => setAddLabel(e.target.value)}
-          />
+          <Field>
+            <FieldLabel className="sr-only">Org or owner</FieldLabel>
+            <Input
+              placeholder="Org or owner"
+              value={addOrg}
+              onChange={(e) => setAddOrg(e.target.value)}
+            />
+          </Field>
+          <Field>
+            <FieldLabel className="sr-only">Token</FieldLabel>
+            <Input
+              placeholder="ghp_… token"
+              type="password"
+              value={addToken}
+              onChange={(e) => setAddToken(e.target.value)}
+              className="font-mono"
+            />
+          </Field>
+          <Field>
+            <FieldLabel className="sr-only">Label (optional)</FieldLabel>
+            <Input
+              placeholder="Label (optional)"
+              value={addLabel}
+              onChange={(e) => setAddLabel(e.target.value)}
+            />
+          </Field>
         </div>
         <Button
           onClick={() => upsert.mutate()}

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -10,6 +10,8 @@ import { Button } from "@/components/ui/button"
 import { SectionError } from "@/components/section-error"
 import { EmptyStatePage } from "@/components/empty-state"
 import { PermissionDriftNotice } from "@/components/permission-drift-notice"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
+import { toast } from "@/components/ui/toast"
 import Link from "next/link"
 import { api } from "@/lib/api/client"
 import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values"
@@ -248,15 +250,7 @@ type ConnectedInstallation = InstallationMeta & (
 
 function ConnectedOrgsSection() {
   const queryClient = useQueryClient()
-  const [confirmingKey, setConfirmingKey] = useState<string | null>(null)
-
-  // Auto-disarm if the user doesn't confirm within a few seconds, same pattern as
-  // ProfileSection's "Sign out of all devices" above.
-  useEffect(() => {
-    if (!confirmingKey) return
-    const timer = setTimeout(() => setConfirmingKey(null), 4000)
-    return () => clearTimeout(timer)
-  }, [confirmingKey])
+  const [confirmRow, setConfirmRow] = useState<ConnectedInstallation | null>(null)
 
   const personalQuery = useQuery<InstallationMeta[]>({
     queryKey: ["installations", "me"],
@@ -296,11 +290,15 @@ function ConnectedOrgsSection() {
       if (row.installation_id == null) return Promise.reject(new Error("This connection has no GitHub installation to disconnect."))
       return api.installations.remove(row.scope === "me" ? { scope: "me" } : { scope: "org", orgLogin: row.orgLogin }, row.installation_id)
     },
-    onSuccess: () => {
+    onSuccess: (_data, row) => {
       queryClient.invalidateQueries({ queryKey: ["installations"] })
-      setConfirmingKey(null)
+      setConfirmRow(null)
+      toast.success(`Disconnected ${row.account_login}.`)
     },
-    onError: () => setConfirmingKey(null),
+    onError: (error) => {
+      setConfirmRow(null)
+      toast.error(error instanceof Error ? error.message : "Disconnect failed.")
+    },
   })
 
   const rowKey = (row: ConnectedInstallation) => `${row.scope}:${row.id}`
@@ -347,7 +345,6 @@ function ConnectedOrgsSection() {
             <tbody className="divide-y divide-border">
               {rows.map((row) => {
                 const key = rowKey(row)
-                const isConfirming = confirmingKey === key
                 const isThisRowMutating = disconnect.isPending && disconnect.variables && rowKey(disconnect.variables) === key
                 const showDrift = (row.blocked_features?.length ?? 0) > 0 || row.permissions_synced_at === null
                 return (
@@ -366,18 +363,10 @@ function ConnectedOrgsSection() {
                         variant="destructive"
                         size="sm"
                         disabled={disconnect.isPending}
-                        onClick={() => {
-                          if (isConfirming) {
-                            disconnect.mutate(row)
-                          } else {
-                            setConfirmingKey(key)
-                          }
-                        }}
+                        onClick={() => setConfirmRow(row)}
                       >
                         {isThisRowMutating ? (
                           <CircleNotch className="size-3 animate-spin" />
-                        ) : isConfirming ? (
-                          "Confirm disconnect"
                         ) : (
                           <><Trash className="size-3" />Disconnect</>
                         )}
@@ -411,6 +400,20 @@ function ConnectedOrgsSection() {
           </p>
         )}
       </div>
+
+      <ConfirmDialog
+        open={confirmRow !== null}
+        onOpenChange={(open) => { if (!open) setConfirmRow(null) }}
+        title="Disconnect this account?"
+        description={
+          confirmRow
+            ? `Clevis will stop being able to access ${confirmRow.account_login} until it's reinstalled.`
+            : ""
+        }
+        confirmLabel="Disconnect"
+        onConfirm={() => confirmRow && disconnect.mutate(confirmRow)}
+        pending={disconnect.isPending}
+      />
     </div>
   )
 }

--- a/apps/ui/app/setup/page.tsx
+++ b/apps/ui/app/setup/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { CircleNotch } from "@phosphor-icons/react"
 
 export default function SetupPage() {
@@ -72,17 +73,17 @@ export default function SetupPage() {
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Name (optional)</label>
+          <Field>
+            <FieldLabel>Name (optional)</FieldLabel>
             <Input
               placeholder="Your name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               autoComplete="name"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+          </Field>
+          <Field>
+            <FieldLabel>Email</FieldLabel>
             <Input
               type="email"
               placeholder="you@example.com"
@@ -91,9 +92,9 @@ export default function SetupPage() {
               required
               autoComplete="email"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Password</label>
+          </Field>
+          <Field>
+            <FieldLabel>Password</FieldLabel>
             <Input
               type="password"
               placeholder="At least 12 characters"
@@ -102,9 +103,9 @@ export default function SetupPage() {
               required
               autoComplete="new-password"
             />
-          </div>
-          <div>
-            <label className="text-xs font-medium text-foreground block mb-1.5">Confirm password</label>
+          </Field>
+          <Field>
+            <FieldLabel>Confirm password</FieldLabel>
             <Input
               type="password"
               placeholder="Repeat password"
@@ -113,7 +114,7 @@ export default function SetupPage() {
               required
               autoComplete="new-password"
             />
-          </div>
+          </Field>
 
           {error && (
             <p className="text-xs text-destructive">{error}</p>

--- a/apps/ui/components/my-items-list.tsx
+++ b/apps/ui/components/my-items-list.tsx
@@ -16,6 +16,10 @@ interface MyItemsListProps {
   page: number
   perPage: number
   onPageChange: (page: number) => void
+  /** True when the backend couldn't resolve who the signed-in user is on GitHub (an
+   * installation/App token can't call GET /user, and this account has no GitHub-OAuth
+   * login on file) -- render a distinct message instead of implying zero items exist. */
+  identityUnresolved?: boolean
 }
 
 // Full-page generalization of the Overview widget's MyViewRow — same row shape
@@ -34,6 +38,7 @@ export function MyItemsList({
   page,
   perPage,
   onPageChange,
+  identityUnresolved = false,
 }: MyItemsListProps) {
   const lastPage = Math.max(1, Math.ceil(totalCount / perPage))
 
@@ -45,6 +50,14 @@ export function MyItemsList({
         </div>
       ) : isError ? (
         <SectionError message={errorMessage} onRetry={onRetry} retrying={retrying} />
+      ) : identityUnresolved ? (
+        <div className="px-4 py-8 border-t border-border/60">
+          <p className="text-sm text-muted-foreground">
+            Clevis can’t tell who you are on GitHub for this account — the connected access
+            doesn’t carry a personal identity. Sign in with GitHub (or add a personal access
+            token) to see your {emptyNoun} here.
+          </p>
+        </div>
       ) : items.length === 0 ? (
         <EmptyStateInline noun={emptyNoun} />
       ) : (

--- a/apps/ui/components/repo/cache-panel.tsx
+++ b/apps/ui/components/repo/cache-panel.tsx
@@ -6,6 +6,8 @@ import Link from "next/link"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
+import { toast } from "@/components/ui/toast"
 import { Warning, Eye, Key, CircleNotch, Trash } from "@phosphor-icons/react"
 import { api } from "@/lib/api/client"
 import { shouldApplyResolvedToken } from "@/lib/token-resolve"
@@ -31,7 +33,7 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
   const [token, setToken] = useState("")
   const [tokenSaved, setTokenSaved] = useState(false)
   const [actor, setActor] = useState("")
-  const [clearArmed, setClearArmed] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
   // null = clearing every cache for this repo (the existing global buttons); set to a
   // specific { key, ref } when the user clicks a row's own "Clear" action instead.
   const [clearTarget, setClearTarget] = useState<{ key: string; ref: string } | null>(null)
@@ -92,24 +94,16 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner, active])
 
-  // Reset stale cache-table/clear-result data and any armed "Confirm clear" state
-  // whenever the owner/repo this panel is scoped to changes (route navigation, or a
-  // tab switch back to a differently-scoped repo).
+  // Reset stale cache-table/clear-result data and any open confirm dialog whenever the
+  // owner/repo this panel is scoped to changes (route navigation, or a tab switch back
+  // to a differently-scoped repo).
   useEffect(() => {
     listMutation.reset()
     clearMutation.reset()
-    setClearArmed(false)
+    setConfirmOpen(false)
     setClearTarget(null)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner, repo])
-
-  // Auto-disarm if the user doesn't confirm within a few seconds, so a stray
-  // later click on the same button spot can't be mistaken for a confirmation.
-  useEffect(() => {
-    if (!clearArmed) return
-    const timer = setTimeout(() => setClearArmed(false), 4000)
-    return () => clearTimeout(timer)
-  }, [clearArmed])
 
 
   const saveTokenMutation = useMutation({
@@ -130,6 +124,18 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
         key: clearTarget?.key,
         ref: clearTarget?.ref,
       }),
+    onSuccess: (data) => {
+      setConfirmOpen(false)
+      if (data.dry_run) {
+        toast.info("Dry run complete — no caches were deleted.")
+      } else if (data.job_id) {
+        toast.success(`Cache clear queued — Job #${data.job_id}`)
+      }
+    },
+    onError: (error) => {
+      setConfirmOpen(false)
+      toast.error(error.message)
+    },
   })
 
   const isLoading = listMutation.isPending || clearMutation.isPending
@@ -199,11 +205,11 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
             <Input
               placeholder="actor"
               value={actor}
-              onChange={(e) => { setActor(e.target.value); setClearArmed(false) }}
+              onChange={(e) => setActor(e.target.value)}
             />
           </div>
           <Button
-            onClick={() => { setClearArmed(false); listMutation.mutate() }}
+            onClick={() => listMutation.mutate()}
             disabled={isLoading}
             className="mt-1"
           >
@@ -222,7 +228,7 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
           <div className="grid grid-cols-2 gap-2">
             <Button
               variant="outline"
-              onClick={() => { setClearArmed(false); setClearTarget(null); clearMutation.mutate(true) }}
+              onClick={() => { setClearTarget(null); clearMutation.mutate(true) }}
               disabled={isLoading || !actor}
             >
               <Eye className="size-3.5" />
@@ -230,29 +236,13 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
             </Button>
             <Button
               variant="destructive"
-              onClick={() => {
-                if (clearArmed && clearTarget === null) {
-                  setClearArmed(false)
-                  clearMutation.mutate(false)
-                } else {
-                  setClearTarget(null)
-                  setClearArmed(true)
-                }
-              }}
+              onClick={() => { setClearTarget(null); setConfirmOpen(true) }}
               disabled={isLoading || !actor}
             >
               <Trash className="size-3.5" />
-              {clearArmed && clearTarget === null ? "Confirm clear" : "Clear"}
+              Clear
             </Button>
           </div>
-          {clearArmed && (
-            <p className="text-xs text-yellow-400/80 flex items-center gap-1.5">
-              <Warning className="size-3 shrink-0" />
-              {clearTarget
-                ? <>Click the row&rsquo;s confirm action again to permanently delete <span className="font-mono">{clearTarget.key}</span> — this can&rsquo;t be undone.</>
-                : "Click again to permanently delete these caches — this can’t be undone."}
-            </p>
-          )}
           {clearMutation.isError && (
             <p className="text-xs text-destructive flex items-center gap-1.5">
               <Warning className="size-3 shrink-0" />
@@ -336,7 +326,6 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
                 {caches.map((c) => {
                   const staleness = classifyStaleness(c.last_accessed_at)
                   const { text: staleText, dot: staleDot } = stalenessColor[staleness]
-                  const isThisRowArmed = clearArmed && clearTarget?.key === c.key && clearTarget?.ref === c.ref
                   return (
                     <tr key={c.id} className="hover:bg-muted/40 transition-colors">
                       <td className="px-4 py-2.5 font-mono text-foreground/80 max-w-[14rem] truncate">{c.key}</td>
@@ -358,18 +347,10 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
                           variant="outline"
                           className="h-6 px-2 text-[0.6875rem]"
                           disabled={isLoading || !actor}
-                          onClick={() => {
-                            if (isThisRowArmed) {
-                              setClearArmed(false)
-                              clearMutation.mutate(false)
-                            } else {
-                              setClearTarget({ key: c.key, ref: c.ref })
-                              setClearArmed(true)
-                            }
-                          }}
+                          onClick={() => { setClearTarget({ key: c.key, ref: c.ref }); setConfirmOpen(true) }}
                         >
                           <Trash className="size-3" />
-                          {isThisRowArmed ? "Confirm clear key" : "Clear key"}
+                          Clear key
                         </Button>
                       </td>
                     </tr>
@@ -416,6 +397,20 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
         </div>
       </div>
     )}
+
+    <ConfirmDialog
+      open={confirmOpen}
+      onOpenChange={setConfirmOpen}
+      title="Delete cache?"
+      description={
+        clearTarget
+          ? `This permanently deletes the "${clearTarget.key}" cache entry (ref ${clearTarget.ref}) — this can't be undone.`
+          : "This permanently deletes every Actions cache entry for this repo — this can't be undone."
+      }
+      confirmLabel="Delete"
+      onConfirm={() => clearMutation.mutate(false)}
+      pending={clearMutation.isPending}
+    />
     </>
   )
 }

--- a/apps/ui/components/ui/confirm-dialog.tsx
+++ b/apps/ui/components/ui/confirm-dialog.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { Button } from "@/components/ui/button"
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm: () => void
+  /** Disables both buttons and shows a busy confirm label while a mutation is in flight.
+   * The caller is responsible for calling onOpenChange(false) once it settles. */
+  pending?: boolean
+  variant?: "destructive" | "default"
+}
+
+// A real, accessible (focus-trapped, Escape-to-cancel) confirmation modal -- replaces the
+// bespoke "click again within N seconds to confirm" pattern that used to be duplicated
+// inline in cache-panel.tsx and settings/page.tsx.
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  pending = false,
+  variant = "destructive",
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPrimitive.Portal>
+        <AlertDialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 transition-opacity duration-150 ease-(--ease-out) data-ending-style:opacity-0 data-starting-style:opacity-0" />
+        <AlertDialogPrimitive.Popup className="fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-popover bg-clip-padding p-5 text-popover-foreground shadow-lg transition-[transform,opacity] duration-150 ease-(--ease-out) data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0">
+          <AlertDialogPrimitive.Title className="font-heading text-base font-medium text-foreground">
+            {title}
+          </AlertDialogPrimitive.Title>
+          <AlertDialogPrimitive.Description className="mt-1.5 text-sm text-muted-foreground">
+            {description}
+          </AlertDialogPrimitive.Description>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialogPrimitive.Close
+              render={<Button variant="outline" size="sm" disabled={pending} />}
+            >
+              {cancelLabel}
+            </AlertDialogPrimitive.Close>
+            <Button variant={variant} size="sm" disabled={pending} onClick={onConfirm}>
+              {pending ? "Working…" : confirmLabel}
+            </Button>
+          </div>
+        </AlertDialogPrimitive.Popup>
+      </AlertDialogPrimitive.Portal>
+    </AlertDialogPrimitive.Root>
+  )
+}

--- a/apps/ui/components/ui/data-table.tsx
+++ b/apps/ui/components/ui/data-table.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { CaretUp, CaretDown, CaretUpDown } from "@phosphor-icons/react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+export interface DataTableColumn<T> {
+  key: string
+  header: string
+  align?: "left" | "right"
+  render: (row: T) => React.ReactNode
+  /** Enables click-to-sort on this column's header. Omit for columns that shouldn't sort
+   * (actions, badges, etc). */
+  sortValue?: (row: T) => string | number
+  headerClassName?: string
+  cellClassName?: string
+}
+
+interface DataTableProps<T> {
+  columns: DataTableColumn<T>[]
+  data: T[]
+  getRowKey: (row: T) => string | number
+  /** Rows per page. Pagination controls only render once data exceeds this. */
+  pageSize?: number
+  rowClassName?: (row: T) => string | undefined
+  /** Attaches a ref to a specific row's <tr> -- e.g. to scroll a highlighted row into
+   * view. Most callers don't need this. */
+  getRowRef?: (row: T) => React.Ref<HTMLTableRowElement> | undefined
+}
+
+/** A shared sortable, paginated table -- built on the same raw `<table>` markup/classes
+ * every hand-rolled table in this app already uses, so adopting it doesn't introduce a
+ * second visual style. Sorting and pagination are both client-side over whatever `data`
+ * the caller passes in; for a table backed by a capped/paginated API response (like the
+ * audit log), that's the caller's own concern, not this component's. */
+export function DataTable<T>({
+  columns,
+  data,
+  getRowKey,
+  pageSize = 20,
+  rowClassName,
+  getRowRef,
+}: DataTableProps<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(null)
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc")
+  const [page, setPage] = useState(1)
+
+  const sorted = useMemo(() => {
+    const col = columns.find((c) => c.key === sortKey)
+    if (!col?.sortValue) return data
+    const sortValue = col.sortValue
+    return [...data].sort((a, b) => {
+      const av = sortValue(a)
+      const bv = sortValue(b)
+      const cmp = av < bv ? -1 : av > bv ? 1 : 0
+      return sortDir === "asc" ? cmp : -cmp
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, sortKey, sortDir])
+
+  // A stale page offset after the underlying data or sort changes would otherwise show
+  // an out-of-range (empty-looking) page instead of resetting to the top.
+  useEffect(() => {
+    setPage(1)
+  }, [data, sortKey, sortDir])
+
+  const lastPage = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const pageRows = sorted.slice((page - 1) * pageSize, page * pageSize)
+
+  function toggleSort(key: string) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"))
+    } else {
+      setSortKey(key)
+      setSortDir("asc")
+    }
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border">
+              {columns.map((col) => {
+                const isSorted = col.sortValue && sortKey === col.key
+                return (
+                  <th
+                    key={col.key}
+                    className={cn(
+                      "font-medium px-4 py-2 text-muted-foreground",
+                      col.align === "right" ? "text-right" : "text-left",
+                      col.sortValue && "cursor-pointer select-none hover:text-foreground",
+                      col.headerClassName,
+                    )}
+                    onClick={col.sortValue ? () => toggleSort(col.key) : undefined}
+                    aria-sort={isSorted ? (sortDir === "asc" ? "ascending" : "descending") : undefined}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {col.header}
+                      {col.sortValue && (
+                        isSorted ? (
+                          sortDir === "asc" ? <CaretUp className="size-3" /> : <CaretDown className="size-3" />
+                        ) : (
+                          <CaretUpDown className="size-3 opacity-40" />
+                        )
+                      )}
+                    </span>
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {pageRows.map((row) => (
+              <tr key={getRowKey(row)} ref={getRowRef?.(row)} className={rowClassName?.(row)}>
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={cn("px-4 py-2.5", col.align === "right" && "text-right", col.cellClassName)}
+                  >
+                    {col.render(row)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {sorted.length > pageSize && (
+        <div className="px-4 py-3 border-t border-border flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            Page {page} of {lastPage} · {sorted.length} total
+          </span>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              Prev
+            </Button>
+            <Button size="sm" variant="outline" disabled={page >= lastPage} onClick={() => setPage((p) => p + 1)}>
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/ui/components/ui/field.tsx
+++ b/apps/ui/components/ui/field.tsx
@@ -4,20 +4,37 @@ import { Field as FieldPrimitive } from "@base-ui/react/field"
 
 import { cn } from "@/lib/utils"
 
+type ClassNameProp<State> = string | ((state: State) => string | undefined) | undefined
+
+// Base UI's className prop can be a plain string or a callback that receives the
+// component's state (e.g. touched/dirty/valid) -- cn() only understands strings, so a
+// callback passed straight through would be silently dropped instead of evaluated.
+// This preserves the callback (merging its result with the default classes at call
+// time) or merges directly when className is already a string.
+function withDefaultClassName<State>(
+  defaultClassName: string,
+  className: ClassNameProp<State>,
+): string | ((state: State) => string) {
+  if (typeof className === "function") {
+    return (state: State) => cn(defaultClassName, className(state))
+  }
+  return cn(defaultClassName, className)
+}
+
 // Wraps Base UI's Field so plain <label>text</label> pairs (visually adjacent to their
 // input but not programmatically associated -- a screen reader won't announce the label
 // on focus) become a real <label htmlFor="..."> / <input id="..."> pair for free. Any
 // Base UI-based control (this project's Input included) picks up the generated id
 // automatically just by rendering inside <Field>, no extra wiring needed per field.
 function Field({ className, ...props }: FieldPrimitive.Root.Props) {
-  return <FieldPrimitive.Root data-slot="field" className={cn(className)} {...props} />
+  return <FieldPrimitive.Root data-slot="field" className={withDefaultClassName("", className)} {...props} />
 }
 
 function FieldLabel({ className, ...props }: FieldPrimitive.Label.Props) {
   return (
     <FieldPrimitive.Label
       data-slot="field-label"
-      className={cn("text-xs font-medium text-foreground block mb-1.5", className)}
+      className={withDefaultClassName("text-xs font-medium text-foreground block mb-1.5", className)}
       {...props}
     />
   )
@@ -27,7 +44,7 @@ function FieldDescription({ className, ...props }: FieldPrimitive.Description.Pr
   return (
     <FieldPrimitive.Description
       data-slot="field-description"
-      className={cn("text-xs text-muted-foreground mt-1", className)}
+      className={withDefaultClassName("text-xs text-muted-foreground mt-1", className)}
       {...props}
     />
   )
@@ -37,7 +54,7 @@ function FieldError({ className, ...props }: FieldPrimitive.Error.Props) {
   return (
     <FieldPrimitive.Error
       data-slot="field-error"
-      className={cn("text-xs text-destructive mt-1", className)}
+      className={withDefaultClassName("text-xs text-destructive mt-1", className)}
       {...props}
     />
   )

--- a/apps/ui/components/ui/field.tsx
+++ b/apps/ui/components/ui/field.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Field as FieldPrimitive } from "@base-ui/react/field"
+
+import { cn } from "@/lib/utils"
+
+// Wraps Base UI's Field so plain <label>text</label> pairs (visually adjacent to their
+// input but not programmatically associated -- a screen reader won't announce the label
+// on focus) become a real <label htmlFor="..."> / <input id="..."> pair for free. Any
+// Base UI-based control (this project's Input included) picks up the generated id
+// automatically just by rendering inside <Field>, no extra wiring needed per field.
+function Field({ className, ...props }: FieldPrimitive.Root.Props) {
+  return <FieldPrimitive.Root data-slot="field" className={cn(className)} {...props} />
+}
+
+function FieldLabel({ className, ...props }: FieldPrimitive.Label.Props) {
+  return (
+    <FieldPrimitive.Label
+      data-slot="field-label"
+      className={cn("text-xs font-medium text-foreground block mb-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: FieldPrimitive.Description.Props) {
+  return (
+    <FieldPrimitive.Description
+      data-slot="field-description"
+      className={cn("text-xs text-muted-foreground mt-1", className)}
+      {...props}
+    />
+  )
+}
+
+function FieldError({ className, ...props }: FieldPrimitive.Error.Props) {
+  return (
+    <FieldPrimitive.Error
+      data-slot="field-error"
+      className={cn("text-xs text-destructive mt-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Field, FieldLabel, FieldDescription, FieldError }

--- a/apps/ui/components/ui/toast.tsx
+++ b/apps/ui/components/ui/toast.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { Toast as ToastPrimitive } from "@base-ui/react/toast"
+import { X } from "@phosphor-icons/react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+// A manager created outside React so `toast.success(...)`/`toast.error(...)` can be
+// called from anywhere (mutation onSuccess/onError callbacks, plain functions) without
+// needing to be inside a component that calls useToastManager(). <Toaster/> (mounted
+// once in app/layout.tsx) wires this same instance into ToastPrimitive.Provider.
+const toastManager = ToastPrimitive.createToastManager()
+
+export const toast = {
+  success: (description: string, title?: string) =>
+    toastManager.add({ type: "success", title, description }),
+  error: (description: string, title?: string) =>
+    toastManager.add({ type: "error", title, description }),
+  info: (description: string, title?: string) =>
+    toastManager.add({ type: "info", title, description }),
+}
+
+const TYPE_ACCENT: Record<string, string> = {
+  success: "border-l-emerald-500/70",
+  error: "border-l-destructive/70",
+  info: "border-l-primary/70",
+}
+
+function ToastList() {
+  const { toasts } = ToastPrimitive.useToastManager()
+
+  return toasts.map((t) => (
+    <ToastPrimitive.Root
+      key={t.id}
+      toast={t}
+      className={cn(
+        "absolute inset-x-0 bottom-0 rounded-md border border-l-2 border-border bg-popover bg-clip-padding p-3 pr-8 text-popover-foreground shadow-lg transition-[transform,opacity] duration-200 ease-(--ease-out) data-ending-style:opacity-0 data-starting-style:translate-y-[150%] data-starting-style:opacity-0",
+        t.type && TYPE_ACCENT[t.type]
+      )}
+      style={{
+        zIndex: "calc(1000 - var(--toast-index))",
+        transform: "translateY(var(--toast-offset-y)) scale(calc(max(0, 1 - (var(--toast-index) * 0.1))))",
+      }}
+    >
+      <ToastPrimitive.Content className="flex flex-col gap-0.5">
+        {t.title && (
+          <ToastPrimitive.Title className="text-sm font-medium text-foreground">
+            {t.title}
+          </ToastPrimitive.Title>
+        )}
+        <ToastPrimitive.Description className="text-sm text-muted-foreground">
+          {t.description}
+        </ToastPrimitive.Description>
+      </ToastPrimitive.Content>
+      <ToastPrimitive.Close
+        render={<Button variant="ghost" size="icon-xs" className="absolute top-2 right-2" />}
+      >
+        <X />
+        <span className="sr-only">Dismiss</span>
+      </ToastPrimitive.Close>
+    </ToastPrimitive.Root>
+  ))
+}
+
+export function Toaster() {
+  return (
+    <ToastPrimitive.Provider toastManager={toastManager}>
+      <ToastPrimitive.Portal>
+        <ToastPrimitive.Viewport className="fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col-reverse gap-2">
+          <ToastList />
+        </ToastPrimitive.Viewport>
+      </ToastPrimitive.Portal>
+    </ToastPrimitive.Provider>
+  )
+}

--- a/apps/ui/e2e/auth.spec.ts
+++ b/apps/ui/e2e/auth.spec.ts
@@ -59,8 +59,9 @@ test.describe("Mid-session 401", () => {
     // Force the next API call to look like an expired/revoked session. /audit auto-fetches
     // GET /audit on mount (see app/audit/page.tsx), so navigating there reliably triggers it.
     // Scoped to the API host specifically — a bare "**/audit" pattern would also match the
-    // UI's own page navigation request to http://localhost:3000/audit.
-    await page.route(`${E2E_API_BASE}/audit`, (route) => route.fulfill({ status: 401, body: "{}" }))
+    // UI's own page navigation request to http://localhost:3000/audit. Trailing "**" so this
+    // still matches once query params (e.g. ?limit=100) are appended to the request.
+    await page.route(`${E2E_API_BASE}/audit**`, (route) => route.fulfill({ status: 401, body: "{}" }))
     await page.goto("/audit")
 
     // Regression check for #75/#115: AuthGuard must call logout() (clearing local auth state)

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -414,8 +414,15 @@ export const api = {
       }),
   },
   audit: {
-    list: (action?: string) =>
-      get<AuditLogOut[]>(`/audit${action ? `?action=${encodeURIComponent(action)}` : ""}`),
+    // limit mirrors the backend's own default/cap (Query(default=100, le=500)) --
+    // callers bump it to page further back through recent history rather than the
+    // backend supporting a true offset/cursor (it only ever returns the N most recent
+    // rows, filtered by action).
+    list: (action?: string, limit = 100) => {
+      const params = new URLSearchParams({ limit: String(limit) })
+      if (action) params.set("action", action)
+      return get<AuditLogOut[]>(`/audit?${params.toString()}`)
+    },
   },
   installations: {
     list: () => get<InstallationMeta[]>("/me/installations"),

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -481,6 +481,10 @@ export interface MyViewResponse {
   review_requests: MyViewPRSummary[]
   assigned_issues: MyViewIssueSummary[]
   my_recent_runs: MyViewRunSummary[]
+  // True when GitHub couldn't tell Clevis who the signed-in user is on GitHub (an
+  // installation/App token can't call GET /user, and this user has no GitHub-OAuth-linked
+  // login to fall back on) -- distinguishes that from "you really have zero open items."
+  identity_unresolved: boolean
 }
 
 export interface MyPrListResponse {
@@ -488,6 +492,7 @@ export interface MyPrListResponse {
   total_count: number
   page: number
   per_page: number
+  identity_unresolved: boolean
 }
 
 export interface MyIssueListResponse {
@@ -495,6 +500,7 @@ export interface MyIssueListResponse {
   total_count: number
   page: number
   per_page: number
+  identity_unresolved: boolean
 }
 
 export interface WorkflowSummary {

--- a/apps/ui/tests/components/audit-page.test.tsx
+++ b/apps/ui/tests/components/audit-page.test.tsx
@@ -155,6 +155,59 @@ describe("AuditPage", () => {
     expect(screen.getByText("—")).toBeInTheDocument();
   });
 
+  it("sorts rows by clicking a sortable column header", async () => {
+    auditListMock.mockResolvedValue([
+      { id: 1, actor: "bravo@e.com", action: "installation.connected", target: "acme", payload: "{}", created_at: "2026-01-01T00:00:00Z" },
+      { id: 2, actor: "alpha@e.com", action: "installation.connected", target: "acme", payload: "{}", created_at: "2026-01-02T00:00:00Z" },
+    ]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("2 entries")).toBeInTheDocument());
+    const rowsBefore = screen.getAllByRole("row").slice(1);
+    expect(rowsBefore[0]).toHaveTextContent("bravo@e.com");
+
+    fireEvent.click(screen.getByText("Actor"));
+
+    const rowsAfterAsc = screen.getAllByRole("row").slice(1);
+    expect(rowsAfterAsc[0]).toHaveTextContent("alpha@e.com");
+
+    fireEvent.click(screen.getByText("Actor"));
+
+    const rowsAfterDesc = screen.getAllByRole("row").slice(1);
+    expect(rowsAfterDesc[0]).toHaveTextContent("bravo@e.com");
+  });
+
+  it("shows a Load more button when the result hits the current limit, and requests a bigger one", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      actor: "u@e.com",
+      action: "installation.connected",
+      target: "acme",
+      payload: "{}",
+      created_at: "2026-01-01T00:00:00Z",
+    }));
+    auditListMock.mockResolvedValue(fullPage);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("100 entries")).toBeInTheDocument());
+    const loadMore = screen.getByRole("button", { name: /load more/i });
+
+    fireEvent.click(loadMore);
+
+    await waitFor(() => expect(auditListMock).toHaveBeenCalledWith(undefined, 200));
+  });
+
+  it("does not show a Load more button when fewer rows than the limit come back", async () => {
+    auditListMock.mockResolvedValue([
+      { id: 1, actor: "u@e.com", action: "installation.connected", target: "acme", payload: "{}", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("1 entries")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
   it("highlights the row matching a ?job_id= deep link, e.g. from the cache panel's 'View in Audit Log' link", async () => {
     mockSearchParams = new URLSearchParams("job_id=42");
     auditListMock.mockResolvedValue([

--- a/apps/ui/tests/components/cache-page.test.tsx
+++ b/apps/ui/tests/components/cache-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -89,7 +89,7 @@ describe("CachePage", () => {
     expect(screen.getByRole("button", { name: /^clear$/i })).toBeDisabled();
   });
 
-  it("requires a second click on Clear before actually clearing caches", async () => {
+  it("requires confirming in a dialog before actually clearing caches", async () => {
     cacheClearMock.mockResolvedValue({ queued: true, dry_run: false, job_id: 7 });
 
     renderPage();
@@ -100,12 +100,12 @@ describe("CachePage", () => {
 
     fireEvent.click(clearButton);
 
-    // First click only arms the button — no request fired yet.
+    // Clicking Clear only opens the confirm dialog — no request fired yet.
     expect(cacheClearMock).not.toHaveBeenCalled();
-    const confirmButton = await screen.findByRole("button", { name: /confirm clear/i });
-    expect(screen.getByText(/click again to permanently delete/i)).toBeInTheDocument();
+    const dialog = await screen.findByRole("alertdialog");
+    expect(screen.getByText(/permanently deletes every Actions cache entry/i)).toBeInTheDocument();
 
-    fireEvent.click(confirmButton);
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() =>
       expect(cacheClearMock).toHaveBeenCalledWith("acme", "demo", {
@@ -114,9 +114,11 @@ describe("CachePage", () => {
         dry_run: false,
       }),
     );
+    // The dialog closes itself once the clear mutation succeeds.
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
   });
 
-  it("disarms the confirm state if the actor is edited before confirming", async () => {
+  it("closes the confirm dialog without clearing when Cancel is clicked", async () => {
     renderPage();
 
     fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
@@ -124,62 +126,15 @@ describe("CachePage", () => {
     await waitFor(() => expect(clearButton).not.toBeDisabled());
 
     fireEvent.click(clearButton);
-    await screen.findByRole("button", { name: /confirm clear/i });
+    const dialog = await screen.findByRole("alertdialog");
 
-    fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "someone-else@example.com" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^cancel$/i }));
 
-    expect(screen.queryByRole("button", { name: /confirm clear/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^clear$/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
     expect(cacheClearMock).not.toHaveBeenCalled();
   });
 
-  it("disarms the confirm state if Load caches is clicked before confirming", async () => {
-    cacheListMock.mockResolvedValue({ actions_caches: [] });
-
-    renderPage();
-
-    fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
-    const clearButton = screen.getByRole("button", { name: /^clear$/i });
-    await waitFor(() => expect(clearButton).not.toBeDisabled());
-
-    fireEvent.click(clearButton);
-    await screen.findByRole("button", { name: /confirm clear/i });
-
-    fireEvent.click(screen.getByRole("button", { name: /load caches/i }));
-
-    await waitFor(() =>
-      expect(screen.queryByRole("button", { name: /confirm clear/i })).not.toBeInTheDocument(),
-    );
-    expect(cacheClearMock).not.toHaveBeenCalled();
-  });
-
-  it("auto-disarms the confirm state after a few seconds of inactivity", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    try {
-      renderPage();
-
-      fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
-      const clearButton = screen.getByRole("button", { name: /^clear$/i });
-      await waitFor(() => expect(clearButton).not.toBeDisabled());
-
-      fireEvent.click(clearButton);
-      await screen.findByRole("button", { name: /confirm clear/i });
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(4000);
-      });
-
-      expect(screen.queryByRole("button", { name: /confirm clear/i })).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /^clear$/i })).toBeInTheDocument();
-      expect(cacheClearMock).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("disarms the confirm state when the route's repo param changes", async () => {
-    cacheClearMock.mockResolvedValue({ queued: true, dry_run: false, job_id: 7 });
-
+  it("closes the confirm dialog when the route's repo param changes", async () => {
     const { rerenderSamePage } = renderPage();
 
     fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
@@ -187,26 +142,17 @@ describe("CachePage", () => {
     await waitFor(() => expect(clearButton).not.toBeDisabled());
 
     fireEvent.click(clearButton);
-    await screen.findByRole("button", { name: /confirm clear/i });
-    expect(screen.getByText(/click again to permanently delete/i)).toBeInTheDocument();
+    await screen.findByRole("alertdialog");
 
     // Navigate to a different repo — same component instance, new route params
     // (in-place rerender, not unmount/remount, so this actually exercises the
-    // params.repo-keyed disarm effect rather than trivially passing).
+    // params.repo-keyed reset effect rather than trivially passing).
     currentRepoParam = "acme~other";
     rerenderSamePage();
 
     await waitFor(() => expect(screen.getByText(/acme\/other/i)).toBeInTheDocument());
-    expect(screen.queryByRole("button", { name: /confirm clear/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^clear$/i })).toBeInTheDocument();
-    expect(screen.queryByText(/click again to permanently delete/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
     expect(cacheClearMock).not.toHaveBeenCalled();
-
-    // A click on the new repo re-arms rather than immediately firing a clear
-    // against it — the stale confirmation must not carry over.
-    fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
-    expect(cacheClearMock).not.toHaveBeenCalled();
-    await screen.findByRole("button", { name: /confirm clear/i });
   });
 
   it("auto-applies a resolved saved token and shows the saved badge", async () => {
@@ -264,7 +210,8 @@ describe("CachePage", () => {
     renderPage();
     fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /confirm clear/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
 
     expect(await screen.findByText(/could not clear caches/i)).toBeInTheDocument();
   });
@@ -295,8 +242,9 @@ describe("CachePage", () => {
     fireEvent.click(clearKeyButton);
 
     expect(cacheClearMock).not.toHaveBeenCalled();
-    const confirmButton = await screen.findByRole("button", { name: /confirm clear key/i });
-    fireEvent.click(confirmButton);
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText(/api-cache-key/)).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() =>
       expect(cacheClearMock).toHaveBeenCalledWith("acme", "demo", {
@@ -308,7 +256,7 @@ describe("CachePage", () => {
       }),
     );
 
-    // The global "Clear" button, not this row's, must stay unarmed by the row action.
+    // The global "Clear" button, not this row's, must remain a plain trigger.
     expect(screen.getByRole("button", { name: /^clear$/i })).toBeInTheDocument();
   });
 
@@ -335,8 +283,8 @@ describe("CachePage", () => {
 
     fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
     fireEvent.click(screen.getByRole("button", { name: /^clear$/i }));
-    const confirmButton = await screen.findByRole("button", { name: /confirm clear/i });
-    fireEvent.click(confirmButton);
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
     await waitFor(() => expect(screen.getByText(/job #42/i)).toBeInTheDocument());
 
     // Navigate to a different repo under the same owner — same component instance, new params.

--- a/apps/ui/tests/components/data-table.test.tsx
+++ b/apps/ui/tests/components/data-table.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
+
+interface Row {
+  id: number;
+  name: string;
+  score: number;
+}
+
+const ROWS: Row[] = [
+  { id: 1, name: "Charlie", score: 30 },
+  { id: 2, name: "Alice", score: 10 },
+  { id: 3, name: "Bob", score: 20 },
+];
+
+const COLUMNS: DataTableColumn<Row>[] = [
+  { key: "name", header: "Name", sortValue: (r) => r.name, render: (r) => r.name },
+  { key: "score", header: "Score", align: "right", sortValue: (r) => r.score, render: (r) => String(r.score) },
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DataTable", () => {
+  it("renders rows in the given order when no sort is applied", () => {
+    render(<DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} />);
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("Charlie");
+    expect(rows[1]).toHaveTextContent("Alice");
+    expect(rows[2]).toHaveTextContent("Bob");
+  });
+
+  it("sorts ascending on first header click and descending on the second", () => {
+    render(<DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} />);
+
+    fireEvent.click(screen.getByText("Name"));
+    let rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("Alice");
+    expect(rows[1]).toHaveTextContent("Bob");
+    expect(rows[2]).toHaveTextContent("Charlie");
+
+    fireEvent.click(screen.getByText("Name"));
+    rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("Charlie");
+    expect(rows[1]).toHaveTextContent("Bob");
+    expect(rows[2]).toHaveTextContent("Alice");
+  });
+
+  it("switches the active sort column when a different header is clicked", () => {
+    render(<DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} />);
+
+    fireEvent.click(screen.getByText("Score"));
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("Alice"); // score 10
+    expect(rows[1]).toHaveTextContent("Bob"); // score 20
+    expect(rows[2]).toHaveTextContent("Charlie"); // score 30
+  });
+
+  it("does not attach a sort handler to columns without sortValue", () => {
+    const columns: DataTableColumn<Row>[] = [{ key: "name", header: "Name", render: (r) => r.name }];
+    render(<DataTable columns={columns} data={ROWS} getRowKey={(r) => r.id} />);
+    const header = screen.getByText("Name").closest("th")!;
+    expect(header.className).not.toContain("cursor-pointer");
+  });
+
+  it("paginates once data exceeds pageSize, and Prev/Next move between pages", () => {
+    render(<DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} pageSize={2} />);
+
+    expect(screen.getByText("Page 1 of 2 · 3 total")).toBeInTheDocument();
+    let rows = screen.getAllByRole("row").slice(1);
+    expect(rows).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Prev" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Page 2 of 2 · 3 total")).toBeInTheDocument();
+    rows = screen.getAllByRole("row").slice(1);
+    expect(rows).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+
+  it("does not show pagination controls when data fits within one page", () => {
+    render(<DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} pageSize={10} />);
+    expect(screen.queryByRole("button", { name: "Prev" })).not.toBeInTheDocument();
+  });
+
+  it("resets to page 1 when the data changes", () => {
+    const { rerender } = render(
+      <DataTable columns={COLUMNS} data={ROWS} getRowKey={(r) => r.id} pageSize={2} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Page 2 of 2 · 3 total")).toBeInTheDocument();
+
+    rerender(
+      <DataTable
+        columns={COLUMNS}
+        data={[...ROWS, { id: 4, name: "Dana", score: 40 }]}
+        getRowKey={(r) => r.id}
+        pageSize={2}
+      />,
+    );
+    expect(screen.getByText("Page 1 of 2 · 4 total")).toBeInTheDocument();
+  });
+
+  it("attaches a ref to the row selected by getRowRef", () => {
+    let refEl: HTMLTableRowElement | null = null;
+    render(
+      <DataTable
+        columns={COLUMNS}
+        data={ROWS}
+        getRowKey={(r) => r.id}
+        getRowRef={(r) => (r.id === 2 ? (el: HTMLTableRowElement | null) => { refEl = el; } : undefined)}
+      />,
+    );
+    expect(refEl).not.toBeNull();
+    expect(refEl!).toHaveTextContent("Alice");
+  });
+});

--- a/apps/ui/tests/components/field.test.tsx
+++ b/apps/ui/tests/components/field.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Field, FieldLabel, FieldDescription, FieldError } from "@/components/ui/field";
+
+afterEach(() => {
+  cleanup();
+});
+
+// Base UI's className prop accepts either a plain string or a callback that receives
+// the component's state (e.g. invalid/touched/dirty) -- these wrappers must merge
+// default classes with both forms rather than only handling the string case.
+
+describe("Field", () => {
+  it("merges a string className with the wrapper's own classes", () => {
+    render(
+      <Field data-testid="field" className="custom-field">
+        <FieldLabel>Email</FieldLabel>
+      </Field>,
+    );
+    expect(screen.getByTestId("field")).toHaveClass("custom-field");
+  });
+
+  it("evaluates a callback className with the field's state and merges the result", () => {
+    render(
+      <Field data-testid="field" invalid className={(state) => (!state.valid ? "is-invalid" : "is-valid")}>
+        <FieldLabel>Email</FieldLabel>
+      </Field>,
+    );
+    const field = screen.getByTestId("field");
+    expect(field).toHaveClass("is-invalid");
+    expect(field).not.toHaveClass("is-valid");
+  });
+});
+
+describe("FieldLabel", () => {
+  it("merges a string className with the default label classes", () => {
+    render(
+      <Field>
+        <FieldLabel data-testid="label" className="custom-label">
+          Email
+        </FieldLabel>
+      </Field>,
+    );
+    const label = screen.getByTestId("label");
+    expect(label).toHaveClass("custom-label");
+    expect(label).toHaveClass("text-xs");
+  });
+
+  it("evaluates a callback className with the field's state and merges the result", () => {
+    render(
+      <Field invalid>
+        <FieldLabel data-testid="label" className={(state) => (!state.valid ? "label-invalid" : undefined)}>
+          Email
+        </FieldLabel>
+      </Field>,
+    );
+    const label = screen.getByTestId("label");
+    expect(label).toHaveClass("label-invalid");
+    expect(label).toHaveClass("text-xs");
+  });
+});
+
+describe("FieldDescription", () => {
+  it("merges a string className with the default description classes", () => {
+    render(
+      <Field>
+        <FieldDescription data-testid="description" className="custom-description">
+          Helper text
+        </FieldDescription>
+      </Field>,
+    );
+    const description = screen.getByTestId("description");
+    expect(description).toHaveClass("custom-description");
+    expect(description).toHaveClass("text-xs");
+  });
+
+  it("evaluates a callback className with the field's state and merges the result", () => {
+    render(
+      <Field invalid>
+        <FieldDescription
+          data-testid="description"
+          className={(state) => (!state.valid ? "description-invalid" : undefined)}
+        >
+          Helper text
+        </FieldDescription>
+      </Field>,
+    );
+    const description = screen.getByTestId("description");
+    expect(description).toHaveClass("description-invalid");
+    expect(description).toHaveClass("text-xs");
+  });
+});
+
+describe("FieldError", () => {
+  it("merges a string className with the default error classes", () => {
+    render(
+      <Field invalid>
+        <FieldError data-testid="error" match className="custom-error">
+          Required
+        </FieldError>
+      </Field>,
+    );
+    const error = screen.getByTestId("error");
+    expect(error).toHaveClass("custom-error");
+    expect(error).toHaveClass("text-destructive");
+  });
+
+  it("evaluates a callback className with the field's state and merges the result", () => {
+    render(
+      <Field invalid>
+        <FieldError data-testid="error" match className={(state) => (!state.valid ? "error-invalid" : undefined)}>
+          Required
+        </FieldError>
+      </Field>,
+    );
+    const error = screen.getByTestId("error");
+    expect(error).toHaveClass("error-invalid");
+    expect(error).toHaveClass("text-destructive");
+  });
+});

--- a/apps/ui/tests/components/github-roster.test.tsx
+++ b/apps/ui/tests/components/github-roster.test.tsx
@@ -110,6 +110,29 @@ describe("GithubRoster (Collaborators page)", () => {
     expect(screen.getByText("Members without 2FA: 1")).toBeInTheDocument();
   });
 
+  it("sorts the members table by clicking a sortable column header", async () => {
+    membersMock.mockResolvedValue({
+      org: "acme",
+      members: [
+        { login: "zoe", avatar_url: "", role: "member", site_admin: false, two_factor_enabled: true },
+        { login: "alice", avatar_url: "", role: "admin", site_admin: false, two_factor_enabled: true },
+      ],
+      two_factor_overlay_available: true,
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("zoe")).toBeInTheDocument());
+    let rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("zoe");
+
+    fireEvent.click(screen.getByRole("columnheader", { name: "Member" }));
+
+    rows = screen.getAllByRole("row").slice(1);
+    expect(rows[0]).toHaveTextContent("alice");
+    expect(rows[1]).toHaveTextContent("zoe");
+  });
+
   it("omits the 2FA chip and footer when the overlay is unavailable", async () => {
     membersMock.mockResolvedValue({
       org: "acme",

--- a/apps/ui/tests/components/my-items-list.test.tsx
+++ b/apps/ui/tests/components/my-items-list.test.tsx
@@ -164,6 +164,27 @@ describe("MyItemsList", () => {
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
 
+  it("shows a distinct message (not the generic empty state) when identityUnresolved is set", () => {
+    render(
+      <MyItemsList
+        items={[]}
+        isLoading={false}
+        isError={false}
+        errorMessage=""
+        onRetry={() => {}}
+        retrying={false}
+        emptyNoun="pull requests"
+        totalCount={0}
+        page={1}
+        perPage={25}
+        onPageChange={() => {}}
+        identityUnresolved={true}
+      />,
+    );
+    expect(screen.getByText(/can’t tell who you are on GitHub/)).toBeInTheDocument();
+    expect(screen.queryByText(/No pull requests/)).not.toBeInTheDocument();
+  });
+
   it("shows a retrying spinner state on the retry button", () => {
     render(
       <MyItemsList

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -65,6 +65,7 @@ const EMPTY_MY_VIEW = {
   review_requests: [],
   assigned_issues: [],
   my_recent_runs: [],
+  identity_unresolved: false,
 };
 
 describe("OverviewPage cockpit", () => {
@@ -96,9 +97,20 @@ describe("OverviewPage cockpit", () => {
     expect(tokensResolveMock).not.toHaveBeenCalled();
     expect(cockpitMock).not.toHaveBeenCalled();
 
-    const configureLinks = screen.getAllByRole("link", { name: /Configure →/i });
-    for (const link of configureLinks) {
-      expect(link).toHaveAttribute("href", "/security");
+    // Each card's "Configure →" must route to the page it actually represents, not all
+    // four piling onto Health & Security (a prior bug: LiveStatCard hardcoded /security).
+    const expectedHrefs: Record<string, string> = {
+      Repositories: "/repos",
+      "Open PRs": "/pulls",
+      "Security Score": "/security",
+      "Team Members": "/collaborators",
+    };
+    for (const [label, href] of Object.entries(expectedHrefs)) {
+      // getByRole (not getByText) since "Security Score" also appears as a plain
+      // <span> chart heading further down the page -- the stat card's <a> is the only
+      // element whose accessible name (label + "Configure →") matches this regex.
+      const card = screen.getByRole("link", { name: new RegExp(label) });
+      expect(card).toHaveAttribute("href", href);
     }
   });
 

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -529,6 +529,20 @@ describe("OverviewPage cockpit", () => {
     expect(screen.queryByText("Fix bug")).not.toBeInTheDocument();
   });
 
+  it("shows a distinct message (not 'Nothing here right now') when My View's identity is unresolved", async () => {
+    localStorage.setItem("default_org", "acme");
+    tokensResolveMock.mockResolvedValue({ token: "ghp_test" });
+    cockpitMock.mockResolvedValue(EMPTY_COCKPIT);
+    myViewMock.mockResolvedValue({ ...EMPTY_MY_VIEW, identity_unresolved: true });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/can’t tell who you are on GitHub/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Nothing here right now")).not.toBeInTheDocument();
+  });
+
   it("shows empty states for release cadence and PR cycle time when all values are zero", async () => {
     localStorage.setItem("default_org", "acme");
     tokensResolveMock.mockResolvedValue({ token: "ghp_test" });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -7,6 +7,7 @@ const installationsListMock = vi.fn();
 const installationsListForOrgMock = vi.fn();
 const installationsRemoveMock = vi.fn();
 const tokensListMock = vi.fn();
+const tokensUpsertMock = vi.fn();
 const configGetAllMock = vi.fn();
 const patchMeMock = vi.fn();
 const revokeSessionsMock = vi.fn();
@@ -36,7 +37,10 @@ vi.mock("@/lib/api/client", () => ({
       listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
       remove: (...args: unknown[]) => installationsRemoveMock(...args),
     },
-    tokens: { list: (...args: unknown[]) => tokensListMock(...args) },
+    tokens: {
+      list: (...args: unknown[]) => tokensListMock(...args),
+      upsert: (...args: unknown[]) => tokensUpsertMock(...args),
+    },
     config: {
       getAll: (...args: unknown[]) => configGetAllMock(...args),
       update: (...args: unknown[]) => configUpdateMock(...args),
@@ -100,6 +104,7 @@ describe("SettingsPage", () => {
     installationsListForOrgMock.mockReset();
     installationsRemoveMock.mockReset();
     tokensListMock.mockReset();
+    tokensUpsertMock.mockReset();
     configGetAllMock.mockReset();
     patchMeMock.mockReset();
     revokeSessionsMock.mockReset();
@@ -523,6 +528,46 @@ describe("SettingsPage", () => {
     expect(screen.getByText("shabnam")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Disconnect" })).toBeInTheDocument();
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the disconnect confirm dialog without disconnecting when Cancel is clicked", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "shabnam", account_type: "User", installation_id: 7, created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /disconnect/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(installationsRemoveMock).not.toHaveBeenCalled();
+    expect(screen.getByText("shabnam")).toBeInTheDocument();
+  });
+
+  it("adds a saved token via the Add token form", async () => {
+    orgsMineMock.mockResolvedValue([]);
+    installationsListMock.mockResolvedValue([]);
+    tokensListMock.mockResolvedValue([]);
+    configGetAllMock.mockResolvedValue({ worker_poll_seconds: "5", registration_enabled: "true" });
+    tokensUpsertMock.mockResolvedValue({ org: "acme", label: "ci", created_at: "", updated_at: "" });
+
+    renderPage();
+
+    await waitFor(() => expect(tokensListMock).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByPlaceholderText("Org or owner"), { target: { value: " acme " } });
+    fireEvent.change(screen.getByPlaceholderText("ghp_… token"), { target: { value: " ghp_manual_token " } });
+    fireEvent.change(screen.getByPlaceholderText("Label (optional)"), { target: { value: " ci " } });
+    fireEvent.click(screen.getByRole("button", { name: /save token/i }));
+
+    await waitFor(() =>
+      expect(tokensUpsertMock).toHaveBeenCalledWith("acme", "ghp_manual_token", "ci"),
+    );
   });
 
 });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -379,9 +379,10 @@ describe("SettingsPage", () => {
 
     fireEvent.click(disconnectButtons[0]);
     expect(installationsRemoveMock).not.toHaveBeenCalled();
-    expect(await screen.findByRole("button", { name: /confirm disconnect/i })).toBeInTheDocument();
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText(/shabnam/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /confirm disconnect/i }));
+    fireEvent.click(within(dialog).getByRole("button", { name: /^disconnect$/i }));
 
     await waitFor(() => {
       expect(installationsRemoveMock).toHaveBeenCalledWith({ scope: "me" }, 7);
@@ -402,7 +403,8 @@ describe("SettingsPage", () => {
 
     const disconnectButton = await screen.findByRole("button", { name: /disconnect/i });
     fireEvent.click(disconnectButton);
-    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^disconnect$/i }));
 
     await waitFor(() => {
       expect(installationsRemoveMock).toHaveBeenCalledWith({ scope: "org", orgLogin: "acme" }, 42);
@@ -460,15 +462,16 @@ describe("SettingsPage", () => {
 
     const disconnectButton = await screen.findByRole("button", { name: /disconnect/i });
     fireEvent.click(disconnectButton);
-    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^disconnect$/i }));
 
     await waitFor(() => {
       expect(installationsRemoveMock).toHaveBeenCalled();
     });
-    // Neither "Disconnect" nor "Confirm disconnect" text remains while the mutation is
-    // in flight -- the row shows a spinner instead.
+    // The row's own button goes back to plain "Disconnect" while the confirm dialog
+    // shows a busy state instead of a second confirm click.
     expect(screen.queryByRole("button", { name: "Disconnect" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Confirm disconnect" })).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /working/i })).toBeDisabled();
 
     await act(async () => {
       removeGate.resolve();
@@ -488,15 +491,17 @@ describe("SettingsPage", () => {
     renderPage();
 
     fireEvent.click(await screen.findByRole("button", { name: /disconnect/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /confirm disconnect/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /^disconnect$/i }));
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("GitHub API unreachable");
     });
     // The row is still there (not silently removed) and can be retried immediately --
-    // confirmingKey was cleared on error, not left stuck on "Confirm disconnect".
+    // the dialog was closed on error, not left stuck open.
     expect(screen.getByText("shabnam")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Disconnect" })).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 
 });

--- a/apps/ui/tests/components/settings-page.test.tsx
+++ b/apps/ui/tests/components/settings-page.test.tsx
@@ -14,6 +14,15 @@ const configUpdateMock = vi.fn();
 const routerReplace = vi.fn();
 let searchParams = new URLSearchParams();
 
+// AuthProvider (wrapping SettingsPage below) calls the real global `fetch` directly
+// (not the mocked api client) to confirm the session against /auth/me. Left unmocked,
+// every test attempts a real network call to localhost:8080; on the first failure it
+// waits a real 2s before retrying (see auth-context.tsx's checkMe), which is slow and,
+// worse, timing-dependent on this machine's TCP-refusal latency -- rendering
+// `waitFor`'s default 1s timeout unreliable for anything else the test is waiting on.
+// Stub it to resolve immediately so tests don't pay for or depend on that retry.
+const fetchMock = vi.fn();
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: routerReplace }),
   useSearchParams: () => searchParams,
@@ -99,11 +108,20 @@ describe("SettingsPage", () => {
     searchParams = new URLSearchParams();
     localStorage.clear();
     localStorage.setItem(TOKEN_KEY, makeAdminJwt());
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ id: 1, email: "admin@example.com", name: "Admin", is_workspace_admin: true }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("renders the profile section and surfaces a retry when a section errors, and shows instance config for admins", async () => {
@@ -368,14 +386,17 @@ describe("SettingsPage", () => {
 
     renderPage();
 
+    // "acme" also appears in the separate "Your organizations" membership card (which
+    // resolves independently, from orgsMineMock alone) -- waiting on that text alone
+    // would race ahead of the "Connected GitHub accounts" table's own org-scoped
+    // installation row, which only appears once orgInstallQueries (chained after
+    // membershipsQuery) settles. Wait on the actual two Disconnect buttons instead.
     await waitFor(() => {
-      expect(screen.getByText("shabnam")).toBeInTheDocument();
-      expect(screen.getByText("acme")).toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: /disconnect/i })).toHaveLength(2);
     });
     expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
 
     const disconnectButtons = screen.getAllByRole("button", { name: /disconnect/i });
-    expect(disconnectButtons).toHaveLength(2);
 
     fireEvent.click(disconnectButtons[0]);
     expect(installationsRemoveMock).not.toHaveBeenCalled();

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -407,6 +407,38 @@ describe("api.repos", () => {
   });
 });
 
+describe("api.audit", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("defaults to limit=100 and omits action when not given", async () => {
+    stubOkJson([]);
+    await api.audit.list();
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get("limit")).toBe("100");
+    expect(parsed.searchParams.has("action")).toBe(false);
+  });
+
+  it("passes a custom limit and action through as query params", async () => {
+    stubOkJson([]);
+    await api.audit.list("cache.clear", 200);
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get("limit")).toBe("200");
+    expect(parsed.searchParams.get("action")).toBe("cache.clear");
+  });
+});
+
 describe("api.collab", () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary

Follow-up fixes from a UX audit of `apps/ui` (nav/structure + design-system consistency + live click-through), plus a backend bug the user reported directly: the "My Work" page showing nothing for an account that should have had items.

- **Overview's "Configure →" stat cards** all linked to `/security` regardless of which card (Repositories/Open PRs/Security Score/Team Members) — `LiveStatCard` hardcoded the href instead of taking one per card. Now each card routes to the page it represents.
- **Health & Security showed no "no account connected" messaging** at all (unlike every other page gated on `useActiveScope()`), going straight to the scan form with no context. Now uses the same `EmptyStateNoAccount` pattern Repos already uses.
- **"My Work" root cause**: `/me/github/my-view`, `/my-prs`, `/my-reviews`, `/my-issues` resolve "who am I on GitHub" via `GET /user`, but a **GitHub App installation token can't call that endpoint** — so any org connected via the App (the primary connection path) silently returned zero items for every user, indistinguishable from genuinely having none. Fixed by falling back to the signed-in user's own GitHub-OAuth-linked login (`users.github_login`) when `/user` fails, and by surfacing an explicit `identity_unresolved` flag (instead of a bare empty list) when identity truly can't be resolved (password-only account, no GitHub link), so the UI can say so plainly instead of implying zero items.

## Sensitive files flagged (per AGENTS.md)

- **Touches auth** (`apps/api/src/core/auth.py`): `UserOut` gains a `github_login` field, populated from the DB inside `require_auth` (the same DB read that function already does to check `token_version` — not carried in the JWT, so it can't go stale between requests). No new capability or permission is granted; it's read-only identity data the user can already see on their own `/auth/me` profile. No RBAC/authorization logic changed.
- No migrations, no schema changes — the new `identity_unresolved` field is a plain Pydantic response field with a default, not a DB column.

## Test plan

- [x] `pytest -q` — 931 passed
- [x] `cd apps/ui && bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` — 459/459 passed on files touched (one pre-existing failure in `settings-page.test.tsx` reproduces identically on a clean `main` checkout, unrelated to this branch)
- [x] Manually verified all three fixes in a running local instance (browser click-through)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GitHub identity detection using linked account information when direct lookup is unavailable.
  * Added clear identity-resolution messages on My Work and overview pages.
  * Added no-account guidance to the Security page.
  * Configure links now direct users to relevant setup areas.
  * Added confirmation dialogs and notifications for account disconnections and cache clearing.
  * Added sortable, paginated tables across audit logs and organization members.
  * Added “Load more” support for audit records.

* **Bug Fixes**
  * Unexpected GitHub lookup errors now surface instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->