### PR TITLE
Fix/bug audit high medium

### DIFF
--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -85,7 +85,10 @@ def get_pending_for_org_and_email(db: Session, org_id: int, email: str) -> Invit
         db.query(Invitation)
         .filter(
             Invitation.org_id == org_id,
-            Invitation.email.ilike(email),
+            # Case-insensitive *exact* match -- ilike(email) would treat `_`/`%` in
+            # the address (a `_` is common in local parts) as wildcards, matching
+            # unrelated invites. Mirrors _expire_lapsed and the lower(email) unique index.
+            func.lower(Invitation.email) == email.lower(),
             Invitation.status == "pending",
             Invitation.expires_at > datetime.now(timezone.utc),
         )
@@ -97,7 +100,8 @@ def list_pending_for_email(db: Session, email: str) -> list[Invitation]:
     return (
         db.query(Invitation)
         .filter(
-            Invitation.email.ilike(email),
+            # Exact, case-insensitive -- see get_pending_for_org_and_email.
+            func.lower(Invitation.email) == email.lower(),
             Invitation.status == "pending",
             Invitation.expires_at > datetime.now(timezone.utc),
         )

--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -51,11 +51,19 @@ def exists_for_user(db: Session, owner: str, user_id: int) -> bool:
     )
 
 
-def list_recent(db: Session, owner: str, limit: int = 30) -> list[dict]:
+def list_recent(
+    db: Session, owner: str, limit: int = 30, scanned_by_user_id: int | None = None
+) -> list[dict]:
+    """Newest-first scan summaries for ``owner``. ``scanned_by_user_id``, when given,
+    restricts the result to that user's own scans -- used on a personal endpoint when
+    the caller's only claim to this owner's history is a prior BYO-PAT scan they ran
+    themselves (see ``_user_history_scope`` in the analytics router), same as
+    ``list_for_export``."""
+    query = db.query(ScanResult).filter(ScanResult.owner == owner)
+    if scanned_by_user_id is not None:
+        query = query.filter(ScanResult.scanned_by_user_id == scanned_by_user_id)
     rows = (
-        db.query(ScanResult)
-        .filter(ScanResult.owner == owner)
-        .order_by(ScanResult.created_at.desc(), ScanResult.id.desc())
+        query.order_by(ScanResult.created_at.desc(), ScanResult.id.desc())
         .limit(limit)
         .all()
     )

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -791,11 +791,30 @@ async def personal_analytics_cockpit(
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    scans = scan_results_repo.list_recent(db, owner=owner, limit=10)
+    # Establish tenant/RLS session context BEFORE any tenant-scoped DB read below.
+    # _cockpit_connected_tenant calls set_tenant_session_context once it has confirmed
+    # membership; scan_results is FORCE ROW LEVEL SECURITY, so reading it first (as this
+    # used to) returns nothing under an enforced-RLS deployment -- only tenant_id IS NULL
+    # rows match an unset app.tenant_id, and real scans always carry a tenant.
+    connected_tenant_id = await anyio.to_thread.run_sync(lambda: _cockpit_connected_tenant(db, user.id, owner))
+
+    # Scan history is a local DB read, not a GitHub-authorized one, so it needs its own
+    # access gate -- the same one /me/analytics/history and /me/analytics/export use.
+    # A caller with no claim at all still gets the rest of the cockpit, just no trend.
+    history_scope = await anyio.to_thread.run_sync(lambda: _user_history_scope(db, user, owner))
+    scans = (
+        scan_results_repo.list_recent(
+            db,
+            owner=owner,
+            limit=10,
+            scanned_by_user_id=user.id if history_scope == "own" else None,
+        )
+        if history_scope is not None
+        else []
+    )
     latest_score = scans[0]["score"] if scans else None
     score_trend = [s["score"] for s in reversed(scans)]
     cache_job_success_rate = _cache_job_success_rate(db)
-    connected_tenant_id = await anyio.to_thread.run_sync(lambda: _cockpit_connected_tenant(db, user.id, owner))
 
     try:
         repos = await anyio.to_thread.run_sync(lambda: _safe_list_repos(owner, token))

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -16,6 +16,7 @@ import hashlib
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import anyio
@@ -266,6 +267,12 @@ _ACTIVITY_SUMMARY_DEFAULT_DAYS = 7
 # gateway timeout would force anyway).
 _SSE_POLL_INTERVAL_SECONDS = 5
 _SSE_MAX_DURATION_SECONDS = 15 * 60
+# Upper bound on a single snapshot read. The stream offloads the read to a threadpool
+# worker via anyio.to_thread.run_sync with abandon_on_cancel=False (the worker owns the
+# Session, so we must not abandon it mid-query) -- meaning a snapshot that blocks would
+# also block cancellation of the stream itself. A server-side statement_timeout lets
+# Postgres kill a stuck read so the worker returns and cancellation can proceed.
+_SSE_SNAPSHOT_TIMEOUT_MS = 20_000
 
 
 def _org_installation_connected(db: Session, org_login: str, ctx: OrgContext) -> bool:
@@ -294,13 +301,63 @@ def _activity_summary_snapshot(db: Session, org_login: str, ctx: OrgContext, day
     )
 
 
-async def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+def _teardown_stream_session(db: Session) -> None:
+    # Mirrors src.core.db.get_db's teardown: app.tenant_id/app.user_id are set with plain
+    # SET (not SET LOCAL -- see set_tenant_session_context), so they persist on the pooled
+    # connection unless RESET before checkin. If any step here fails it's unclear whether
+    # the RESET took, so invalidate() to force the pool to discard the DBAPI connection
+    # rather than risk handing a still-tenant-scoped one to an unrelated later request.
+    try:
+        db.rollback()
+        db.execute(text("RESET app.tenant_id"))
+        db.execute(text("RESET app.user_id"))
+        db.commit()
+        db.close()
+    except Exception:
+        logger.exception("failed to reset SSE stream session context; invalidating connection instead of reusing it")
+        db.invalidate()
+
+
+@contextmanager
+def _stream_poll_session():
+    """A fresh short-lived Session for one poll, torn down (and its connection returned to
+    the pool) before the caller sleeps until the next poll. The stream must NOT hold one
+    Session open for its whole <=15-min lifetime: the Session keeps a pooled connection
+    checked out for as long as it has an open transaction, so a handful of idle streams --
+    openable by any org member -- would otherwise exhaust the connection pool."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        _teardown_stream_session(db)
+
+
+def _run_activity_summary_poll(session_scope, org_login: str, ctx: OrgContext, days: int) -> ActivitySummaryResponse:
+    """One snapshot read on its own session (see _stream_poll_session). Runs in a
+    threadpool worker via anyio.to_thread; the SET LOCAL statement_timeout bounds a read
+    that blocks so stream cancellation isn't stuck waiting on Postgres."""
+    with session_scope() as db:
+        set_tenant_session_context(db, ctx.org.tenant_id, ctx.membership.user_id)
+        db.execute(text(f"SET LOCAL statement_timeout = {int(_SSE_SNAPSHOT_TIMEOUT_MS)}"))
+        return _activity_summary_snapshot(db, org_login, ctx, days)
+
+
+async def _activity_summary_stream(
+    org_login: str,
+    ctx: OrgContext,
+    days: int,
+    poll_interval: float = _SSE_POLL_INTERVAL_SECONDS,
+    *,
+    session_scope=_stream_poll_session,
+):
     """Async SSE body generator. The between-poll wait is `await asyncio.sleep`, not a
     blocking `time.sleep` on a threadpool worker -- a stream stays open up to
     _SSE_MAX_DURATION_SECONDS (15 min), and the previous sync generator pinned one of
     Starlette's ~40 shared threadpool tokens for that whole time, so ~40 concurrent
     EventSource connections (openable by any org member) could starve every other
-    endpoint. Only the short DB snapshot is offloaded to a thread.
+    endpoint. Each poll's DB snapshot runs on its own short-lived session, offloaded to a
+    thread, so nothing DB-side is held across the sleep either (`session_scope` is
+    injectable only so tests can reuse their transaction-scoped fixture session).
 
     Only emits a real `activity_summary` event when the aggregate actually changed since
     the last poll (comparing on totals/connected, not generated_at, which changes every
@@ -310,7 +367,7 @@ async def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext,
     deadline = time.monotonic() + _SSE_MAX_DURATION_SECONDS
     last_key: tuple | None = None
     while time.monotonic() < deadline:
-        snapshot = await anyio.to_thread.run_sync(_activity_summary_snapshot, db, org_login, ctx, days)
+        snapshot = await anyio.to_thread.run_sync(_run_activity_summary_poll, session_scope, org_login, ctx, days)
         key = (snapshot.connected, tuple(sorted((t.repo, t.event_type, t.count) for t in snapshot.totals)))
         if key != last_key:
             yield f"event: activity_summary\ndata: {snapshot.model_dump_json()}\n\n"
@@ -340,42 +397,6 @@ def org_activity_summary(
     return _activity_summary_snapshot(db, org_login, ctx, days)
 
 
-def _teardown_stream_session(db: Session) -> None:
-    # Mirrors src.core.db.get_db's teardown: app.tenant_id/app.user_id are set with plain
-    # SET (not SET LOCAL -- see set_tenant_session_context), so they persist on the pooled
-    # connection unless RESET before checkin. If any step here fails it's unclear whether
-    # the RESET took, so invalidate() to force the pool to discard the DBAPI connection
-    # rather than risk handing a still-tenant-scoped one to an unrelated later request.
-    try:
-        db.rollback()
-        db.execute(text("RESET app.tenant_id"))
-        db.execute(text("RESET app.user_id"))
-        db.commit()
-        db.close()
-    except Exception:
-        logger.exception("failed to reset SSE stream session context; invalidating connection instead of reusing it")
-        db.invalidate()
-
-
-async def _activity_summary_stream_session(org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
-    """Owns a dedicated DB session for the SSE connection's whole lifetime instead of the
-    request-scoped `Depends(get_db)` session: FastAPI 0.116.1 runs a yield-dependency's
-    cleanup as soon as the route handler *returns* the StreamingResponse object, not after
-    this generator finishes streaming its body -- a borrowed request session would already
-    be closed (and its tenant/user SET vars RESET) before this loop's first poll runs.
-
-    The sync session is only ever touched from one thread at a time (each blocking call is
-    awaited via anyio.to_thread before the next starts), so it's safe to shuttle it
-    between threadpool workers this way."""
-    db = SessionLocal()
-    try:
-        await anyio.to_thread.run_sync(set_tenant_session_context, db, ctx.org.tenant_id, ctx.membership.user_id)
-        async for chunk in _activity_summary_stream(db, org_login, ctx, days, poll_interval):
-            yield chunk
-    finally:
-        await anyio.to_thread.run_sync(_teardown_stream_session, db)
-
-
 @router.get("/github/orgs/{org_login}/activity-summary/stream")
 async def org_activity_summary_stream(
     org_login: str,
@@ -383,10 +404,13 @@ async def org_activity_summary_stream(
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
 ):
     """SSE channel pushing the same shape org_activity_summary returns, whenever it
-    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream
-    and _activity_summary_stream_session."""
+    changes. First concrete piece of S6's "+ SSE" half -- see _activity_summary_stream.
+
+    No `Depends(get_db)`: FastAPI 0.116.1 tears a yield-dependency down as soon as the
+    handler *returns* the StreamingResponse, before the body has streamed -- so the
+    stream opens its own per-poll sessions instead (see _stream_poll_session)."""
     days = max(1, min(days, _ACTIVITY_SUMMARY_MAX_DAYS))
-    return StreamingResponse(_activity_summary_stream_session(org_login, ctx, days), media_type="text/event-stream")
+    return StreamingResponse(_activity_summary_stream(org_login, ctx, days), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -11,11 +11,13 @@ itself (no `prefix=` passed to include_router in main.py), matching every
 sibling org-scoped router's convention of defining its complete path locally.
 """
 
+import asyncio
 import hashlib
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
+import anyio
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -289,10 +291,13 @@ def _activity_summary_snapshot(db: Session, org_login: str, ctx: OrgContext, day
     )
 
 
-def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
-    """SSE body generator. Runs in Starlette's threadpool iterator (this route is a plain
-    `def`, matching every other handler in this file, so FastAPI already executes it off
-    the event loop) -- the blocking time.sleep below does not stall other requests.
+async def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+    """Async SSE body generator. The between-poll wait is `await asyncio.sleep`, not a
+    blocking `time.sleep` on a threadpool worker -- a stream stays open up to
+    _SSE_MAX_DURATION_SECONDS (15 min), and the previous sync generator pinned one of
+    Starlette's ~40 shared threadpool tokens for that whole time, so ~40 concurrent
+    EventSource connections (openable by any org member) could starve every other
+    endpoint. Only the short DB snapshot is offloaded to a thread.
 
     Only emits a real `activity_summary` event when the aggregate actually changed since
     the last poll (comparing on totals/connected, not generated_at, which changes every
@@ -302,14 +307,14 @@ def _activity_summary_stream(db: Session, org_login: str, ctx: OrgContext, days:
     deadline = time.monotonic() + _SSE_MAX_DURATION_SECONDS
     last_key: tuple | None = None
     while time.monotonic() < deadline:
-        snapshot = _activity_summary_snapshot(db, org_login, ctx, days)
+        snapshot = await anyio.to_thread.run_sync(_activity_summary_snapshot, db, org_login, ctx, days)
         key = (snapshot.connected, tuple(sorted((t.repo, t.event_type, t.count) for t in snapshot.totals)))
         if key != last_key:
             yield f"event: activity_summary\ndata: {snapshot.model_dump_json()}\n\n"
             last_key = key
         else:
             yield ": heartbeat\n\n"
-        time.sleep(poll_interval)
+        await asyncio.sleep(poll_interval)
 
 
 @router.get("/github/orgs/{org_login}/activity-summary", response_model=ActivitySummaryResponse)
@@ -332,28 +337,37 @@ def org_activity_summary(
     return _activity_summary_snapshot(db, org_login, ctx, days)
 
 
-def _activity_summary_stream_session(org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
+def _teardown_stream_session(db: Session) -> None:
+    try:
+        db.rollback()
+        db.execute(text("RESET app.tenant_id"))
+        db.execute(text("RESET app.user_id"))
+        db.commit()
+    finally:
+        db.close()
+
+
+async def _activity_summary_stream_session(org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):
     """Owns a dedicated DB session for the SSE connection's whole lifetime instead of the
     request-scoped `Depends(get_db)` session: FastAPI 0.116.1 runs a yield-dependency's
     cleanup as soon as the route handler *returns* the StreamingResponse object, not after
     this generator finishes streaming its body -- a borrowed request session would already
-    be closed (and its tenant/user SET vars RESET) before this loop's first poll runs."""
+    be closed (and its tenant/user SET vars RESET) before this loop's first poll runs.
+
+    The sync session is only ever touched from one thread at a time (each blocking call is
+    awaited via anyio.to_thread before the next starts), so it's safe to shuttle it
+    between threadpool workers this way."""
     db = SessionLocal()
     try:
-        set_tenant_session_context(db, ctx.org.tenant_id, ctx.membership.user_id)
-        yield from _activity_summary_stream(db, org_login, ctx, days, poll_interval)
+        await anyio.to_thread.run_sync(set_tenant_session_context, db, ctx.org.tenant_id, ctx.membership.user_id)
+        async for chunk in _activity_summary_stream(db, org_login, ctx, days, poll_interval):
+            yield chunk
     finally:
-        try:
-            db.rollback()
-            db.execute(text("RESET app.tenant_id"))
-            db.execute(text("RESET app.user_id"))
-            db.commit()
-        finally:
-            db.close()
+        await anyio.to_thread.run_sync(_teardown_stream_session, db)
 
 
 @router.get("/github/orgs/{org_login}/activity-summary/stream")
-def org_activity_summary_stream(
+async def org_activity_summary_stream(
     org_login: str,
     days: int = _ACTIVITY_SUMMARY_DEFAULT_DAYS,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),

--- a/apps/api/src/routers/github.py
+++ b/apps/api/src/routers/github.py
@@ -13,6 +13,7 @@ sibling org-scoped router's convention of defining its complete path locally.
 
 import asyncio
 import hashlib
+import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
@@ -42,6 +43,8 @@ from src.schemas.github import (
 )
 from src.services.github_client import GitHubClient, github_error as _github_error
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token
+
+logger = logging.getLogger(__name__)
 
 # repo_events.event_type is the lowercase vocabulary apps/worker's event_consumer.py and
 # backfill.py both write (issue #191/#192) -- the UI's event-feed.tsx filter chips match
@@ -338,13 +341,20 @@ def org_activity_summary(
 
 
 def _teardown_stream_session(db: Session) -> None:
+    # Mirrors src.core.db.get_db's teardown: app.tenant_id/app.user_id are set with plain
+    # SET (not SET LOCAL -- see set_tenant_session_context), so they persist on the pooled
+    # connection unless RESET before checkin. If any step here fails it's unclear whether
+    # the RESET took, so invalidate() to force the pool to discard the DBAPI connection
+    # rather than risk handing a still-tenant-scoped one to an unrelated later request.
     try:
         db.rollback()
         db.execute(text("RESET app.tenant_id"))
         db.execute(text("RESET app.user_id"))
         db.commit()
-    finally:
         db.close()
+    except Exception:
+        logger.exception("failed to reset SSE stream session context; invalidating connection instead of reusing it")
+        db.invalidate()
 
 
 async def _activity_summary_stream_session(org_login: str, ctx: OrgContext, days: int, poll_interval: float = _SSE_POLL_INTERVAL_SECONDS):

--- a/apps/api/src/services/github_app.py
+++ b/apps/api/src/services/github_app.py
@@ -43,6 +43,10 @@ class _CachedToken:
 
 _cache: dict[int, _CachedToken] = {}
 _lock = threading.Lock()
+# One mint lock per installation_id, so a stampede for the same uncached
+# installation collapses into a single GitHub call without serialising mints for
+# *other* installations (which holding _lock across the HTTP POST used to do).
+_mint_locks: dict[int, threading.Lock] = {}
 
 
 def _require_config() -> tuple[str, str]:
@@ -127,14 +131,38 @@ def delete_installation(installation_id: int) -> None:
     resp.raise_for_status()
 
 
-def get_installation_token(installation_id: int) -> str:
-    """Return a valid installation access token, minting and caching it as needed."""
+def _cached_token(installation_id: int) -> str | None:
     with _lock:
         cached = _cache.get(installation_id)
-        if cached and cached.expires_at - _TOKEN_EXPIRY_MARGIN_SECONDS > time.time():
-            return cached.token
+    if cached and cached.expires_at - _TOKEN_EXPIRY_MARGIN_SECONDS > time.time():
+        return cached.token
+    return None
+
+
+def get_installation_token(installation_id: int) -> str:
+    """Return a valid installation access token, minting and caching it as needed.
+
+    The blocking mint (`_request_installation_token` -- an httpx POST to GitHub,
+    up to a 20s timeout) is done *outside* `_lock`. Holding the shared cache lock
+    across that call serialised token resolution for every installation behind a
+    single slow GitHub response. A per-installation `_mint_locks` entry still
+    collapses a concurrent stampede for the same uncached installation into one
+    mint, and the cache is re-checked after acquiring it."""
+    hit = _cached_token(installation_id)
+    if hit is not None:
+        return hit
+
+    with _lock:
+        mint_lock = _mint_locks.setdefault(installation_id, threading.Lock())
+
+    with mint_lock:
+        # Another thread may have minted while we waited for mint_lock.
+        hit = _cached_token(installation_id)
+        if hit is not None:
+            return hit
         fresh = _request_installation_token(installation_id)
-        _cache[installation_id] = fresh
+        with _lock:
+            _cache[installation_id] = fresh
         return fresh.token
 
 
@@ -167,3 +195,4 @@ def clear_cache() -> None:
     """Drop all cached installation tokens (used by tests and on config change)."""
     with _lock:
         _cache.clear()
+        _mint_locks.clear()

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -25,8 +25,6 @@ existing memberships are left untouched rather than being wiped on a transient f
 
 import logging
 
-import httpx
-
 from sqlalchemy.orm import Session
 
 from src.core.db import Org, User, set_session_user
@@ -86,7 +84,12 @@ def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None
     set_session_user(db, user.id)
     try:
         memberships = github_oauth.list_user_org_memberships(user_token)
-    except httpx.HTTPError:
+    except Exception:  # noqa: BLE001 -- best-effort; must never block login
+        # Not just httpx.HTTPError: a shape drift in GitHub's response (a missing
+        # `organization`/`id`/`login`/`role` key, a non-JSON body) raises KeyError /
+        # TypeError / ValueError, which previously escaped this handler and 500'd the
+        # OAuth callback -- contrary to the module docstring's "logged and swallowed".
+        # Matches connect_admin_org_from_token's own catch above.
         logger.warning(
             "Failed to list GitHub org memberships for user %s during org provisioning", user.id, exc_info=True
         )

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -164,6 +164,39 @@ def test_cockpit_hides_score_trend_from_a_non_member_byo_pat_caller(http, db, mo
     assert body["score_trend"] == []
 
 
+def test_cockpit_shows_own_byo_pat_scans_when_caller_has_no_org_membership(http, db, mock_user):
+    # An org row for "acme" exists but the caller has no membership and no installation
+    # -- their only claim to its history is a scan they ran themselves, so
+    # _user_history_scope is "own" and only their own scan rows feed the trend.
+    # Mirrors test_analytics_history.py::test_personal_history_returns_seeded_rows_newest_first.
+    org = org_repo.get_or_create(db, github_login="acme")
+    other = User(email="other-cockpit@example.com", name=None, is_workspace_admin=False)
+    db.add(other)
+    db.flush()
+    scan_results_repo.insert(
+        db, owner="acme", score=60, total_checks=5, failed_checks=2, checks=[],
+        tenant_id=org.tenant_id, scanned_by_user_id=mock_user.id,
+    )
+    scan_results_repo.insert(
+        db, owner="acme", score=90, total_checks=5, failed_checks=0, checks=[],
+        tenant_id=org.tenant_id, scanned_by_user_id=other.id,
+    )
+
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Only mock_user's own scan (60), not the other user's (90).
+    assert body["latest_score"] == 60
+    assert body["score_trend"] == [60]
+
+
 def test_cockpit_no_cache_jobs_yet(http, db, mock_user):
     patchers = _patch_all()
     _start_all(patchers)

--- a/apps/api/tests/test_analytics_cockpit.py
+++ b/apps/api/tests/test_analytics_cockpit.py
@@ -97,6 +97,9 @@ def test_cockpit_no_token_available_returns_400(http):
 
 def test_cockpit_success_all_sources(http, db, mock_user):
     org = org_repo.get_or_create(db, github_login="acme")
+    # The score trend is gated the same way /me/analytics/history is -- the caller
+    # must be a member of the matching org (or have their own BYO-PAT scans).
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
     scan_results_repo.insert(db, owner="acme", score=70, total_checks=5, failed_checks=1, checks=[], tenant_id=org.tenant_id)
     scan_results_repo.insert(db, owner="acme", score=85, total_checks=5, failed_checks=0, checks=[], tenant_id=org.tenant_id)
     for status in ("done", "done", "done", "failed"):
@@ -126,6 +129,27 @@ def test_cockpit_success_all_sources(http, db, mock_user):
 
 
 def test_cockpit_no_scans_yet(http, db, mock_user):
+    patchers = _patch_all()
+    _start_all(patchers)
+    try:
+        with patch("src.routers.analytics.resolve_owner_token", return_value="ghp_test"):
+            resp = http.get("/me/analytics/cockpit/acme")
+    finally:
+        _stop_all(patchers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["latest_score"] is None
+    assert body["score_trend"] == []
+
+
+def test_cockpit_hides_score_trend_from_a_non_member_byo_pat_caller(http, db, mock_user):
+    # A connected org with scan history exists, but mock_user has no membership and
+    # never ran a scan of it -- resolving a BYO-PAT for the login must not expose the
+    # org's score history, same gate as /me/analytics/history.
+    org = org_repo.get_or_create(db, github_login="acme")
+    scan_results_repo.insert(db, owner="acme", score=70, total_checks=5, failed_checks=1, checks=[], tenant_id=org.tenant_id)
+
     patchers = _patch_all()
     _start_all(patchers)
     try:

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -269,6 +269,24 @@ async def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypat
     fake_db.close.assert_called_once()
 
 
+def test_teardown_stream_session_invalidates_connection_when_reset_fails():
+    """Regression (CodeRabbit finding on PR #405): app.tenant_id/app.user_id are set with
+    plain SET, so a teardown that fails partway (RESET or commit raises) must discard the
+    pooled connection rather than close() it back into the pool still tenant-scoped --
+    same contract as src.core.db.get_db's teardown."""
+    from unittest.mock import MagicMock
+
+    from src.routers.github import _teardown_stream_session
+
+    db = MagicMock()
+    db.execute.side_effect = RuntimeError("connection dropped mid-RESET")
+
+    _teardown_stream_session(db)
+
+    db.invalidate.assert_called_once()
+    db.close.assert_not_called()
+
+
 @pytest.fixture()
 def rbac_ctx_factory(db):
     from src.core.rbac import OrgContext, set_tenant_session_context

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -2,6 +2,7 @@
 concrete piece of the feat/aggregates-api-sse foundation -- see docs/plan.md's S6 section."""
 
 import json
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
@@ -13,6 +14,7 @@ from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
 from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.github import _activity_summary_stream, router as github_router
+from src.schemas.github import ActivitySummaryResponse
 
 _MEMBER = UserOut(id=1, email="member@example.com", name=None, is_workspace_admin=False)
 
@@ -189,13 +191,25 @@ async def _take(agen, n):
     return out
 
 
+def _reuse_session(session):
+    """A `session_scope` for _activity_summary_stream that hands each poll the test's own
+    transaction-scoped fixture session (so it can see uncommitted fixture rows) and skips
+    the real per-poll teardown, which would roll the fixture data back."""
+
+    @contextmanager
+    def _scope():
+        yield session
+
+    return _scope
+
+
 @pytest.mark.asyncio
 async def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme_org_with_installation, rbac_ctx_factory):
     today = date.today()
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
     ctx = rbac_ctx_factory(acme_org_with_installation)
 
-    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    gen = _activity_summary_stream("acme", ctx, days=7, poll_interval=0, session_scope=_reuse_session(db))
     first, second = await _take(gen, 2)
     await gen.aclose()
 
@@ -210,7 +224,7 @@ async def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_
     today = date.today()
     ctx = rbac_ctx_factory(acme_org_with_installation)
 
-    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    gen = _activity_summary_stream("acme", ctx, days=7, poll_interval=0, session_scope=_reuse_session(db))
     (first,) = await _take(gen, 1)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
     (second,) = await _take(gen, 1)
@@ -224,7 +238,7 @@ async def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_
 async def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_factory):
     ctx = rbac_ctx_factory(acme_org)
 
