### PR TITLE
refactor(api): drop the legacy org_memberships table (issue #331)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,10 @@ Clevis is a GitHub analytics dashboard with three independently deployable servi
 
 ### Database models (`apps/api/src/core/db.py`)
 
-Tables managed by Alembic — no runtime DDL. (Not an exhaustive list of every table in `apps/api/src/core/db.py` — `tenants`/`memberships` predate this list being kept current; see that file for the authoritative schema.)
+Tables managed by Alembic — no runtime DDL. (Not an exhaustive list of every table in `apps/api/src/core/db.py`; see that file for the authoritative schema.)
 - **`users`** — email/password or GitHub-OAuth-linked accounts. `is_workspace_admin` (instance-level, set once at first-run `/auth/setup`), `token_version` (bumped to invalidate all issued JWTs), `email_verified` / `email_verify_token` / `email_verify_token_expires_at` (issue #217 — self-registered accounts start unverified and can't accept org invites until they click the emailed link; GitHub-linked and first-run-setup accounts are verified immediately since their email is already trusted).
-- **`orgs`** / **`org_memberships`** — a GitHub org becomes a Clevis `Org` row once someone connects it; `org_memberships` is the `(org_id, user_id) -> role ("member"|"admin")` join table `require_org_role` checks against.
+- **`orgs`** — a GitHub org becomes a Clevis `Org` row once someone connects it, paired 1:1 with a `kind="org"` **`tenants`** row.
+- **`tenants`** / **`memberships`** — every org (and every user, personally) has a `Tenant`; `memberships` is the tenant-scoped `(tenant_id, user_id) -> role ("member"|"admin")` join table `require_org_role` checks against (via `tenant_repo.get_membership`). The legacy org_id-keyed `org_memberships` table it superseded was dropped in migration 0045 / issue #331; `org_membership_repo` is now a thin org_id→tenant_id adapter over `tenant_repo`.
 - **`invitations`** — pending org invites by email; `accept_invitation` requires the accepting user's email to match and (per #217) `email_verified=True`.
 - **`github_installations`** — account login, installation ID, auth mode, and `token_ref` (a symbolic reference like `tok_acme`, not the actual token). Exactly one of `org_id` / `owner_user_id` is set (org-connected vs. personal installs).
 - **`saved_tokens`** — legacy Fernet-encrypted PAT-per-org fallback, used when no GitHub App installation covers that org.
@@ -36,7 +37,7 @@ Tables managed by Alembic — no runtime DDL. (Not an exhaustive list of every t
 Access is enforced with JWT session auth, not an `X-Role` header:
 
 - `require_auth` / `require_workspace_admin` — `apps/api/src/core/auth.py` (any signed-in user vs instance workspace admin).
-- `require_org_role("member"|"admin")` — `apps/api/src/core/rbac.py` (org-scoped membership lookup in the DB, against `org_memberships`).
+- `require_org_role("member"|"admin")` — `apps/api/src/core/rbac.py` (org-scoped membership lookup in the DB, against the tenant-scoped `memberships` table via `tenant_repo.get_membership`).
 
 The old `viewer` / `analyst` / `admin` header model was removed in Phase 5.
 

--- a/apps/api/alembic/versions/0045_drop_org_memberships.py
+++ b/apps/api/alembic/versions/0045_drop_org_memberships.py
@@ -1,0 +1,80 @@
+"""Drop the legacy org_memberships table (issue #331).
+
+SCHEMA CHANGE -- this migration DROPs a table. It is not additive and not automatically
+reversible with data.
+
+Background: org_memberships (org_id-keyed) was the original org RBAC join table. Issue
+#190 moved org membership onto the tenant-scoped `memberships` table: reads cut over in
+step 6a (PR #326, every `require_org_role` call site) and writes were dual-written from
+step 4 (PR #322) onward. Since then org_memberships has been pure write-amplification --
+every membership change touched both tables, but nothing read org_memberships. #190's
+own rollout plan (Phase E) explicitly scoped this drop as a tracked follow-up.
+
+This PR removes the dual-write (org_membership_repo is now a thin org_id->tenant_id
+adapter over tenant_repo, writing only `memberships`) and drops the now-unreferenced
+table here.
+
+Data loss: the org_memberships rows are discarded. This is safe because `memberships`
+has held an equivalent row for every one of them since #190 PR 4's dual-write, and
+migration 0029's docstring carries the verification query that asserted that parity.
+Nothing else references org_memberships.id (it is a leaf join table).
+
+downgrade() recreates the table structure and its clevis_api grants but CANNOT restore
+the dropped rows -- it yields an empty table. A real rollback would additionally need to
+re-run #190 PR 4's backfill from `memberships`.
+
+Revision ID: 0045
+Revises: 0044
+Create Date: 2026-09-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0045"
+down_revision = "0044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # DROP TABLE cascades to the id sequence, the uq_org_memberships_org_user constraint,
+    # the org_id/user_id foreign keys, and every GRANT on the table / its sequence
+    # (migration 0032 and docker/provision-api-role-existing-deployment.sh both granted
+    # clevis_api DML here). No RLS policy to drop -- org_memberships was deliberately
+    # excluded from the RLS scaffolding in migration 0030.
+    op.drop_table("org_memberships")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "org_memberships",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Integer, sa.ForeignKey("orgs.id"), nullable=False),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role", sa.String, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("org_id", "user_id", name="uq_org_memberships_org_user"),
+    )
+    # Restore the clevis_api grants migration 0032 gave this table, guarded by role
+    # existence (the role only exists when API_DB_PASSWORD is configured -- issue #330).
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'clevis_api') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON org_memberships TO clevis_api;
+                GRANT USAGE, SELECT ON org_memberships_id_seq TO clevis_api;
+              END IF;
+            END
+            $$;
+            """
+        )
+    )
+    # NOTE: the org_memberships rows themselves are not restored -- see module docstring.

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -415,15 +415,10 @@ class Org(Base):
     tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
-class OrgMembership(Base):
-    __tablename__ = "org_memberships"
-    __table_args__ = (UniqueConstraint("org_id", "user_id", name="uq_org_memberships_org_user"),)
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    org_id: Mapped[int] = mapped_column(ForeignKey("orgs.id"), nullable=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
-    role: Mapped[str] = mapped_column(String, nullable=False)  # "admin" | "member"
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+# The legacy org_memberships table (org_id-keyed) was dropped in migration 0045 / issue
+# #331: reads cut over to the tenant-scoped `Membership` table in #190 step 6a and writes
+# in #190 PR 4, leaving org_memberships a pure write-amplification mirror. Org membership
+# now lives entirely in `Membership` below, keyed on the org's `Tenant`.
 
 
 class Tenant(Base):

--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -13,7 +13,7 @@ INVITATION_LIFETIME = timedelta(days=7)
 
 class DuplicatePendingInvitation(Exception):
     """Raised by create() when an active pending invitation already exists for this
-    (org, email). Mirrors org_membership_repo.get_or_create's IntegrityError handling:
+    (org, email). Mirrors tenant_repo._persist_new's IntegrityError handling:
     the partial unique index uq_invitations_org_email_pending (migration 0042) is what
     makes the losing side of a concurrent double-insert fail instead of both winning."""
 
@@ -55,7 +55,7 @@ def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Inv
         # Only convert to a 409 if the failure was actually a duplicate pending invite
         # (the concurrent-insert race). Any other IntegrityError -- an FK violation, a
         # token collision, a future constraint -- must surface as itself, not as a
-        # misleading "already exists". Mirrors org_membership_repo.get_or_create, which
+        # misleading "already exists". Mirrors tenant_repo._persist_new, which
         # re-queries the specific row and re-raises when it isn't there.
         if get_pending_for_org_and_email(db, org_id=org_id, email=email) is None:
             raise

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -1,108 +1,78 @@
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from src.core.db import OrgMembership
+from src.core.db import Membership
 from src.repositories import tenant_repo
 
+# The legacy org_memberships table (org_id-keyed) was dropped in migration 0045 / issue
+# #331 -- memberships (tenant-scoped) is the sole store, and has been the source of truth
+# for org RBAC reads since #190 step 6a. This module stays as a thin org_id-keyed adapter
+# over tenant_repo (tenant_id-keyed) so the many call sites that seed / mutate an org
+# membership by (org_id, user_id) -- routers, org provisioning, ~30 test modules -- don't
+# each have to resolve the org's tenant themselves.
+#
+# The write functions take a SELECT ... FOR UPDATE on the memberships row and issue exactly
+# one commit per operation, so a concurrent grant and revoke for the same (org, user) stay
+# serialized (issue #334): the tenant_repo helpers run with commit=False so that lock is
+# held from acquisition to the single commit here. Every write self-establishes
+# app.user_id first (SET LOCAL) -- otherwise, under the FORCE-RLS clevis_api runtime role
+# (issue #330), the lock query would be filtered to zero rows and acquire nothing.
+#
+# Read paths (get, list_*) that hit an org with no tenant row yet return empty rather than
+# provisioning one -- only get_or_create creates the tenant.
 
-def get(db: Session, org_id: int, user_id: int, for_update: bool = False) -> OrgMembership | None:
-    query = db.query(OrgMembership).filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-    if for_update:
-        # Locks the row (or blocks until a concurrent delete()'s own implicit row lock
-        # releases) so get_or_create/update_role can't read a membership that's mid-deletion
-        # and resurrect its tenant mirror via _sync_membership_mirror right after revocation.
-        query = query.with_for_update()
-    return query.first()
+
+def _set_session_user(db: Session, user_id: int) -> None:
+    db.execute(text(f"SET LOCAL app.user_id = {int(user_id)}"))
 
 
-def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership) -> None:
-    # commit=False (issue #334): the callers below hold a SELECT ... FOR UPDATE lock on the
-    # OrgMembership row and must keep it until they issue their own single db.commit(). The
-    # tenant_repo helpers used to commit internally, ending the transaction and releasing
-    # that lock mid-operation, which let a concurrent delete() interleave. They now flush
-    # into this transaction instead, so the lock is held for the whole logical operation.
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id, commit=False)
-    tenant_repo.upsert_membership(
-        db, tenant_id=tenant.id, user_id=membership.user_id, role=membership.role, commit=False
+def get(db: Session, org_id: int, user_id: int) -> Membership | None:
+    tenant = tenant_repo.get_org_tenant(db, org_id)
+    if tenant is None:
+        return None
+    return tenant_repo.get_membership(db, tenant.id, user_id)
+
+
+def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> Membership:
+    _set_session_user(db, user_id)
+    tenant_id = tenant_repo.get_or_create_org_tenant(db, org_id, commit=False).id
+    # Lock the row if it exists so a concurrent delete() can't land before our commit.
+    # If it doesn't exist yet there's nothing to lock; upsert_membership's own
+    # IntegrityError/SAVEPOINT recovery handles a lost insert race, and the whole call is
+    # one transaction (no early commit) so a concurrent delete runs fully before or fully
+    # after, never mid-write.
+    tenant_repo.get_membership(db, tenant_id, user_id, for_update=True)
+    membership = tenant_repo.upsert_membership(
+        db, tenant_id=tenant_id, user_id=user_id, role=role, commit=False
     )
-
-
-def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
-    membership = get(db, org_id, user_id, for_update=True)
-    if membership is not None:
-        # Lock held from the get() above through the mirror sync to this commit -- the
-        # tenant_repo helpers no longer commit internally (issue #334), so this is the one
-        # commit that ends the operation and releases the lock.
-        _sync_membership_mirror(db, org_id, membership)
-        db.commit()
-        return membership
-    membership = OrgMembership(org_id=org_id, user_id=user_id, role=role)
-    db.add(membership)
-    try:
-        db.commit()
-    except IntegrityError:
-        # Lost a race with a concurrent insert of the same (org_id, user_id) pair.
-        db.rollback()
-        membership = get(db, org_id, user_id, for_update=True)
-        if membership is None:
-            raise
-        _sync_membership_mirror(db, org_id, membership)
-        db.commit()
-        return membership
-    # Re-lock the row we just committed before syncing its mirror -- the commit above
-    # released any lock, opening a window where a concurrent delete() could remove this
-    # row and find no mirror yet (nothing synced), then have this call resume and create a
-    # mirror for a membership that's already revoked (CodeRabbit finding on #323's 2nd
-    # review). If the re-lock finds the row already gone, retry from scratch instead of
-    # syncing a mirror for a membership that no longer exists. The re-lock is now held
-    # across the mirror sync until the final commit below (issue #334).
-    membership = get(db, org_id, user_id, for_update=True)
-    if membership is None:
-        return get_or_create(db, org_id, user_id, role)
-    _sync_membership_mirror(db, org_id, membership)
     db.commit()
     return membership
 
 
-def list_for_user(db: Session, user_id: int) -> list[OrgMembership]:
-    return db.query(OrgMembership).filter(OrgMembership.user_id == user_id).all()
-
-
-def list_for_org(db: Session, org_id: int) -> list[OrgMembership]:
-    return db.query(OrgMembership).filter(OrgMembership.org_id == org_id).all()
-
-
-def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership | None:
-    membership = get(db, org_id, user_id, for_update=True)
-    if membership is None:
+def update_role(db: Session, org_id: int, user_id: int, role: str) -> Membership | None:
+    tenant = tenant_repo.get_org_tenant(db, org_id)
+    if tenant is None:
         return None
-    membership.role = role
-    # Sync the mirror before committing -- committing first would release the FOR UPDATE
-    # lock get() just took, reopening the window a concurrent delete() could land in.
-    # _sync_membership_mirror flushes (does not commit -- issue #334) both the pending
-    # OrgMembership role change and the mirror row into this transaction; the single
-    # commit() below persists them together and releases the lock.
-    _sync_membership_mirror(db, org_id, membership)
+    _set_session_user(db, user_id)
+    if tenant_repo.get_membership(db, tenant.id, user_id, for_update=True) is None:
+        db.commit()  # close the read transaction cleanly; nothing to update
+        return None
+    tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user_id, role=role, commit=False)
     db.commit()