-    gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
+    gen = _activity_summary_stream("acme", ctx, days=7, poll_interval=0, session_scope=_reuse_session(db))
     (first,) = await _take(gen, 1)
     await gen.aclose()
 
@@ -233,40 +247,49 @@ async def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rba
 
 
 @pytest.mark.asyncio
-async def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
-    """Regression test (CodeRabbit finding on PR #349): the SSE route must not reuse the
-    request-scoped `Depends(get_db)` session, which FastAPI 0.116.1 closes (and RESETs its
-    tenant/user SET vars on) as soon as the route handler returns the StreamingResponse --
-    before this generator has streamed anything. Verifies the wrapper opens its own
-    session via SessionLocal, sets tenant context on it, and closes it once the stream
-    ends, independent of _activity_summary_stream's own query logic (covered above)."""
+async def test_stream_opens_and_tears_down_a_fresh_session_per_poll(monkeypatch):
+    """Regression test (CodeRabbit findings on PR #349 and #405): the SSE stream must not
+    reuse the request-scoped `Depends(get_db)` session (FastAPI 0.116.1 tears that down as
+    soon as the handler returns the StreamingResponse), and it must not hold ONE session
+    open across the whole <=15-min stream either -- an open Session pins a pooled
+    connection, so a few idle streams would exhaust the pool. Each poll gets its own
+    SessionLocal(), with tenant context + a bounded statement_timeout set on it, and it's
+    closed before the next poll."""
     from types import SimpleNamespace
     from unittest.mock import MagicMock
 
     import src.routers.github as github_module
 
-    fake_db = MagicMock()
-    monkeypatch.setattr(github_module, "SessionLocal", lambda: fake_db)
+    sessions: list = []
 
-    captured: dict = {}
+    def _fake_session_local():
+        s = MagicMock()
+        sessions.append(s)
+        return s
 
-    async def _fake_inner_stream(db, org_login, ctx, days, poll_interval):
-        captured["db"] = db
-        yield "event: activity_summary\ndata: {}\n\n"
-
-    monkeypatch.setattr(github_module, "_activity_summary_stream", _fake_inner_stream)
+    monkeypatch.setattr(github_module, "SessionLocal", _fake_session_local)
+    monkeypatch.setattr(
+        github_module,
+        "_activity_summary_snapshot",
+        lambda db, org_login, ctx, days: ActivitySummaryResponse(
+            org=org_login, days=days, connected=False, generated_at=datetime.now(timezone.utc), totals=[]
+        ),
+    )
 
     ctx = SimpleNamespace(org=SimpleNamespace(tenant_id=42), membership=SimpleNamespace(user_id=7))
-    gen = github_module._activity_summary_stream_session("acme", ctx, days=1, poll_interval=0)
-    (first,) = await _take(gen, 1)
+    gen = github_module._activity_summary_stream("acme", ctx, days=1, poll_interval=0)
+    await _take(gen, 2)
     await gen.aclose()
 