-    # Not db.refresh(membership): the row lock is released by the commit above, so a
-    # concurrent delete() can remove this row before we get here -- re-query instead of
-    # refreshing so that legitimate outcome returns None rather than raising.
-    return get(db, org_id, user_id)
+    # Not a refresh: the commit released the lock, so a concurrent delete() may have
+    # removed the row -- re-query (re-establishing context the commit cleared) so that
+    # legitimate outcome returns None rather than raising on a detached instance.
+    _set_session_user(db, user_id)
+    return tenant_repo.get_membership(db, tenant.id, user_id)
 
 
 def delete(db: Session, org_id: int, user_id: int) -> None:
-    # Delete the mirror before committing the OrgMembership delete -- committing first (the
-    # original ordering) released the DELETE's own implicit row lock before the mirror was
-    # touched, leaving a window where a concurrent get_or_create() could find the row gone,
-    # legitimately re-create a fresh OrgMembership + mirror, and then have this function's
-    # now-unblocked mirror delete remove that brand-new mirror out from under it. Same
-    # principle as update_role's lock-then-sync-then-commit ordering above. Both tenant_repo
-    # calls run with commit=False (issue #334) so the DELETE's implicit row lock is held
-    # until this function's single commit() -- a concurrent get_or_create() blocks on it for
-    # the whole operation instead of slipping in after an early internal commit.
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id, commit=False)
-    db.query(OrgMembership).filter(
-        OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
-    ).delete()
+    tenant = tenant_repo.get_org_tenant(db, org_id)
+    if tenant is None:
+        return
+    _set_session_user(db, user_id)
+    # Lock (if present) then delete + commit as one operation, so a concurrent
+    # get_or_create() blocks on the row until this finishes rather than racing it.
+    tenant_repo.get_membership(db, tenant.id, user_id, for_update=True)
     tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user_id, commit=False)
     db.commit()

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -57,14 +57,18 @@ def _persist_new(db: Session, obj, refetch, *, commit: bool):
     return obj
 
 