-    assert first == "event: activity_summary\ndata: {}\n\n"
-    assert captured["db"] is fake_db
-    executed_sql = [c.args[0].text for c in fake_db.execute.call_args_list]
-    assert "SET app.tenant_id = 42" in executed_sql
-    assert "SET app.user_id = 7" in executed_sql
-    fake_db.close.assert_called_once()
+    # One session per poll, each closed (not left holding a connection across the sleep).
+    assert len(sessions) >= 2
+    for s in sessions:
+        executed_sql = [c.args[0].text for c in s.execute.call_args_list]
+        assert "SET app.tenant_id = 42" in executed_sql
+        assert "SET app.user_id = 7" in executed_sql
+        assert any(sql.startswith("SET LOCAL statement_timeout") for sql in executed_sql)
+        assert "RESET app.tenant_id" in executed_sql
+        s.close.assert_called_once()
 
 
 def test_teardown_stream_session_invalidates_connection_when_reset_fails():

--- a/apps/api/tests/test_github_activity_summary.py
+++ b/apps/api/tests/test_github_activity_summary.py
@@ -176,19 +176,28 @@ def test_activity_summary_non_member_forbidden(db, acme_org):
 # ---------------------------------------------------------------------------
 # SSE stream -- tested against the generator function directly (not through
 # TestClient's own streaming, which would require a real multi-second wait per
-# poll interval); a tiny poll_interval keeps these tests fast.
+# poll interval); a tiny poll_interval keeps these tests fast. The generators are
+# async (the between-poll wait is `await asyncio.sleep`, not a blocking
+# `time.sleep` on a threadpool worker -- see _activity_summary_stream).
 # ---------------------------------------------------------------------------
 
 
-def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme_org_with_installation, rbac_ctx_factory):
+async def _take(agen, n):
+    out = []
+    for _ in range(n):
+        out.append(await agen.__anext__())
+    return out
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme_org_with_installation, rbac_ctx_factory):
     today = date.today()
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
     ctx = rbac_ctx_factory(acme_org_with_installation)
 
     gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
-    first = next(gen)
-    second = next(gen)
-    gen.close()
+    first, second = await _take(gen, 2)
+    await gen.aclose()
 
     assert first.startswith("event: activity_summary\ndata: ")
     payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
@@ -196,32 +205,35 @@ def test_stream_emits_a_real_event_first_then_heartbeats_when_unchanged(db, acme
     assert second == ": heartbeat\n\n"
 
 
-def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_with_installation, rbac_ctx_factory):
+@pytest.mark.asyncio
+async def test_stream_emits_a_new_event_when_the_aggregate_changes(db, acme_org_with_installation, rbac_ctx_factory):
     today = date.today()
     ctx = rbac_ctx_factory(acme_org_with_installation)
 
     gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
-    first = next(gen)
+    (first,) = await _take(gen, 1)
     _insert_daily_count(db, acme_org_with_installation.tenant_id, repo="acme/api", event_type="push", day=today, count=1)
-    second = next(gen)
-    gen.close()
+    (second,) = await _take(gen, 1)
+    await gen.aclose()
 
     assert json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())["totals"] == []
     assert second.startswith("event: activity_summary\ndata: ")
 
 
-def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_factory):
+@pytest.mark.asyncio
+async def test_stream_reports_unconnected_for_a_legacy_pat_org(db, acme_org, rbac_ctx_factory):
     ctx = rbac_ctx_factory(acme_org)
 
     gen = _activity_summary_stream(db, "acme", ctx, days=7, poll_interval=0)
-    first = next(gen)
-    gen.close()
+    (first,) = await _take(gen, 1)
+    await gen.aclose()
 
     payload = json.loads(first.removeprefix("event: activity_summary\ndata: ").strip())
     assert payload["connected"] is False
 
 
-def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
+@pytest.mark.asyncio
+async def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
     """Regression test (CodeRabbit finding on PR #349): the SSE route must not reuse the
     request-scoped `Depends(get_db)` session, which FastAPI 0.116.1 closes (and RESETs its
     tenant/user SET vars on) as soon as the route handler returns the StreamingResponse --
@@ -238,7 +250,7 @@ def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
 
     captured: dict = {}
 
-    def _fake_inner_stream(db, org_login, ctx, days, poll_interval):
+    async def _fake_inner_stream(db, org_login, ctx, days, poll_interval):
         captured["db"] = db
         yield "event: activity_summary\ndata: {}\n\n"
 
@@ -246,8 +258,8 @@ def test_stream_session_wrapper_opens_and_closes_its_own_session(monkeypatch):
 
     ctx = SimpleNamespace(org=SimpleNamespace(tenant_id=42), membership=SimpleNamespace(user_id=7))
     gen = github_module._activity_summary_stream_session("acme", ctx, days=1, poll_interval=0)
-    first = next(gen)
-    gen.close()
+    (first,) = await _take(gen, 1)
+    await gen.aclose()
 
     assert first == "event: activity_summary\ndata: {}\n\n"
     assert captured["db"] is fake_db

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -96,6 +96,24 @@ def test_expired_cache_refetches(app_configured):
     assert mock_client.post.call_count == 2
 
 
+def test_get_installation_token_rechecks_cache_after_acquiring_mint_lock(app_configured, monkeypatch):
+    # Simulates another thread minting the token in the window between the lock-free
+    # cache check and this call acquiring the per-installation mint lock: the second
+    # check must short-circuit and no HTTP mint should happen.
+    calls: list[int] = []
+
+    def fake_cached(installation_id: int):
+        calls.append(installation_id)
+        return None if len(calls) == 1 else "ghs_raced"
+
+    minted = MagicMock()
+    monkeypatch.setattr(github_app, "_cached_token", fake_cached)
+    monkeypatch.setattr(github_app, "_request_installation_token", minted)
+
+    assert github_app.get_installation_token(42) == "ghs_raced"
+    minted.assert_not_called()
+
+
 def test_not_configured_raises(monkeypatch):
     monkeypatch.setattr(settings, "github_app_id", None)
     monkeypatch.setattr(settings, "github_app_private_key", None)

--- a/apps/ui/app/layout.tsx
+++ b/apps/ui/app/layout.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { Toaster } from "@/components/ui/toast"
 import { QueryProvider } from "@/components/query-provider"
+import { QueryAuthSync } from "@/components/query-auth-sync"
 import { AuthProvider } from "@/lib/auth-context"
 import { AuthGuard } from "@/components/auth-guard"
 import { ShellRouter } from "@/components/shell-router"
@@ -58,6 +59,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <TooltipProvider>
             <IconProvider>
               <AuthProvider>
+                <QueryAuthSync />
                 <AuthGuard>
                   <ShellRouter>{children}</ShellRouter>
                   <Toaster />

--- a/apps/ui/app/verify-email/page.tsx
+++ b/apps/ui/app/verify-email/page.tsx
@@ -11,21 +11,25 @@ export default function VerifyEmailPage() {
   const token = searchParams.get("token")
   const [state, setState] = useState<"pending" | "success" | "error">("pending")
   const [errorMessage, setErrorMessage] = useState("")
-  const ranRef = useRef(false)
+  // Tracks which token value we've already POSTed. Scoped to the token, not the
+  // component instance: a boolean "ran" flag would also swallow a genuinely new
+  // token (URL changes, or a missing token becoming present) after the first run.
+  const attemptedToken = useRef<string | null>(null)
 
   useEffect(() => {
-    // The verification token is single-use: React Strict Mode (dev) double-invokes
-    // this effect, and a client nav away-and-back remounts it. Without this guard the
-    // second POST 400s on the now-consumed token and overwrites a real "success" with
-    // an error. Mirrors app/settings/github-callback/page.tsx.
-    if (ranRef.current) return
-    ranRef.current = true
-
     if (!token) {
       setState("error")
       setErrorMessage("This verification link is missing its token.")
       return
     }
+    // The verification token is single-use: React Strict Mode (dev) double-invokes
+    // this effect. Without this guard the second POST 400s on the now-consumed token
+    // and overwrites a real "success" with an error. A hard remount (new component
+    // instance) still can't be deduped from the client alone -- the API clears the
+    // token server-side, so a resubmit legitimately surfaces "expired".
+    if (attemptedToken.current === token) return
+    attemptedToken.current = token
+    setState("pending")
     api.auth
       .verifyEmail(token)
       .then(() => setState("success"))

--- a/apps/ui/app/verify-email/page.tsx
+++ b/apps/ui/app/verify-email/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import { PageHeader } from "@/components/page-header"
 import { api } from "@/lib/api/client"
@@ -11,8 +11,16 @@ export default function VerifyEmailPage() {
   const token = searchParams.get("token")
   const [state, setState] = useState<"pending" | "success" | "error">("pending")
   const [errorMessage, setErrorMessage] = useState("")
+  const ranRef = useRef(false)
 
   useEffect(() => {
+    // The verification token is single-use: React Strict Mode (dev) double-invokes
+    // this effect, and a client nav away-and-back remounts it. Without this guard the
+    // second POST 400s on the now-consumed token and overwrites a real "success" with
+    // an error. Mirrors app/settings/github-callback/page.tsx.
+    if (ranRef.current) return
+    ranRef.current = true
+
     if (!token) {
       setState("error")
       setErrorMessage("This verification link is missing its token.")

--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { Fragment, useEffect, useRef } from "react"
 import { useRouter, usePathname } from "next/navigation"
 import { X } from "@phosphor-icons/react"
 import { useAuth } from "@/lib/auth-context"
@@ -106,7 +106,13 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
           </button>
         </div>
       )}
-      {children}
+      {/* Remount the whole authenticated page subtree when the signed-in user
+          changes on the same tab. QueryAuthSync empties the shared QueryClient
+          synchronously on that transition, but a live QueryObserver memoizes its
+          last result, so a query keyed on `org` alone (e.g. ["tokens.resolve",
+          org]) would still paint the previous user's data for one frame. A fresh
+          key forces new observers that read the just-cleared cache instead. */}
+      <Fragment key={user.id}>{children}</Fragment>
     </>
   )
 }

--- a/apps/ui/components/query-auth-sync.tsx
+++ b/apps/ui/components/query-auth-sync.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useAuth } from "@/lib/auth-context"
+
+/**
+ * Drops the entire React Query cache whenever the signed-in user changes,
+ * including sign-out (id -> null) and an account switch on the same tab.
+ *
+ * The QueryClient is created once and outlives a logout/login that happens
+ * via client navigation, and several sensitive queries are keyed on `org`
+ * alone (`["tokens.resolve", org]` resolves to a decrypted GitHub PAT,
+ * `["analytics.my-view", org]`, `["my-orgs"]`, `["installations"]`, …). Without
+ * this, user B landing on the app within `staleTime` of user A signing out
+ * could be served A's cached PAT and personal data (CWE-200). `app/page.tsx`
+ * mitigated one query by adding `user?.id` to its key; this generalises it.
+ *
+ * Rendered inside AuthProvider (needs useAuth) and QueryProvider (needs
+ * useQueryClient); it renders nothing.
+ */
+export function QueryAuthSync() {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const lastUserId = useRef<number | null | undefined>(undefined)
+
+  useEffect(() => {
+    const current = user?.id ?? null
+    if (lastUserId.current === undefined) {
+      // First observation on mount — nothing cached under a prior identity yet.
+      lastUserId.current = current
+      return
+    }
+    if (lastUserId.current !== current) {
+      lastUserId.current = current
+      queryClient.clear()
+    }
+  }, [user?.id, queryClient])
+
+  return null
+}

--- a/apps/ui/components/query-auth-sync.tsx
+++ b/apps/ui/components/query-auth-sync.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useRef } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useAuth } from "@/lib/auth-context"
 
@@ -13,8 +13,17 @@ import { useAuth } from "@/lib/auth-context"
  * alone (`["tokens.resolve", org]` resolves to a decrypted GitHub PAT,
  * `["analytics.my-view", org]`, `["my-orgs"]`, `["installations"]`, …). Without
  * this, user B landing on the app within `staleTime` of user A signing out
- * could be served A's cached PAT and personal data (CWE-200). `app/page.tsx`
- * mitigated one query by adding `user?.id` to its key; this generalises it.
+ * could be served A's cached PAT and personal data (CWE-200).
+ *
+ * The clear runs **during render**, not in an effect. This component is
+ * rendered immediately before `<AuthGuard>` in `app/layout.tsx`, so a
+ * synchronous clear here lands before any `useQuery` inside the authenticated
+ * subtree reads the cache on the same commit. An effect-based clear would run
+ * only after that first paint, leaving one frame in which a query keyed on
+ * `org` alone serves the previous user's data. Adjusting external state during
+ * render for a prop change is a supported React pattern; `queryClient.clear()`
+ * is idempotent and the ref guard makes it fire once per identity change
+ * (Strict Mode's double render included).
  *
  * Rendered inside AuthProvider (needs useAuth) and QueryProvider (needs
  * useQueryClient); it renders nothing.
@@ -24,18 +33,14 @@ export function QueryAuthSync() {
   const queryClient = useQueryClient()
   const lastUserId = useRef<number | null | undefined>(undefined)
 
-  useEffect(() => {
-    const current = user?.id ?? null
-    if (lastUserId.current === undefined) {
-      // First observation on mount — nothing cached under a prior identity yet.
-      lastUserId.current = current
-      return
-    }
-    if (lastUserId.current !== current) {
-      lastUserId.current = current
-      queryClient.clear()
-    }
-  }, [user?.id, queryClient])
+  const currentUserId = user?.id ?? null
+  if (lastUserId.current === undefined) {
+    // First observation on mount — nothing cached under a prior identity yet.
+    lastUserId.current = currentUserId
+  } else if (lastUserId.current !== currentUserId) {
+    lastUserId.current = currentUserId
+    queryClient.clear()
+  }
 
   return null
 }

--- a/apps/ui/lib/active-scope.ts
+++ b/apps/ui/lib/active-scope.ts
@@ -77,6 +77,16 @@ export function setActiveScope(scope: ActiveScope): void {
   window.dispatchEvent(new Event(CHANGE_EVENT))
 }
 
+// Called on logout so a new user on the same browser doesn't start already
+// scoped into the previous user's org (which would also fire scoped requests
+// for an org they may have no relationship with). Clears the legacy key too.
+export function clearActiveScope(): void {
+  if (typeof window === "undefined") return
+  localStorage.removeItem(STORAGE_KEY)
+  localStorage.removeItem(LEGACY_ORG_KEY)
+  window.dispatchEvent(new Event(CHANGE_EVENT))
+}
+
 export function useActiveScope(): { scope: ActiveScope | null; setScope: (scope: ActiveScope) => void } {
   const scope = useSyncExternalStore(subscribe, read, getServerSnapshot)
   const setScope = useCallback((next: ActiveScope) => setActiveScope(next), [])

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -38,6 +38,21 @@ const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
 const _LOGOUT_WARNING =
   "Logged out locally, but the server session may still be active. Avoid shared devices until you can retry."
 
+// Per-user browser state that must not survive an identity change on this tab.
+// active_scope / default_org would point a new user at the previous user's org
+// for owner-scoped requests; activity_last_seen_at would mis-seed their unread
+// count. Cleared on logout AND on login/setSession (the public /register route
+// calls setSession() while a session is already active, replacing the user
+// without ever going through logout()).
+function clearPerUserBrowserState(): void {
+  clearActiveScope()
+  try {
+    localStorage.removeItem("activity_last_seen_at")
+  } catch {
+    // best-effort; nothing to do if storage is unavailable
+  }
+}
+
 function parseJwtPayload(token: string): AuthUser | null {
   try {
     const segment = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")
@@ -89,8 +104,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Drop per-user browser state so a different user on this browser doesn't
     // inherit the previous user's org scope / unread-activity marker. The React
     // Query cache is cleared separately by QueryAuthSync on the user-id change.
-    clearActiveScope()
-    localStorage.removeItem("activity_last_seen_at")
+    clearPerUserBrowserState()
     setToken(null)
     setUser(null)
     setAuthUnconfirmed(false)
@@ -225,6 +239,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
     bumpSessionEpoch()
     clearLogoutWarning()
+    clearPerUserBrowserState()
     localStorage.setItem(_TOKEN_KEY, access_token)
     setToken(access_token)
     setUser(u)
@@ -241,6 +256,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     (jwtToken: string, authUser: AuthUser, invitations: PendingInvitationSummary[] = []) => {
       bumpSessionEpoch()
       clearLogoutWarning()
+      clearPerUserBrowserState()
       localStorage.setItem(_TOKEN_KEY, jwtToken)
       setToken(jwtToken)
       setUser(authUser)

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 import type { PendingInvitationSummary } from "@/lib/api/types"
+import { clearActiveScope } from "@/lib/active-scope"
 
 export interface AuthUser {
   id: number
@@ -85,6 +86,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       })
       .catch(() => setLogoutWarning(_LOGOUT_WARNING))
     localStorage.removeItem(_TOKEN_KEY)
+    // Drop per-user browser state so a different user on this browser doesn't
+    // inherit the previous user's org scope / unread-activity marker. The React
+    // Query cache is cleared separately by QueryAuthSync on the user-id change.
+    clearActiveScope()
+    localStorage.removeItem("activity_last_seen_at")
     setToken(null)
     setUser(null)
     setAuthUnconfirmed(false)

--- a/apps/ui/tests/components/query-auth-sync.test.tsx
+++ b/apps/ui/tests/components/query-auth-sync.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+let mockUser: { id: number } | null = null
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ user: mockUser }),
+}))
+
+import { QueryAuthSync } from "@/components/query-auth-sync"
+
+function renderWith(qc: QueryClient) {
+  return render(
+    <QueryClientProvider client={qc}>
+      <QueryAuthSync />
+    </QueryClientProvider>,
+  )
+}
+
+describe("QueryAuthSync", () => {
+  afterEach(() => {
+    cleanup()
+    mockUser = null
+  })
+
+  it("does not clear the cache on the first observation", () => {
+    mockUser = { id: 1 }
+    const qc = new QueryClient()
+    const clear = vi.spyOn(qc, "clear")
+
+    renderWith(qc)
+
+    expect(clear).not.toHaveBeenCalled()
+  })
+
+  it("clears the cache when the signed-in user changes", () => {
+    mockUser = { id: 1 }
+    const qc = new QueryClient()
+    const clear = vi.spyOn(qc, "clear")
+    const { rerender } = renderWith(qc)
+
+    mockUser = { id: 2 }
+    rerender(
+      <QueryClientProvider client={qc}>
+        <QueryAuthSync />
+      </QueryClientProvider>,
+    )
+
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears the cache on sign-out (user becomes null) but not on an unchanged id", () => {
+    mockUser = { id: 7 }
+    const qc = new QueryClient()
+    const clear = vi.spyOn(qc, "clear")
+    const { rerender } = renderWith(qc)
+
+    const redraw = () =>
+      rerender(
+        <QueryClientProvider client={qc}>
+          <QueryAuthSync />
+        </QueryClientProvider>,
+      )
+
+    redraw() // same id -> no clear
+    expect(clear).not.toHaveBeenCalled()
+
+    mockUser = null
+    redraw() // signed out -> clear
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/ui/tests/components/query-auth-sync.test.tsx
+++ b/apps/ui/tests/components/query-auth-sync.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render } from "@testing-library/react"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { Fragment } from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 let mockUser: { id: number } | null = null
@@ -24,7 +25,14 @@ describe("QueryAuthSync", () => {
     mockUser = null
   })
 
-  it("does not clear the cache on the first observation", () => {
+  it("renders nothing", () => {
+    mockUser = { id: 1 }
+    const qc = new QueryClient()
+    const { container } = renderWith(qc)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("does not clear the cache on the first observation (initial mount)", () => {
     mockUser = { id: 1 }
     const qc = new QueryClient()
     const clear = vi.spyOn(qc, "clear")
@@ -34,7 +42,25 @@ describe("QueryAuthSync", () => {
     expect(clear).not.toHaveBeenCalled()
   })
 
-  it("clears the cache when the signed-in user changes", () => {
+  it("does not clear the cache when the identity is unchanged across re-renders", () => {
+    mockUser = { id: 7 }
+    const qc = new QueryClient()
+    const clear = vi.spyOn(qc, "clear")
+    const { rerender } = renderWith(qc)
+
+    const redraw = () =>
+      rerender(
+        <QueryClientProvider client={qc}>
+          <QueryAuthSync />
+        </QueryClientProvider>,
+      )
+    redraw()
+    redraw()
+
+    expect(clear).not.toHaveBeenCalled()
+  })
+
+  it("clears the cache once when the signed-in user changes (account switch)", () => {
     mockUser = { id: 1 }
     const qc = new QueryClient()
     const clear = vi.spyOn(qc, "clear")
@@ -50,24 +76,61 @@ describe("QueryAuthSync", () => {
     expect(clear).toHaveBeenCalledTimes(1)
   })
 
-  it("clears the cache on sign-out (user becomes null) but not on an unchanged id", () => {
+  it("clears the cache on sign-out (user becomes null)", () => {
     mockUser = { id: 7 }
     const qc = new QueryClient()
     const clear = vi.spyOn(qc, "clear")
     const { rerender } = renderWith(qc)
 
-    const redraw = () =>
-      rerender(
+    mockUser = null
+    rerender(
+      <QueryClientProvider client={qc}>
+        <QueryAuthSync />
+      </QueryClientProvider>,
+    )
+
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not re-render previous-user data for a query keyed on org alone", async () => {
+    // Regression: ["tokens.resolve", org] is not partitioned by user id, and the
+    // QueryClient outlives a same-tab account switch. QueryAuthSync empties the cache
+    // synchronously on the identity change; layout.tsx/AuthGuard additionally remount the
+    // authenticated subtree (mirrored here by the keyed Fragment) so a memoized
+    // QueryObserver result can't paint user A's resolved PAT for user B.
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    let resolvedToken = "user-A-PAT"
+    function TokenConsumer() {
+      const { data } = useQuery({
+        queryKey: ["tokens.resolve", "acme"],
+        queryFn: () => Promise.resolve({ token: resolvedToken }),
+      })
+      return <span data-testid="token">{data?.token ?? "none"}</span>
+    }
+
+    function Tree() {
+      return (
         <QueryClientProvider client={qc}>
           <QueryAuthSync />
-        </QueryClientProvider>,
+          <Fragment key={mockUser?.id ?? "anon"}>
+            <TokenConsumer />
+          </Fragment>
+        </QueryClientProvider>
       )
+    }
 
-    redraw() // same id -> no clear
-    expect(clear).not.toHaveBeenCalled()
+    mockUser = { id: 1 }
+    const { rerender } = render(<Tree />)
+    await screen.findByText("user-A-PAT")
 
-    mockUser = null
-    redraw() // signed out -> clear
-    expect(clear).toHaveBeenCalledTimes(1)
+    // Account switch on the same tab; the backend would now resolve a different token.
+    resolvedToken = "user-B-PAT"
+    mockUser = { id: 2 }
+    rerender(<Tree />)
+
+    // The stale "user-A-PAT" must never be shown after the identity changed.
+    expect(screen.getByTestId("token").textContent).not.toBe("user-A-PAT")
+    await screen.findByText("user-B-PAT")
   })
 })

--- a/apps/ui/tests/components/verify-email-page.test.tsx
+++ b/apps/ui/tests/components/verify-email-page.test.tsx
@@ -55,4 +55,43 @@ describe("VerifyEmailPage", () => {
     await screen.findByText(/missing its token/i);
     expect(verifyEmailMock).not.toHaveBeenCalled();
   });
+
+  it("submits the new token when the URL token changes", async () => {
+    mockSearchParams = new URLSearchParams({ token: "first-token" });
+    verifyEmailMock.mockResolvedValue({ ok: true });
+
+    const { rerender } = render(<VerifyEmailPage />);
+    await screen.findByText(/your email is verified/i);
+    expect(verifyEmailMock).toHaveBeenCalledWith("first-token");
+
+    mockSearchParams = new URLSearchParams({ token: "second-token" });
+    rerender(<VerifyEmailPage />);
+
+    await vi.waitFor(() => expect(verifyEmailMock).toHaveBeenCalledWith("second-token"));
+  });
+
+  it("submits once a token appears after initially being absent", async () => {
+    verifyEmailMock.mockResolvedValue({ ok: true });
+
+    const { rerender } = render(<VerifyEmailPage />);
+    await screen.findByText(/missing its token/i);
+
+    mockSearchParams = new URLSearchParams({ token: "late-token" });
+    rerender(<VerifyEmailPage />);
+
+    await vi.waitFor(() => expect(verifyEmailMock).toHaveBeenCalledWith("late-token"));
+  });
+
+  it("does not resubmit the same token on re-render (Strict Mode replay)", async () => {
+    mockSearchParams = new URLSearchParams({ token: "stable-token" });
+    verifyEmailMock.mockResolvedValue({ ok: true });
+
+    const { rerender } = render(<VerifyEmailPage />);
+    await screen.findByText(/your email is verified/i);
+
+    rerender(<VerifyEmailPage />);
+    rerender(<VerifyEmailPage />);
+
+    expect(verifyEmailMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/ui/tests/lib/auth-context.test.tsx
+++ b/apps/ui/tests/lib/auth-context.test.tsx
@@ -687,3 +687,71 @@ describe("AuthProvider pendingInvitations", () => {
     expect(result.current.pendingInvitations).toEqual([]);
   });
 });
+
+describe("AuthProvider per-user browser state", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function seedPerUserState() {
+    localStorage.setItem("active_scope", JSON.stringify({ kind: "org", login: "acme" }));
+    localStorage.setItem("default_org", "acme");
+    localStorage.setItem("activity_last_seen_at", "2024-01-01T00:00:00Z");
+  }
+
+  function expectPerUserStateCleared() {
+    expect(localStorage.getItem("active_scope")).toBeNull();
+    expect(localStorage.getItem("default_org")).toBeNull();
+    expect(localStorage.getItem("activity_last_seen_at")).toBeNull();
+  }
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => <AuthProvider>{children}</AuthProvider>;
+
+  it("clears the previous user's scope and activity marker on setSession (register flow)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) return Promise.resolve(new Response(null, { status: 401 }));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+    seedPerUserState();
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    act(() => {
+      result.current.setSession(makeJwt(9, "new-user@e.com"), { ...passwordUser, id: 9, email: "new-user@e.com" });
+    });
+
+    expectPerUserStateCleared();
+  });
+
+  it("clears the previous user's scope and activity marker on login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/auth/login")) {
+          return Promise.resolve(jsonResponse({ access_token: makeJwt(9, "new-user@e.com"), user: passwordUser }));
+        }
+        if (url.endsWith("/auth/me")) return Promise.resolve(new Response(null, { status: 401 }));
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+    seedPerUserState();
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      await result.current.login("new-user@example.com", "supersecret1234");
+    });
+
+    expectPerUserStateCleared();
+  });
+});

--- a/apps/worker/src/event_consumer.py
+++ b/apps/worker/src/event_consumer.py
@@ -434,6 +434,18 @@ def _process_entry(pg_conn: psycopg.Connection, redis_client: redis.Redis, entry
     redis_client.xack(_STREAM_KEY, _GROUP_NAME, entry_id)
 
 
+def _rollback_quietly(pg_conn: psycopg.Connection) -> None:
+    """Clear an aborted transaction after a failed entry so the shared connection is
+    usable for the rest of the batch. Without this, a psycopg error on one entry leaves
+    pg_conn in InFailedSqlTransaction and every subsequent entry in the same
+    xreadgroup/xclaim batch fails its first execute -- the per-entry isolation the
+    callers' comments claim doesn't actually hold at batch granularity."""
+    try:
+        pg_conn.rollback()
+    except Exception:  # noqa: BLE001 -- best effort; the outer loop reconnects on a dead conn
+        log.exception("rollback after a failed stream entry itself failed")
+
+
 def _sweep_pending(pg_conn: psycopg.Connection, redis_client: redis.Redis) -> None:
     """Reclaims entries idle longer than _RECLAIM_IDLE_MS (a prior consumer likely
     crashed mid-processing), or drops ones that have failed too many times."""
@@ -461,6 +473,7 @@ def _sweep_pending(pg_conn: psycopg.Connection, redis_client: redis.Redis) -> No
             _process_entry(pg_conn, redis_client, entry_id, fields)
         except Exception:
             log.exception("failed to process reclaimed stream entry %s", entry_id)
+            _rollback_quietly(pg_conn)
 
 
 def run() -> None:
@@ -497,8 +510,11 @@ def run() -> None:
                             # Left unacked on purpose -- _sweep_pending reclaims it next
                             # pass once _RECLAIM_IDLE_MS has elapsed, same "one bad
                             # entry doesn't take down the loop" posture as
-                            # worker.py's process_job.
+                            # worker.py's process_job. Roll back first so an aborted
+                            # transaction from this entry doesn't poison the rest of
+                            # the batch on the shared connection.
                             log.exception("failed to process stream entry %s", entry_id)
+                            _rollback_quietly(pg_conn)
         except (psycopg.OperationalError, redis.RedisError) as error:
             log.error("event consumer connection error: %s", type(error).__name__)
             time.sleep(5)

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -38,7 +38,21 @@ HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")
 _MAX_POLL_SECONDS = 30
 
 # psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
-_DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+_CONNECT_TIMEOUT_SECONDS = 5
+
+
+def _plain_db_url(url: str) -> str:
+    """Strip the SQLAlchemy dialect prefix and bound connection establishment. Without an
+    explicit connect_timeout, psycopg.connect() can block indefinitely on a network blip /
+    paused pooler -- and it's called on the hot poll-loop path (and, worse, synchronously in
+    _JobHeartbeat.__enter__ after a job is already committed as 'processing'), so an
+    unbounded hang there stalls the worker until the 60s docker healthcheck restarts it."""
+    stripped = url.replace("postgresql+psycopg://", "postgresql://")
+    sep = "&" if "?" in stripped else "?"
+    return f"{stripped}{sep}connect_timeout={_CONNECT_TIMEOUT_SECONDS}"
+
+
+_DB_URL = _plain_db_url(settings.database_url.get_secret_value())
 
 # Shared cap on jobs.retry_count, incremented by both the reclaim sweep (a worker
 # crashed mid-job) and a transient-failure requeue in process_job — either path marks

--- a/apps/worker/tests/test_event_consumer.py
+++ b/apps/worker/tests/test_event_consumer.py
@@ -583,6 +583,20 @@ def test_parse_alert_timestamp_falls_back_on_missing_or_malformed_value():
     assert event_consumer._parse_alert_timestamp("not-a-real-timestamp", fallback) == fallback
 
 
+def test_rollback_quietly_clears_the_transaction():
+    conn = MagicMock()
+    event_consumer._rollback_quietly(conn)
+    conn.rollback.assert_called_once_with()
+
+
+def test_rollback_quietly_swallows_a_failing_rollback():
+    conn = MagicMock()
+    conn.rollback.side_effect = psycopg.OperationalError("connection already gone")
+    # Must not raise -- the outer loop reconnects on a dead connection.
+    event_consumer._rollback_quietly(conn)
+    conn.rollback.assert_called_once_with()
+
+
 def _org_member(conn, tenant_id, login):
     with conn.cursor() as cur:
         cur.execute(f"SET app.tenant_id = {int(tenant_id)}")

--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -34,13 +34,29 @@ _MAX_RETRY_AFTER_SECONDS = 60
 def _retry_delay_seconds(r: httpx.Response, attempt: int) -> float:
     """Prefer the server's own Retry-After value (GitHub's rate-limit responses include
     one) over a blind exponential backoff -- retrying before the window it asked for just