-def get_or_create_org_tenant(db: Session, org_id: int, *, commit: bool = True) -> Tenant:
-    def _find():
-        return db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+def get_org_tenant(db: Session, org_id: int) -> Tenant | None:
+    """Read-only lookup of an org's tenant, or None if the org has no tenant row yet."""
+    return db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
 
-    tenant = _find()
+
+def get_or_create_org_tenant(db: Session, org_id: int, *, commit: bool = True) -> Tenant:
+    tenant = get_org_tenant(db, org_id)
     if tenant is not None:
         return tenant
-    return _persist_new(db, Tenant(kind="org", org_id=org_id), _find, commit=commit)
+    return _persist_new(
+        db, Tenant(kind="org", org_id=org_id), lambda: get_org_tenant(db, org_id), commit=commit
+    )
 
 
 def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Tenant:
@@ -117,19 +121,24 @@ def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Te
     return tenant
 
 
-def get_membership(db: Session, tenant_id: int, user_id: int) -> Membership | None:
-    """Read-only lookup, keyed on tenant_id -- the memberships-side equivalent of
-    org_membership_repo.get's org_id-keyed lookup on the legacy org_memberships table.
-    Issue #190 step 6a: RBAC callsites now read from here instead of org_memberships;
-    org_membership_repo's write functions are unchanged and keep dual-writing into
-    memberships via _sync_membership_mirror, so this always sees the current state."""
-    return db.query(Membership).filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id).first()
+def get_membership(
+    db: Session, tenant_id: int, user_id: int, *, for_update: bool = False
+) -> Membership | None:
+    """Lookup keyed on tenant_id -- the source of truth for org RBAC since #190 step 6a
+    (RBAC call sites read here; org_membership_repo is a thin org_id-keyed adapter over it).
+
+    for_update takes a SELECT ... FOR UPDATE row lock, used by org_membership_repo to
+    serialize a concurrent grant and revoke for the same (org, user) across the whole
+    logical operation (issue #334)."""
+    query = db.query(Membership).filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+    if for_update:
+        query = query.with_for_update()
+    return query.first()
 
 
 def list_org_memberships_for_user(db: Session, user_id: int) -> list[tuple[Org, Membership]]:
-    """All of a user's org-tenant memberships, joined back to each Org row -- the
-    memberships-side equivalent of org_membership_repo.list_for_user, for callers that
-    need to enumerate a user's orgs rather than check one specific org."""
+    """All of a user's org-tenant memberships, joined back to each Org row -- for callers
+    that need to enumerate a user's orgs rather than check one specific org."""
     return (
         db.query(Org, Membership)
         .join(Tenant, Tenant.org_id == Org.id)

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -1,21 +1,19 @@
-"""Tests for src.repositories.org_membership_repo's Membership dual-write (issue #190 PR 4):
-every OrgMembership create/update/delete must be mirrored onto the tenants/memberships
-tables, keyed off the org's tenant."""
+"""Tests for src.repositories.org_membership_repo.
+
+Since #331 dropped the legacy org_memberships table, this module is a thin org_id->
+tenant_id adapter over tenant_repo: every create/update/delete lands in the tenant-scoped
+`memberships` table, keyed off the org's tenant. The write paths still take a
+SELECT ... FOR UPDATE on the memberships row and commit once (issue #334), so a concurrent
+grant and revoke for the same (org, user) stay serialized.
+"""
 
 import threading
 from unittest.mock import patch
 
 from sqlalchemy import text
 
-from src.core.db import Membership, Org, OrgMembership, SessionLocal, Tenant, User
-from src.repositories import org_membership_repo, org_repo
-
-# The 3 concurrency tests below were previously xfail (issue #330/#334): tenant_repo's
-# mirror-sync helpers each committed internally, which released org_membership_repo's outer
-# FOR UPDATE lock mid-operation and let a concurrent delete() interleave -- reliably so
-# under the RLS-forced clevis_api role's extra round-trips. Fixed in #334: the helpers now
-# take commit=False and flush into the caller's transaction, so the lock is held for the
-# whole logical operation until org_membership_repo's single commit.
+from src.core.db import Membership, Org, SessionLocal, Tenant, User
+from src.repositories import org_membership_repo, org_repo, tenant_repo
 
 
 def _make_user(db, email: str) -> User:
@@ -33,7 +31,7 @@ def _membership_row(db, org_id: int, user_id: int) -> Membership | None:
     return db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
 
 
-def test_get_or_create_mirrors_a_membership_row(db):
+def test_get_or_create_writes_the_membership_row(db):
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "alice@example.com")
 
@@ -44,7 +42,7 @@ def test_get_or_create_mirrors_a_membership_row(db):
     assert membership.role == "admin"
 
 
-def test_get_or_create_is_idempotent_on_the_mirror_too(db):
+def test_get_or_create_is_idempotent(db):
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "bob@example.com")
 
@@ -56,7 +54,18 @@ def test_get_or_create_is_idempotent_on_the_mirror_too(db):
     assert len(rows) == 1
 
 
-def test_update_role_mirrors_onto_membership(db):
+def test_get_returns_none_for_an_org_with_no_tenant(db):
+    # A read for an org that was never provisioned must not create the tenant as a side effect.
+    org = Org(github_login="unprovisioned")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    assert org_membership_repo.get(db, org_id=org.id, user_id=1) is None
+    assert db.query(Tenant).filter(Tenant.org_id == org.id).first() is None
+
+
+def test_update_role_changes_the_membership_role(db):
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "carol@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
@@ -68,27 +77,49 @@ def test_update_role_mirrors_onto_membership(db):
     assert membership.role == "admin"
 
 
-def test_delete_removes_the_membership_mirror_too(db):
+def test_update_role_returns_none_when_there_is_no_membership(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "wanda@example.com")
+
+    assert org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin") is None
+
+
+def test_update_role_returns_none_for_an_unprovisioned_org(db):
+    org = Org(github_login="unprovisioned-3")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    assert org_membership_repo.update_role(db, org_id=org.id, user_id=1, role="admin") is None
+    assert db.query(Tenant).filter(Tenant.org_id == org.id).first() is None
+
+
+def test_delete_removes_the_membership_row(db):
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "dave@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
 
     org_membership_repo.delete(db, org_id=org.id, user_id=user.id)
 