-    burns the fixed attempt budget hitting the same limit again."""
+    burns the fixed attempt budget hitting the same limit again. Falls back to
+    X-RateLimit-Reset (epoch seconds) when Retry-After is absent -- GitHub's docs say to
+    wait until that reset time when X-RateLimit-Remaining is 0 but no Retry-After was sent.
+    If neither header is usable, a 429 or a secondary-limit 403 waits the full cap
+    (GitHub's documented minimum rate-limit backoff) rather than a fast exponential retry
+    that would just hit the same limit again; any other status (a plain 5xx) still uses
+    exponential backoff. Ported from apps/worker/src/backfill.py's copy of this contract."""
     raw = r.headers.get("Retry-After")
     if raw is not None:
         try:
             return min(float(raw), _MAX_RETRY_AFTER_SECONDS)
         except ValueError:
             pass
+    reset_raw = r.headers.get("X-RateLimit-Reset")
+    if reset_raw is not None:
+        try:
+            delay = float(reset_raw) - time.time()
+            if delay > 0:
+                return min(delay, _MAX_RETRY_AFTER_SECONDS)
+        except ValueError:
+            pass
+    if r.status_code == 429 or _is_secondary_rate_limit(r):
+        return _MAX_RETRY_AFTER_SECONDS
     return 2**attempt
 
 