-    membership = _membership_row(db, org.id, user.id)
-    assert membership is None
+    assert _membership_row(db, org.id, user.id) is None
 
 
-def test_get_or_create_repairs_a_missing_mirror_on_an_existing_membership(db):
-    # Regression test for a CodeRabbit finding on #323: get_or_create's early-return path
-    # (OrgMembership already exists) used to skip the dual-write entirely, so a Membership
-    # row deleted or never created out-of-band would never get repaired on subsequent calls
-    # -- exactly the pattern org_provisioning.py's reconcile loop hits on every login.
+def test_delete_is_a_noop_for_an_unprovisioned_org(db):
+    org = Org(github_login="unprovisioned-2")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+
+    org_membership_repo.delete(db, org_id=org.id, user_id=1)  # must not raise
+    assert db.query(Tenant).filter(Tenant.org_id == org.id).first() is None
+
+
+def test_get_or_create_recreates_a_row_deleted_out_of_band(db):
+    # org_provisioning.py's reconcile loop calls get_or_create on every login; if the
+    # membership row went missing out of band it must be recreated, not skipped.
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "grace@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
-    assert _membership_row(db, org.id, user.id) is not None
-    # Simulate the mirror having gone missing out-of-band.
     tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
     db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).delete()
     db.commit()
@@ -101,11 +132,10 @@ def test_get_or_create_repairs_a_missing_mirror_on_an_existing_membership(db):
     assert membership.role == "member"
 
 