@@ -349,14 +365,21 @@ class DefaultBranchNoForcePushCheck(Check):
         for repo in repos:
             branch = repo.get("default_branch")
             try:
-                details = _get(f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}", token)
+                # The dedicated branch-protection sub-resource -- the plain
+                # /repos/{owner}/{repo}/branches/{branch} response only carries a reduced
+                # `protection` object (enabled + required_status_checks) and never
+                # `allow_force_pushes`, so reading force-push status off it always saw
+                # None and this check could never return "fail" for a protected branch.
+                details = _get(
+                    f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}/protection", token
+                )
             except httpx.HTTPStatusError as exc:
                 if exc.response.status_code == 404:
-                    # No branch protection at all -- force pushes are unambiguously
-                    # allowed, not merely "unknown". Bucketing this with the genuine
-                    # unknowns below meant an org where every repo's default branch had
-                    # no protection at all reported checked == 0 -> "error", never the
-                    # "fail" this check exists to catch.
+                    # 404 here means "Branch not protected" -- no protection rules at all,
+                    # so force pushes are unambiguously allowed, not merely "unknown".
+                    # Bucketing this with the genuine unknowns below meant an org where
+                    # every repo's default branch had no protection reported checked == 0
+                    # -> "error", never the "fail" this check exists to catch.
                     checked += 1
                     force_push_allowed += 1
                     continue
@@ -370,8 +393,7 @@ class DefaultBranchNoForcePushCheck(Check):
                 unknown += 1
                 continue
             checked += 1
-            protection = details.get("protection") or {}
-            allow_force_pushes = (protection.get("allow_force_pushes") or {}).get("enabled")
+            allow_force_pushes = (details.get("allow_force_pushes") or {}).get("enabled")
             if allow_force_pushes:
                 force_push_allowed += 1
         if checked == 0:

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -1,5 +1,6 @@
 """Tests for individual GitHub security checks."""
 
+import time
 from unittest.mock import patch
 
 import httpx
@@ -174,6 +175,39 @@ def test_get_honors_the_actual_retry_after_value_not_a_blind_backoff():
 def test_get_caps_an_excessive_retry_after_value():
     request = httpx.Request("GET", "https://x/y")
     rate_limited = httpx.Response(429, headers={"Retry-After": "600"}, request=request)
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([rate_limited, ok_response])
+
+    with patch("time.sleep") as mock_sleep, patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        _get("https://x/y", "tok")
+    mock_sleep.assert_called_once_with(_MAX_RETRY_AFTER_SECONDS)
+
+
+def test_get_falls_back_to_ratelimit_reset_when_no_retry_after():
+    # GitHub's docs say to wait until X-RateLimit-Reset (epoch seconds) when
+    # X-RateLimit-Remaining is 0 but no Retry-After was sent -- the common primary
+    # rate-limit shape. Previously this hit a blind 2**attempt = 1s retry that just
+    # burned the attempt budget.
+    request = httpx.Request("GET", "https://x/y")
+    reset_at = time.time() + 30
+    rate_limited = httpx.Response(
+        429, headers={"X-RateLimit-Reset": str(int(reset_at))}, request=request
+    )
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([rate_limited, ok_response])
+
+    with patch("time.sleep") as mock_sleep, patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        result = _get("https://x/y", "tok")
+    assert result == {"login": "acme"}
+    slept = mock_sleep.call_args[0][0]
+    assert 20 <= slept <= 30
+
+
+def test_get_waits_the_cap_for_a_ratelimit_with_no_usable_header():
+    # A 429 with neither Retry-After nor X-RateLimit-Reset waits the full documented
+    # minimum backoff, not a fast exponential retry into the same limit.
+    request = httpx.Request("GET", "https://x/y")
+    rate_limited = httpx.Response(429, request=request)
     ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
     responses = iter([rate_limited, ok_response])
 
@@ -479,7 +513,10 @@ def test_force_push_passes_when_disallowed():
     repos = [{"name": "api", "default_branch": "main"}]
 
     def fake_get(url, token):
-        return {"protection": {"allow_force_pushes": {"enabled": False}}}
+        # The dedicated /branches/{branch}/protection sub-resource -- this is where
+        # allow_force_pushes actually lives (the plain branch endpoint never returns it).
+        assert url.endswith("/repos/acme/api/branches/main/protection")
+        return {"allow_force_pushes": {"enabled": False}}
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("checks.github_checks._get", fake_get)
@@ -493,7 +530,8 @@ def test_force_push_fails_when_allowed():
     repos = [{"name": "api", "default_branch": "main"}]
 
     def fake_get(url, token):
-        return {"protection": {"allow_force_pushes": {"enabled": True}}}
+        assert url.endswith("/repos/acme/api/branches/main/protection")
+        return {"allow_force_pushes": {"enabled": True}}
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("checks.github_checks._get", fake_get)
@@ -503,8 +541,9 @@ def test_force_push_fails_when_allowed():
 
 
 def test_force_push_unprotected_branch_404_means_force_push_is_allowed():
-    # Regression test for #245: a 404 from the branches endpoint means the default
-    # branch has NO protection at all -- force pushes are unambiguously allowed, not
+    # Regression test for #245: a 404 from the branch-protection endpoint ("Branch not
+    # protected") means the default branch has NO protection at all -- force pushes are
+    # unambiguously allowed, not
     # merely "unknown". Previously this was excluded from the denominator entirely, so
     # an org where every repo's default branch was completely unprotected (the exact
     # worst case this check exists to catch) reported checked == 0 -> "error", never

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -203,6 +203,20 @@ def test_get_falls_back_to_ratelimit_reset_when_no_retry_after():
     assert 20 <= slept <= 30
 
 
+def test_get_ignores_a_malformed_ratelimit_reset_and_waits_the_cap():
+    # A non-numeric X-RateLimit-Reset must not raise -- it falls through to the cap
+    # (same as having no usable header at all).
+    request = httpx.Request("GET", "https://x/y")
+    rate_limited = httpx.Response(429, headers={"X-RateLimit-Reset": "soon"}, request=request)
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([rate_limited, ok_response])
+
+    with patch("time.sleep") as mock_sleep, patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        result = _get("https://x/y", "tok")
+    assert result == {"login": "acme"}
+    mock_sleep.assert_called_once_with(_MAX_RETRY_AFTER_SECONDS)
+
+
 def test_get_waits_the_cap_for_a_ratelimit_with_no_usable_header():
     # A 429 with neither Retry-After nor X-RateLimit-Reset waits the full documented
     # minimum backoff, not a fast exponential retry into the same limit.


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

Closes #<!-- issue number, if any -->

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
- [ ] Relevant `pytest` tests pass (if API/worker changed)
- [ ] Docker images still build, if `Dockerfile`/deps changed
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Email searches now match addresses exactly, including those containing `%` or `_`.
  - Analytics history respects membership and personal access permissions.
  - Email verification tokens are no longer submitted twice.
  - Signing out or switching accounts clears previously cached account and organization data.
  - GitHub force-push protection checks now accurately detect repository settings.
  - GitHub rate-limit retries use more reliable wait times.
  - Webhook processing recovers cleanly after individual event failures.
  - Organization setup better handles unexpected GitHub response errors.

- **Performance**
  - Organization activity streams remain responsive during long-lived connections.
  - GitHub integration token requests are handled more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->