-def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
+def test_get_or_create_repairs_a_stale_role(db):
     org = org_repo.get_or_create(db, github_login="acme")
     user = _make_user(db, "heidi@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
-    # Simulate the mirror's role having drifted out-of-band from the OrgMembership's role.
     tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
     stale = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
     stale.role = "admin"
@@ -113,16 +143,66 @@ def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
 
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
 
-    membership = _membership_row(db, org.id, user.id)
-    assert membership.role == "member"
+    assert _membership_row(db, org.id, user.id).role == "member"
 
 
-def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
-    """Regression test for a CodeRabbit finding on #324: without row locking, a concurrent
-    delete() could interleave between update_role's membership lookup and its mirror sync,
-    resurrecting the tenant Membership mirror right after revocation. Needs two genuinely
-    separate connections (not the savepoint-per-test `db` fixture, same reasoning as
-    test_db_get_db.py) since the race only exists across real concurrent transactions."""
+def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    admin = _make_user(db, "erin@example.com")
+    member = _make_user(db, "frank@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+
+    assert _membership_row(db, org.id, admin.id).tenant_id == _membership_row(db, org.id, member.id).tenant_id
+
+
+# ── Concurrency: the FOR UPDATE lock serializes a grant against a concurrent revoke ──
+#
+# These use two or three genuinely separate SessionLocal() connections (not the
+# savepoint-per-test `db` fixture) because the race only exists across real concurrent
+# transactions. They pause a tenant_repo helper *inside* org_membership_repo's locked
+# section (after get_membership(for_update=True), before the single commit) and assert a
+# concurrent delete()/get_or_create() blocks on the row until that commit lands.
+
+
+def _cleanup(session, org_id: int, user_id: int) -> None:
+    session.rollback()
+    tenant = session.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is not None:
+        # memberships has FORCE row-level security (migration 0031); under the non-superuser
+        # clevis_api role this bulk delete matches nothing unless a tenant context is set.
+        # SET LOCAL, not SET: transaction-scoped so it can't leak onto the pooled connection.
+        session.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
+        session.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+        org_row = session.query(Org).filter(Org.id == org_id).first()
+        if org_row is not None:
+            # orgs.tenant_id and tenants.org_id reference each other (composite reciprocal
+            # FK) -- null the org side first so either row can then be deleted freely.
+            org_row.tenant_id = None
+            session.commit()
+        session.query(Tenant).filter(Tenant.id == tenant.id).delete()
+    session.query(Org).filter(Org.id == org_id).delete()
+    session.query(User).filter(User.id == user_id).delete()
+    session.commit()
+    session.close()
+
+
+def _membership_after(session, org_id: int, user_id: int) -> Membership | None:
+    tenant = session.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is None:
+        return None
+    # The operation under test committed and cleared session's SET LOCAL app.user_id;
+    # re-establish a context so this assertion isn't RLS-filtered to a vacuous None.
+    session.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
+    return (
+        session.query(Membership)
+        .filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id)
+        .first()
+    )
+
+
+def test_update_role_blocks_a_concurrent_delete_until_it_commits():
     setup = SessionLocal()
     org = org_repo.get_or_create(setup, github_login="acme-lock-test")
     user = User(email="ivy@example.com", name=None, password_hash=None, is_workspace_admin=False)
@@ -132,17 +212,15 @@ def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
     org_id, user_id = org.id, user.id
     org_membership_repo.get_or_create(setup, org_id=org_id, user_id=user_id, role="member")
     setup.close()
-    # org/user are bound to `setup`, now closed -- only org_id/user_id (plain ints) are used
-    # from here on, never the detached ORM objects themselves.
 
     reached_lock = threading.Event()
     release_lock = threading.Event()
-    original_sync = org_membership_repo._sync_membership_mirror
+    original = tenant_repo.update_membership_role
 
-    def paused_sync(db, org_id, membership):
+    def paused(db, tenant_id, user_id, role, *, commit=True):
         reached_lock.set()
-        assert release_lock.wait(timeout=5), "test setup never released the paused sync"
-        original_sync(db, org_id, membership)
+        assert release_lock.wait(timeout=5), "test setup never released the paused update"
+        return original(db, tenant_id, user_id, role, commit=commit)
 
     update_result: dict[str, bool] = {}
     delete_result: dict[str, bool] = {}
@@ -162,7 +240,7 @@ def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
 
     session_a = SessionLocal()
     try:
-        with patch.object(org_membership_repo, "_sync_membership_mirror", paused_sync):
+        with patch.object(tenant_repo, "update_membership_role", paused):
             update_thread = threading.Thread(target=run_update_role, args=(session_a,))
             update_thread.start()
             assert reached_lock.wait(timeout=5), "update_role never reached its locked section"
@@ -178,57 +256,14 @@ def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
         assert update_result.get("finished") is True
         assert delete_result.get("finished") is True
 
-        # The delete landed after update_role's commit released the lock, so the final
-        # state must reflect the delete -- no resurrected mirror row.
-        remaining = (
-            session_a.query(OrgMembership)
-            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-            .first()
-        )
-        assert remaining is None
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        # session_a's SET LOCAL app.user_id was cleared by the commit inside the operation
-        # under test; re-establish a tenant context so this assertion query can actually
-        # see memberships rows (FORCE row-level security, migration 0031) rather than
-        # getting an RLS-filtered empty result and passing vacuously.
-        session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-        mirror = (
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
-        )
-        assert mirror is None
+        # The delete landed after update_role's commit released the lock -- final state
+        # must reflect the delete.
+        assert _membership_after(session_a, org_id, user_id) is None
     finally:
-        # This test uses real committing connections (not the savepoint-per-test `db`
-        # fixture), so the rows it creates persist unless cleaned up explicitly here.
-        session_a.rollback()
-        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        if tenant is not None:
-            # memberships has FORCE row-level security (migration 0031); under the
-            # non-superuser clevis_api role this bulk delete matches nothing unless a
-            # tenant session context is set first.
-            session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
-            # orgs.tenant_id and tenants.org_id reference each other (composite reciprocal
-            # FK) -- null the org side first so either row can then be deleted freely.
-            org_row = session_a.query(Org).filter(Org.id == org_id).first()
-            if org_row is not None:
-                org_row.tenant_id = None
-                session_a.commit()
-            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
-        session_a.query(Org).filter(Org.id == org_id).delete()
-        session_a.query(User).filter(User.id == user_id).delete()
-        session_a.commit()
-        session_a.close()
+        _cleanup(session_a, org_id, user_id)
 
 
-def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commits():
-    """Regression test for a code-review finding on #324: delete()'s original two-phase
-    commit (commit the OrgMembership delete, *then* delete the mirror) released its row
-    lock before the mirror was touched. A concurrent get_or_create() could see the row
-    already gone, legitimately re-create a fresh OrgMembership + mirror, and then have
-    delete()'s now-unblocked mirror deletion remove that brand-new mirror out from under
-    it -- membership drift from the opposite direction of the get_or_create/update_role
-    race fixed above. Needs two genuinely separate connections, same reasoning as above."""
+def test_delete_blocks_a_concurrent_get_or_create_until_it_commits():
     setup = SessionLocal()
     org = org_repo.get_or_create(setup, github_login="acme-lock-test-2")
     user = User(email="mallory@example.com", name=None, password_hash=None, is_workspace_admin=False)
@@ -241,12 +276,12 @@ def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commit
 
     reached_lock = threading.Event()
     release_lock = threading.Event()
-    original_delete_membership = org_membership_repo.tenant_repo.delete_membership
+    original = tenant_repo.delete_membership
 
-    def paused_delete_membership(db, tenant_id, user_id, *, commit=True):
+    def paused(db, tenant_id, user_id, *, commit=True):
         reached_lock.set()
         assert release_lock.wait(timeout=5), "test setup never released the paused delete"
-        original_delete_membership(db, tenant_id=tenant_id, user_id=user_id, commit=commit)
+        original(db, tenant_id=tenant_id, user_id=user_id, commit=commit)
 
     delete_result: dict[str, bool] = {}
     recreate_result: dict[str, bool] = {}
@@ -266,7 +301,7 @@ def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commit
 
     session_a = SessionLocal()
     try:
-        with patch.object(org_membership_repo.tenant_repo, "delete_membership", paused_delete_membership):
+        with patch.object(tenant_repo, "delete_membership", paused):
             delete_thread = threading.Thread(target=run_delete, args=(session_a,))
             delete_thread.start()
             assert reached_lock.wait(timeout=5), "delete() never reached its locked section"
@@ -283,55 +318,21 @@ def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commit
         assert recreate_result.get("finished") is True
 
         # get_or_create() ran after delete()'s commit released the lock, legitimately
-        # re-creating the membership -- its mirror must exist and match, not be missing
-        # (which is what the pre-fix ordering would have left behind).
-        remaining = (
-            session_a.query(OrgMembership)
-            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-            .first()
-        )
-        assert remaining is not None
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        # session_a's SET LOCAL app.user_id was cleared by the commit inside the operation
-        # under test; re-establish a tenant context so this assertion query can actually
-        # see memberships rows (FORCE row-level security, migration 0031) rather than
-        # getting an RLS-filtered empty result and passing vacuously.
-        session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-        mirror = (
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
-        )
-        assert mirror is not None
-        assert mirror.role == remaining.role
+        # re-creating the membership.
+        recreated = _membership_after(session_a, org_id, user_id)
+        assert recreated is not None
+        assert recreated.role == "member"
     finally:
-        session_a.rollback()
-        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        if tenant is not None:
-            # memberships has FORCE row-level security (migration 0031); under the
-            # non-superuser clevis_api role this bulk delete matches nothing unless a
-            # tenant session context is set first.
-            session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
-            org_row = session_a.query(Org).filter(Org.id == org_id).first()
-            if org_row is not None:
-                org_row.tenant_id = None
-                session_a.commit()
-            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
-        session_a.query(Org).filter(Org.id == org_id).delete()
-        session_a.query(User).filter(User.id == user_id).delete()
-        session_a.commit()
-        session_a.close()
+        _cleanup(session_a, org_id, user_id)
 
 
-def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirror_sync_commits():
-    """Regression test for a CodeRabbit finding on #323's 2nd review: get_or_create's
-    new-row path used to commit the freshly-inserted OrgMembership, then sync its mirror
-    with no lock held across that gap. A concurrent delete() landing in the gap would
-    remove the just-created row and find no mirror yet, then have this call resume and
-    create a mirror for a membership that's already revoked. Fixed by re-locking the row
-    immediately after the insert commits, before syncing -- same lock-then-sync ordering
-    as update_role's fix. Needs two genuinely separate connections, same reasoning as the
-    other concurrency tests in this file (the race only exists across real transactions)."""
+def test_concurrent_get_or_create_and_delete_on_a_fresh_row_end_consistently():
+    # With no pre-existing row there is nothing for get_or_create to FOR UPDATE lock, so
+    # it and a concurrent delete() aren't strictly serialized -- but the whole get_or_create
+    # is one transaction and upsert_membership's own IntegrityError/SAVEPOINT recovery means
+    # the outcome is always consistent: the row is present with the granted role, or absent.
+    # Never a half-written row, never an exception. (Supersedes the pre-#331 test that relied
+    # on get_or_create's now-removed commit-then-mirror-sync gap.)
     setup = SessionLocal()
     org = org_repo.get_or_create(setup, github_login="acme-lock-test-3")
     user = User(email="judy@example.com", name=None, password_hash=None, is_workspace_admin=False)
@@ -340,106 +341,38 @@ def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirr
     setup.refresh(user)
     org_id, user_id = org.id, user.id
     setup.close()
-    # No get_or_create() call yet for (org_id, user_id) -- the pair doesn't exist, so the
-    # first call below goes down the new-row insert path, not the early-return path.
 
-    reached_lock = threading.Event()
-    delete_started = threading.Event()
-    release_lock = threading.Event()
-    original_sync = org_membership_repo._sync_membership_mirror
+    errors: list[BaseException] = []
 
-    def paused_sync(db, org_id, membership):
-        reached_lock.set()
-        assert release_lock.wait(timeout=5), "test setup never released the paused sync"
-        original_sync(db, org_id, membership)
-
-    create_result: dict[str, bool] = {}
-    delete_result: dict[str, bool] = {}
-
-    def run_get_or_create(session_a):
-        org_membership_repo.get_or_create(session_a, org_id=org_id, user_id=user_id, role="member")
-        create_result["finished"] = True
+    def run_get_or_create():
+        session = SessionLocal()
+        try:
+            org_membership_repo.get_or_create(session, org_id=org_id, user_id=user_id, role="member")
+        except BaseException as exc:  # noqa: BLE001 -- surfaced via `errors` below
+            errors.append(exc)
+        finally:
+            session.close()
 
     def run_delete():
-        session_b = SessionLocal()
+        session = SessionLocal()
         try:
-            assert reached_lock.wait(timeout=5), "get_or_create never reached its locked section"
-            delete_started.set()
-            org_membership_repo.delete(session_b, org_id=org_id, user_id=user_id)
-            delete_result["finished"] = True
+            org_membership_repo.delete(session, org_id=org_id, user_id=user_id)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
         finally:
-            session_b.close()
+            session.close()
 
     session_a = SessionLocal()
     try:
-        with patch.object(org_membership_repo, "_sync_membership_mirror", paused_sync):
-            create_thread = threading.Thread(target=run_get_or_create, args=(session_a,))
-            create_thread.start()
-            assert reached_lock.wait(timeout=5), "get_or_create never reached its locked section"
+        t1 = threading.Thread(target=run_get_or_create)
+        t2 = threading.Thread(target=run_delete)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
 
-            delete_thread = threading.Thread(target=run_delete)
-            delete_thread.start()
-            # Wait for the delete thread to actually reach delete() (not just start()) before
-            # checking it's blocked -- otherwise a slow scheduler could let the 0.3s timeout
-            # below expire before run_delete has even called delete(), passing "not
-            # delete_result" for the wrong reason instead of proving the lock blocked it.
-            assert delete_started.wait(timeout=5), "delete thread never reached delete()"
-            delete_thread.join(timeout=0.3)
-            assert not delete_result, "delete() must block while get_or_create holds the row lock"
-
-            release_lock.set()
-            create_thread.join(timeout=5)
-            delete_thread.join(timeout=5)
-        assert create_result.get("finished") is True
-        assert delete_result.get("finished") is True
-
-        # The delete landed after get_or_create's sync committed the mirror, so the final
-        # state must reflect the delete -- no leftover membership or mirror.
-        remaining = (
-            session_a.query(OrgMembership)
-            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-            .first()
-        )
-        assert remaining is None
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        # session_a's SET LOCAL app.user_id was cleared by the commit inside the operation
-        # under test; re-establish a tenant context so this assertion query can actually
-        # see memberships rows (FORCE row-level security, migration 0031) rather than
-        # getting an RLS-filtered empty result and passing vacuously.
-        session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-        mirror = (
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
-        )
-        assert mirror is None
+        assert not errors, f"a concurrent get_or_create/delete raised: {errors}"
+        final = _membership_after(session_a, org_id, user_id)
+        assert final is None or final.role == "member"
     finally:
-        session_a.rollback()
-        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
-        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
-        if tenant is not None:
-            # memberships has FORCE row-level security (migration 0031); under the
-            # non-superuser clevis_api role this bulk delete matches nothing unless a
-            # tenant session context is set first.
-            session_a.execute(text(f"SET LOCAL app.tenant_id = {tenant.id}"))
-            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
-            org_row = session_a.query(Org).filter(Org.id == org_id).first()
-            if org_row is not None:
-                org_row.tenant_id = None
-                session_a.commit()
-            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
-        session_a.query(Org).filter(Org.id == org_id).delete()
-        session_a.query(User).filter(User.id == user_id).delete()
-        session_a.commit()
-        session_a.close()
-
-
-def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
-    org = org_repo.get_or_create(db, github_login="acme")
-    admin = _make_user(db, "erin@example.com")
-    member = _make_user(db, "frank@example.com")
-
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
-
-    admin_membership = _membership_row(db, org.id, admin.id)
-    member_membership = _membership_row(db, org.id, member.id)
-    assert admin_membership.tenant_id == member_membership.tenant_id
+        _cleanup(session_a, org_id, user_id)

--- a/docker/provision-api-role-existing-deployment.sh
+++ b/docker/provision-api-role-existing-deployment.sh
@@ -53,8 +53,8 @@ $fmt$, :'api_password') \gexec
 
 GRANT CONNECT ON DATABASE :"db_name" TO clevis_api;
 GRANT USAGE ON SCHEMA public TO clevis_api;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, org_memberships, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
-GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, org_memberships_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
+GRANT SELECT, INSERT, UPDATE, DELETE ON users, orgs, tenants, memberships, invitations, github_installations, saved_tokens, audit_logs, scan_results, jobs, app_config, webhook_deliveries TO clevis_api;
+GRANT USAGE, SELECT ON users_id_seq, orgs_id_seq, tenants_id_seq, memberships_id_seq, invitations_id_seq, github_installations_id_seq, saved_tokens_id_seq, audit_logs_id_seq, scan_results_id_seq, jobs_id_seq, webhook_deliveries_id_seq TO clevis_api;
 
 -- repo_events (migration 0036, issue #191/S4 PR 1): the API doesn't write this table
 -- itself (only apps/worker's consumer does; S6 will add API reads later), but CI runs


### PR DESCRIPTION
Closes #331.

> **Stacked on #425** (`fix/334-...`). Review/merge #425 first; I'll rebase this onto `main` and retarget once it lands.

## ⚠️ Schema change

**Migration `0045_drop_org_memberships.py` DROPs the `org_memberships` table.** Not additive, not reversible with data.

### Why it's safe

`org_memberships` (org_id-keyed) was the original org RBAC join table. Issue #190 moved org membership onto the tenant-scoped `memberships` table: reads cut over in step 6a (PR #326 — every `require_org_role` call site), writes dual-written from step 4 (PR #322). Since then `org_memberships` has been pure write-amplification — touched on every change, read by nothing. Confirmed with a fresh repo-wide grep: nothing outside `org_membership_repo` itself reads it. #190's rollout plan (Phase E) explicitly scoped this drop as a tracked follow-up.

Every `org_memberships` row has had an equivalent `memberships` row since #190 PR 4's dual-write (migration 0029's docstring carries the parity query). It's a leaf join table — nothing FKs into `org_memberships.id` — so `DROP TABLE` is clean. `alembic check` confirms no model/migration drift after deleting the `OrgMembership` ORM class.

### Data loss / downgrade

`upgrade()` discards the rows. `downgrade()` recreates the table structure, unique constraint, FKs, and `clevis_api` grants but **yields an empty table** — a real rollback would also need to re-run #190 PR 4's backfill from `memberships`. Stated in the migration docstring.

## Code changes

- **`org_membership_repo` is now a thin `org_id`→`tenant_id` adapter over `tenant_repo`**, writing only `memberships`. The ~30 test modules and 3 routers that use it keep working unchanged.
  - Preserves #334's guarantee: `SELECT ... FOR UPDATE` on the `memberships` row + one commit per operation, so concurrent grant/revoke for the same `(org, user)` stay serialized (`tenant_repo` helpers run `commit=False`).
  - **Self-establishes `app.user_id` (`SET LOCAL`) before the lock query** — without it the `FOR UPDATE` is a silent no-op under the `FORCE`-RLS `clevis_api` role (issue #330), which filters the row out and locks nothing. Caught by running the concurrency tests under `clevis_api`.
  - `get` on an org with no tenant returns `None` rather than provisioning one — only `get_or_create` creates the tenant.
- **`tenant_repo.get_membership` gains `for_update=`**; new read-only `tenant_repo.get_org_tenant`.
- **Dead code removed**: `list_for_user` / `list_for_org` had zero callers (consumers moved to `tenant_repo.list_org_memberships_for_user` in #190 step 6).
- **`OrgMembership` ORM model deleted** from `db.py`.
- `docker/provision-api-role-existing-deployment.sh` drops `org_memberships` from its GRANT lists; `AGENTS.md` (models list + the already-stale RBAC line) and `docs/architecture/clevis-architecture.md` updated; stale `invitation_repo.py` comments repointed at `tenant_repo._persist_new`.
- **`test_org_membership_repo.py` rewritten** for the adapter model. The 3 concurrency tests keep their premise but retarget their monkeypatch from the gone `_sync_membership_mirror` onto the `tenant_repo` helpers; the third (new-row path) becomes a consistency check (no pre-existing row to lock).

## Sensitive files

- **Migration** — flagged above.
- **RBAC-adjacent** (`org_membership_repo.py`, `tenant_repo.py`, `db.py`): membership semantics preserved; the request path and every `commit=True` caller behave identically.
- **Role-provisioning script**: `org_memberships` grants removed (table gone).

## Verification

- `alembic upgrade head` → `downgrade -1` → `upgrade head` on a scratch DB: both directions clean; `org_memberships` gone → recreated → gone.
- `alembic check`: no drift.
- Full `pytest -q` under the **`clevis_api` role** (CI-equivalent): **1194 passed**.
- Diff coverage on changed `src/` lines: 97%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01No1CibsqddPEP4RXtJgQTP
